### PR TITLE
feat: forgot password page

### DIFF
--- a/.agents/skills/clerk-backend-api/SKILL.md
+++ b/.agents/skills/clerk-backend-api/SKILL.md
@@ -1,0 +1,455 @@
+---
+name: clerk-backend-api
+description: "Clerk Backend REST API explorer and executor. Browse tags, inspect endpoint schemas, and execute authenticated requests. Use when listing users, managing organizations, or calling any Clerk API endpoint."
+allowed-tools: Bash, Read, Grep, Skill, WebFetch
+license: MIT
+metadata:
+  inputs:
+    - name: CLERK_SECRET_KEY
+      description: Clerk secret key (sk_*) for Backend API calls
+      required: true
+---
+
+## Options context
+
+User Prompt: $ARGUMENTS
+
+## CRITICAL: Mandatory checks before EVERY write request
+
+Before ANY POST / PATCH / PUT / DELETE, you MUST do ALL of the following in your response:
+
+1. **Check CLERK_SECRET_KEY** — verify it is set:
+
+   ```bash
+   echo $CLERK_SECRET_KEY | head -c 10
+   ```
+
+   If empty, stop and ask the user. Do not proceed without a valid key.
+
+2. **Check CLERK_BAPI_SCOPES** — run:
+
+   ```bash
+   echo $CLERK_BAPI_SCOPES
+   ```
+
+   Inspect the output. If scopes are missing or do not include the required write permission, tell the user: _"This is a write operation and your current scopes may not allow it. Rerun with --admin to bypass?"_ Do NOT attempt the request and fail — ask first.
+
+3. **For DELETE requests:** warn explicitly that the action is **IRREVERSIBLE** and list exactly what data will be permanently destroyed (user record, all sessions, all memberships, all associated data). Require explicit confirmation before proceeding. This warning is MANDATORY — never skip it.
+
+4. **For metadata operations:** always explain which metadata type is being used and why (see Metadata types section below).
+
+---
+
+## FAST PATH: Common operations (use directly, no spec fetching needed)
+
+For the operations below, skip spec fetching and execute immediately using these exact templates. Substitute `$CLERK_SECRET_KEY`, `$USER_ID`, `$ORG_ID`, `$EMAIL` as needed from the user's context.
+
+### Create organization + invite member (two-step)
+
+```bash
+# Step 1 — Create organization
+ORG=$(curl -s -X POST "https://api.clerk.com/v1/organizations" \
+  -H "Authorization: Bearer $CLERK_SECRET_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{\"name\": \"Acme Corp\", \"created_by\": \"$USER_ID\"}")
+echo "$ORG" | python3 -c "import sys,json; d=json.load(sys.stdin); print(json.dumps(d, indent=2))"
+
+# Step 2 — Extract org ID
+ORG_ID=$(echo "$ORG" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
+
+# Step 3 — Invite member with role
+curl -s -X POST "https://api.clerk.com/v1/organizations/${ORG_ID}/invitations" \
+  -H "Authorization: Bearer $CLERK_SECRET_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{\"email_address\": \"user@example.com\", \"role\": \"org:admin\"}" \
+  | python3 -c "import sys,json; print(json.dumps(json.load(sys.stdin), indent=2))"
+```
+
+**Roles:** use `"org:admin"` or `"org:member"` (always prefix with `org:`).
+
+### SDK equivalent (for Next.js / TypeScript projects with `@clerk/nextjs` or `@clerk/backend`)
+
+```typescript
+import { clerkClient } from "@clerk/nextjs/server";
+// OR if using @clerk/backend directly:
+// import { createClerkClient } from '@clerk/backend'
+// const clerkClient = createClerkClient({ secretKey: process.env.CLERK_SECRET_KEY })
+
+// Step 1: Create organization
+const org = await clerkClient.organizations.createOrganization({
+  name: "Acme Corp",
+  createdBy: userId, // required — the ID of the user creating the org
+});
+
+// Step 2: Invite member to the org
+const invitation = await clerkClient.organizations.createOrganizationInvitation({
+  organizationId: org.id,
+  emailAddress: "user@example.com",
+  role: "org:admin", // or 'org:member'
+});
+```
+
+### Update user metadata
+
+**Always explain the three metadata types before asking which to use:**
+
+| Type    | Field              | Readable by     | Writable by     | Use for                                                                       |
+| ------- | ------------------ | --------------- | --------------- | ----------------------------------------------------------------------------- |
+| Public  | `public_metadata`  | Client + Server | **Server only** | Plan tier, roles, feature flags the frontend reads                            |
+| Private | `private_metadata` | **Server only** | **Server only** | Stripe IDs, compliance flags, internal identifiers                            |
+| Unsafe  | `unsafe_metadata`  | Client + Server | Client + Server | Ephemeral UI state, onboarding steps (client-writable — avoid sensitive data) |
+
+**For `plan: 'pro'` and `onboarded: true` — use `public_metadata`** (frontend-readable, server-writable):
+
+```bash
+curl -s -X PATCH "https://api.clerk.com/v1/users/${USER_ID}" \
+  -H "Authorization: Bearer $CLERK_SECRET_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"public_metadata": {"plan": "pro", "onboarded": true}}' \
+  | python3 -c "import sys,json; d=json.load(sys.stdin); print(f'Updated user {d[\"id\"]}: public_metadata={d.get(\"public_metadata\")}')"
+```
+
+**SDK equivalent:**
+
+```typescript
+import { clerkClient } from "@clerk/nextjs/server";
+// OR: import { createClerkClient } from '@clerk/backend'
+
+await clerkClient.users.updateUser(userId, {
+  publicMetadata: { plan: "pro", onboarded: true }, // readable by client, writable server-only
+  // privateMetadata: { stripeId: 'cus_xxx' },         // server-only read AND write
+  // unsafeMetadata: { step: 'welcome' },              // client-writable, avoid sensitive data
+});
+```
+
+**Note:** REST API uses `snake_case` (`public_metadata`). SDK uses `camelCase` (`publicMetadata`).
+
+### List users (last 7 days)
+
+```bash
+curl -s "https://api.clerk.com/v1/users?limit=100&offset=0&order_by=-created_at&created_at=gt:$(date -d '7 days ago' +%s 2>/dev/null || date -v-7d +%s)000" \
+  -H "Authorization: Bearer $CLERK_SECRET_KEY" \
+  | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+if isinstance(data, list):
+    print(f'Found {len(data)} users:')
+    for u in data:
+        print(f'  {u[\"id\"]}: {u.get(\"email_addresses\", [{}])[0].get(\"email_address\", \"no email\")}')
+else:
+    print(json.dumps(data, indent=2))
+"
+```
+
+### Delete user (confirm required)
+
+```bash
+# ONLY run after explicit user confirmation
+curl -s -X DELETE "https://api.clerk.com/v1/users/${USER_ID}" \
+  -H "Authorization: Bearer $CLERK_SECRET_KEY" \
+  | python3 -c "import sys,json; d=json.load(sys.stdin); print(f'Deleted: {d}')"
+```
+
+---
+
+## Clerk Backend API — Full Endpoint Reference
+
+Base URL: `https://api.clerk.com/v1`
+Auth: `Authorization: Bearer $CLERK_SECRET_KEY` on every request.
+
+### Users
+
+**List users**
+
+```
+GET /v1/users
+Query params: limit (max 500, default 10), offset, order_by (+/-created_at, +/-updated_at, +/-email_address, +/-web3wallet, +/-first_name, +/-last_name, +/-phone_number, +/-username, +/-last_active_at, +/-last_sign_in_at), email_address[], phone_number[], username[], web3wallet[], user_id[], query, created_at (ISO 8601 range: gt:TIMESTAMP or lt:TIMESTAMP in Unix ms)
+Returns: array of User objects
+```
+
+**Get user**
+
+```
+GET /v1/users/{user_id}
+Returns: User object
+```
+
+**Update user**
+
+```
+PATCH /v1/users/{user_id}
+Body (JSON, snake_case): { public_metadata, private_metadata, unsafe_metadata, first_name, last_name, username, ... }
+```
+
+**Delete user — IRREVERSIBLE**
+
+```
+DELETE /v1/users/{user_id}
+Destroys: user record, all sessions, all memberships, all associated data
+Returns: { id, object, deleted: true }
+```
+
+Always warn the user this is permanent and confirm before proceeding.
+
+### Organizations
+
+**Create organization**
+
+```
+POST /v1/organizations
+Body: { name: string, created_by: string (user_id), public_metadata?, private_metadata?, max_allowed_memberships? }
+Returns: Organization object with { id, name, slug, ... }
+```
+
+**List organizations**
+
+```
+GET /v1/organizations
+Query params: limit, offset, query, order_by
+```
+
+**Invite member**
+
+```
+POST /v1/organizations/{organization_id}/invitations
+Body: { email_address: string, role: string ("org:admin" or "org:member"), public_metadata?, private_metadata? }
+Returns: OrganizationInvitation object
+```
+
+---
+
+## How to execute requests
+
+**ALWAYS execute requests with direct `curl` commands.** Use the spec-extraction scripts (`api-specs-context.sh`, `extract-tags.js`, `extract-endpoint-detail.sh`) to discover endpoints, but make actual API calls with `curl`. Do NOT use `scripts/execute-request.sh` — it's a local dev helper, not for agent use.
+
+Template for GET requests:
+
+```bash
+curl -s "https://api.clerk.com/v1${PATH}${QUERY_STRING}" \
+  -H "Authorization: Bearer $CLERK_SECRET_KEY"
+```
+
+Template for POST/PATCH requests:
+
+```bash
+curl -s -X ${METHOD} "https://api.clerk.com/v1${PATH}" \
+  -H "Authorization: Bearer $CLERK_SECRET_KEY" \
+  -H "Content-Type: application/json" \
+  -d '${BODY_JSON}'
+```
+
+Template for DELETE requests:
+
+```bash
+curl -s -X DELETE "https://api.clerk.com/v1${PATH}" \
+  -H "Authorization: Bearer $CLERK_SECRET_KEY"
+```
+
+**After getting the response:** Parse and display it clearly. Use `python3 -c "import sys,json; data=json.load(sys.stdin); print(json.dumps(data, indent=2))"` to pretty-print JSON. Extract key fields (id, email, name, etc.) and summarize them for the user.
+
+---
+
+## API specs context
+
+Before doing anything outside the FAST PATH, fetch the available spec versions and tags by running:
+
+```bash
+bash scripts/api-specs-context.sh
+```
+
+Use the output to determine the latest version and available tags.
+
+**Caching:** If you already fetched the spec context earlier in this conversation, do NOT fetch it again. Reuse the version and tags from the previous call.
+
+---
+
+## Rules
+
+- For common operations (list users, create org, invite, update metadata, delete user): use the FAST PATH above — do NOT fetch specs first.
+- Always disregard endpoints/schemas related to `platform`.
+- Always confirm before performing write requests (POST/PUT/PATCH/DELETE).
+- For DELETE operations, always warn the user that the action is **irreversible** and mention what data will be lost (user record, sessions, memberships). This warning is MANDATORY — never skip it.
+- For write operations (POST/PUT/PATCH/DELETE), check `CLERK_BAPI_SCOPES` before attempting the request. If missing or insufficient, ask the user upfront. Do NOT attempt and fail — ask before executing. This check is MANDATORY.
+- For metadata operations, always explain all three types (public, private, unsafe) and recommend the appropriate one.
+- Pagination: always use `limit` + `offset` and mention that results may be paginated for large datasets.
+- Use direct curl commands for all API calls — never use `scripts/execute-request.sh`.
+
+---
+
+## Rate Limits & Gotchas
+
+### Rate Limits
+
+| Environment                   | Limit                       |
+| ----------------------------- | --------------------------- |
+| Production                    | 1,000 requests / 10 seconds |
+| Development                   | 100 requests / 10 seconds   |
+| Single invitations            | 100 / hour                  |
+| Bulk invitations              | 25 / hour                   |
+| Org invitations               | 250 / hour                  |
+| Frontend API sign-in creation | 5 / 10 seconds              |
+| Frontend API sign-in attempts | 3 / 10 seconds              |
+| List users max per page       | 500                         |
+
+`currentUser()` makes a real API call that counts against rate limits. Use `auth()` for just the session claims — it reads from the token without an API call.
+
+### Metadata Overwrites (Not Merges)
+
+`updateUser({ publicMetadata: { role: 'admin' } })` REPLACES all public metadata, not merges. To add a field without losing existing data: read first, spread, then write.
+
+Wrong:
+
+```typescript
+await clerkClient.users.updateUser(userId, { publicMetadata: { newField: "value" } });
+```
+
+This DELETES all other `publicMetadata` fields.
+
+Right:
+
+```typescript
+const user = await clerkClient.users.getUser(userId);
+await clerkClient.users.updateUser(userId, {
+  publicMetadata: { ...user.publicMetadata, newField: "value" },
+});
+```
+
+---
+
+## Modes
+
+Determine the active mode based on the user prompt in [Options context](#options-context):
+
+| Mode      | Trigger                                                                                     | Behavior                             |
+| --------- | ------------------------------------------------------------------------------------------- | ------------------------------------ |
+| `help`    | Prompt is empty, or contains only `help` / `-h` / `--help`                                  | Print usage examples (step 0)        |
+| `browse`  | Prompt is `tags`, or a tag name (e.g. `Users`)                                              | List all tags or endpoints for a tag |
+| `execute` | Specific endpoint (e.g. `GET /users`) or natural language action (e.g. "get user john_doe") | Look up endpoint, execute request    |
+| `detail`  | Endpoint + `help` / `-h` / `--help` (e.g. `GET /users help`)                                | Show endpoint schema, don't execute  |
+
+---
+
+## Your Task
+
+Use the **LATEST VERSION** from [API specs context](#api-specs-context) by default. If the user specifies a different version (e.g. `--version 2024-10-01`), use that version instead.
+
+Determine the active mode, then follow the applicable steps below.
+
+---
+
+### 0. Print usage
+
+**Modes:** `help` only — **Skip** for `browse`, `execute`, and `detail`.
+
+Print the following examples to the user verbatim:
+
+```
+Browse
+  /clerk-backend-api tags                         — list all tags
+  /clerk-backend-api Users                        — browse endpoints for the Users tag
+  /clerk-backend-api Users version 2025-11-10.yml — browse using a different version
+
+Execute
+  /clerk-backend-api GET /users             — fetch all users
+  /clerk-backend-api get user john_doe      — natural language works too
+  /clerk-backend-api POST /invitations      — create an invitation
+
+Inspect
+  /clerk-backend-api GET /users help        — show endpoint schema without executing
+  /clerk-backend-api POST /invitations -h   — view request/response details
+
+Options
+  --admin                            — bypass scope restrictions for write/delete
+  --version [date], version [date]   — use a specific spec version
+  --help, -h, help                   — inspect endpoint instead of executing
+```
+
+Stop here.
+
+---
+
+### 1. Fetch tags
+
+**Modes:** `browse` (when prompt is `tags` or no tag specified) — **Skip** for `help`, `execute`, and `detail`.
+
+If using a non-latest version, fetch tags for that version:
+
+```bash
+curl -s https://raw.githubusercontent.com/clerk/openapi-specs/main/bapi/${version_name} | node scripts/extract-tags.js
+```
+
+Otherwise, use the **TAGS** already in [API specs context](#api-specs-context).
+
+Share tags in a table and prompt the user to select a query.
+
+---
+
+### 2. Fetch tag endpoints
+
+**Modes:** `browse` (when a tag name is provided) — **Skip** for `help`, `execute`, and `detail`.
+
+Fetch all endpoints for the identified tag:
+
+```bash
+curl -s https://raw.githubusercontent.com/clerk/openapi-specs/main/bapi/${version_name} | bash scripts/extract-tag-endpoints.sh "${tag_name}"
+```
+
+Share the results (endpoints, schemas, parameters) with the user.
+
+---
+
+### 3. Fetch endpoint detail
+
+**Modes:** `execute`, `detail` — **Skip** for `help` and `browse`.
+
+For natural language prompts in `execute` mode, first check if the operation matches a FAST PATH entry above. If it does, skip this step and proceed directly to step 4 using the FAST PATH template.
+
+For other endpoints, identify the matching endpoint by searching the tags in context. Fetch tag endpoints if needed to resolve the exact path and method.
+
+Extract the full endpoint definition:
+
+```bash
+curl -s https://raw.githubusercontent.com/clerk/openapi-specs/main/bapi/${version_name} | bash scripts/extract-endpoint-detail.sh "${path}" "${method}"
+```
+
+- `${path}` — e.g. `/users/{user_id}`
+- `${method}` — lowercase, e.g. `get`
+
+**`detail` mode:** Share the endpoint definition and schemas with the user. Stop here.
+
+**`execute` mode:** Continue to step 4.
+
+---
+
+### 4. Execute request
+
+**Modes:** `execute` only.
+
+1. Run the **mandatory checks** from the CRITICAL section above.
+2. Identify required and optional parameters from the spec (step 3) or FAST PATH.
+3. Ask the user for any required path/query/body parameters that weren't provided.
+4. Build and execute a **direct curl command** (see How to execute requests above). Do NOT use `scripts/execute-request.sh`.
+5. Parse the JSON response and display it clearly. Extract and summarize key fields for the user.
+
+**Example — list users and parse response:**
+
+```bash
+RESPONSE=$(curl -s "https://api.clerk.com/v1/users?limit=10" \
+  -H "Authorization: Bearer $CLERK_SECRET_KEY")
+echo "$RESPONSE" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+if isinstance(data, list):
+    print(f'Found {len(data)} users:')
+    for u in data:
+        print(f'  {u[\"id\"]}: {u.get(\"email_addresses\", [{}])[0].get(\"email_address\", \"no email\")}')
+else:
+    print(json.dumps(data, indent=2))
+"
+```
+
+## See Also
+
+- `clerk-setup` - Initial Clerk install
+- `clerk-orgs` - Manage organizations via API
+- `clerk-webhooks` - Real-time event sync

--- a/.agents/skills/clerk-backend-api/evals/evals.json
+++ b/.agents/skills/clerk-backend-api/evals/evals.json
@@ -1,0 +1,87 @@
+{
+  "skill_name": "clerk-backend-api",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "i need to get all users who signed up in the last 7 days from clerk's backend API. show me how",
+      "expected_output": "REST API call to GET /v1/users with date filter, Bearer token auth using CLERK_SECRET_KEY, response parsing and pagination handling",
+      "scaffold": "nextjs-basic-auth",
+      "files": [],
+      "expectations": [
+        "Uses GET /v1/users endpoint",
+        "Includes a created_at or date-based filter query parameter to narrow to last 7 days",
+        "Sets CLERK_SECRET_KEY as Bearer token in the Authorization header",
+        "Parses the JSON response array of user objects",
+        "Handles or mentions pagination via limit and offset parameters"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "use the clerk backend api to create a new organization called 'Acme Corp' and invite user@example.com as an admin",
+      "expected_output": "Two API calls: POST /v1/organizations to create org, then POST /v1/organizations/{id}/invitations to invite with admin role",
+      "scaffold": "nextjs-basic-auth",
+      "files": [],
+      "expectations": [
+        "Uses POST /v1/organizations to create the organization with name 'Acme Corp'",
+        "Uses POST /v1/organizations/{id}/invitations to send the invitation",
+        "Sets the role to admin (or org:admin) in the invitation payload",
+        "Authenticates both API calls using CLERK_SECRET_KEY in the Authorization header",
+        "Extracts the organization ID from the first response and uses it in the invitation request"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "i need to set custom metadata on a user via clerk's backend api. set their plan to 'pro' and onboarded to true",
+      "expected_output": "PATCH /v1/users/{user_id} with public_metadata or private_metadata body, explanation of metadata types and when to use each",
+      "scaffold": "nextjs-basic-auth",
+      "files": [],
+      "expectations": [
+        "Uses PATCH /v1/users/{user_id} endpoint",
+        "Sets the metadata in the correct field: public_metadata, private_metadata, or unsafe_metadata",
+        "Explains the difference between metadata types (client-readable vs server-only vs client-writable)",
+        "Includes a properly formed JSON body with the plan and onboarded fields",
+        "Mentions checking write permissions before executing the update"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "remove a user with id user_abc123 from our clerk instance using the backend api",
+      "expected_output": "DELETE /v1/users/{user_id} call with warning about irreversibility, CLERK_BAPI_SCOPES check, and CLERK_SECRET_KEY auth",
+      "scaffold": "nextjs-basic-auth",
+      "files": [],
+      "expectations": [
+        "Uses DELETE /v1/users/{user_id} endpoint with the correct user ID",
+        "Warns that the action is destructive and irreversible",
+        "Requires or recommends explicit confirmation before executing the delete",
+        "Includes CLERK_SECRET_KEY as Bearer token in the Authorization header",
+        "Mentions implications such as loss of user data, sessions, and associated records"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "i'm updating user metadata to add a 'plan' field but it keeps deleting the existing 'role' field. what am i doing wrong?",
+      "expected_output": "Metadata updates overwrite not merge. Read existing metadata first, spread it, then write back.",
+      "scaffold": "nextjs-basic-auth",
+      "expectations": [
+        "Explains that updateUser publicMetadata replaces all existing metadata, not merges",
+        "Shows reading the existing user first with getUser(userId)",
+        "Spreads existing metadata before adding new fields ({ ...user.publicMetadata, plan: 'pro' })",
+        "Calls updateUser with the merged metadata object",
+        "Warns that this applies to publicMetadata, privateMetadata, and unsafeMetadata equally"
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "my clerk backend api calls are failing with 429 errors in development. what are the rate limits?",
+      "expected_output": "Development has 100 req/10s limit (vs 1000/10s in production). Batch operations or reduce call frequency.",
+      "scaffold": "nextjs-basic-auth",
+      "expectations": [
+        "States the development rate limit (100 requests per 10 seconds)",
+        "States the production rate limit (1000 requests per 10 seconds)",
+        "Suggests batching operations or reducing call frequency",
+        "Mentions that currentUser() counts as an API call against the limit",
+        "Recommends using auth() instead of currentUser() when only session claims are needed"
+      ]
+    }
+  ]
+}

--- a/.agents/skills/clerk-backend-api/scripts/api-specs-context.sh
+++ b/.agents/skills/clerk-backend-api/scripts/api-specs-context.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Fetches all available BAPI spec versions, determines the latest,
+# and extracts tags from it. Output is used as skill context.
+
+set -euo pipefail
+
+API_URL="https://api.github.com/repos/clerk/openapi-specs/contents/bapi"
+RAW_BASE="https://raw.githubusercontent.com/clerk/openapi-specs/main/bapi"
+
+# Fetch version list, parse dates, sort, pick latest
+versions=$(curl -s "$API_URL" | node -e "
+  let d='';
+  process.stdin.on('data',c=>d+=c);
+  process.stdin.on('end',()=>{
+    const items = JSON.parse(d)
+      .map(i=>i.name)
+      .filter(n=>/^\d{4}-\d{2}-\d{2}\.yml$/.test(n))
+      .sort();
+    items.forEach(n=>console.log(n));
+  });
+")
+
+latest=$(echo "$versions" | tail -1)
+
+echo "AVAILABLE VERSIONS: $(echo "$versions" | tr '\n' ' ')"
+echo "LATEST VERSION: $latest"
+echo ""
+echo "TAGS:"
+curl -s "${RAW_BASE}/${latest}" | node "$(dirname "$0")/extract-tags.js"

--- a/.agents/skills/clerk-backend-api/scripts/execute-request.sh
+++ b/.agents/skills/clerk-backend-api/scripts/execute-request.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+# Execute a Clerk Backend API request with scope enforcement.
+#
+# Usage: bash execute-request.sh [--admin] <METHOD> <PATH> [BODY]
+#
+# Scope enforcement:
+#   GET     — always allowed
+#   POST, PUT, PATCH — requires CLERK_BAPI_SCOPES="write" or --admin flag
+#   DELETE  — requires CLERK_BAPI_SCOPES="write,delete" or --admin flag
+
+set -euo pipefail
+
+# Walk up from $PWD to find .env/.env.local (mirrors Clerk CLI behavior).
+# Stops at the first directory that provides CLERK_SECRET_KEY.
+_dir="$PWD"
+while true; do
+  for _envfile in "$_dir/.env" "$_dir/.env.local"; do
+    if [[ -f "$_envfile" ]]; then
+      set -a
+      source "$_envfile"
+      set +a
+    fi
+  done
+  [[ -n "${CLERK_SECRET_KEY:-}" ]] && break
+  _parent="$(dirname "$_dir")"
+  [[ "$_parent" == "$_dir" ]] && break
+  _dir="$_parent"
+done
+unset _dir _parent _envfile
+
+# Parse --admin flag
+ADMIN=false
+if [[ "${1:-}" == "--admin" ]]; then
+  ADMIN=true
+  shift
+fi
+
+METHOD="${1:?Usage: execute-request.sh [--admin] <METHOD> <PATH> [BODY]}"
+PATH_ARG="${2:?Usage: execute-request.sh [--admin] <METHOD> <PATH> [BODY]}"
+BODY="${3:-}"
+
+METHOD_UPPER=$(echo "$METHOD" | tr '[:lower:]' '[:upper:]')
+SCOPES="${CLERK_BAPI_SCOPES:-}"
+
+# Scope check
+if [[ "$ADMIN" == false ]]; then
+  case "$METHOD_UPPER" in
+    GET)
+      ;; # always allowed
+    POST|PUT|PATCH)
+      if [[ "$SCOPES" != *"write"* ]]; then
+        echo "ERROR: $METHOD_UPPER requests require CLERK_BAPI_SCOPES=\"write\" or --admin flag." >&2
+        echo "Current CLERK_BAPI_SCOPES: \"$SCOPES\"" >&2
+        exit 1
+      fi
+      ;;
+    DELETE)
+      if [[ "$SCOPES" != *"write"* ]] || [[ "$SCOPES" != *"delete"* ]]; then
+        echo "ERROR: DELETE requests require CLERK_BAPI_SCOPES=\"write,delete\" or --admin flag." >&2
+        echo "Current CLERK_BAPI_SCOPES: \"$SCOPES\"" >&2
+        exit 1
+      fi
+      ;;
+    *)
+      echo "ERROR: Unknown HTTP method: $METHOD_UPPER" >&2
+      exit 1
+      ;;
+  esac
+fi
+
+# Base URL: use CLERK_REST_API_URL if set, otherwise default to production
+BASE_URL="${CLERK_REST_API_URL:-https://api.clerk.com}"
+
+# Build curl command
+CURL_ARGS=(
+  -s
+  -X "$METHOD_UPPER"
+  "${BASE_URL}/v1${PATH_ARG}"
+  -H "Authorization: Bearer ${CLERK_SECRET_KEY:?CLERK_SECRET_KEY is not set}"
+  -H "Content-Type: application/json"
+)
+
+if [[ -n "$BODY" ]]; then
+  CURL_ARGS+=(-d "$BODY")
+fi
+
+curl "${CURL_ARGS[@]}"

--- a/.agents/skills/clerk-backend-api/scripts/extract-endpoint-detail.sh
+++ b/.agents/skills/clerk-backend-api/scripts/extract-endpoint-detail.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# extract-endpoint-detail.sh
+#
+# Extracts full details for a specific endpoint from an OpenAPI YAML spec (stdin),
+# including parameters, request body, responses, and all referenced component schemas.
+#
+# Usage:
+#   curl -s <spec-url> | bash extract-endpoint-detail.sh "/users/{user_id}/billing/subscription" "get"
+
+set -euo pipefail
+
+ENDPOINT="${1:?Usage: extract-endpoint-detail.sh <path> <method>}"
+METHOD="${2:?Usage: extract-endpoint-detail.sh <path> <method>}"
+TMPDIR_WORK=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_WORK"' EXIT
+
+SPEC="$TMPDIR_WORK/spec.yml"
+cat > "$SPEC"
+
+node - "$ENDPOINT" "$METHOD" "$SPEC" <<'SCRIPT'
+const fs = require("fs");
+const endpoint = process.argv[2];
+const method = process.argv[3].toLowerCase();
+const specFile = process.argv[4];
+const lines = fs.readFileSync(specFile, "utf8").split("\n");
+
+const httpMethods = ["get", "post", "put", "patch", "delete", "options", "head"];
+
+// Locate paths: and components: sections
+let pathsStart = -1, pathsEnd = -1, componentsStart = -1;
+for (let i = 0; i < lines.length; i++) {
+  if (/^paths:\s*$/.test(lines[i])) pathsStart = i;
+  else if (pathsStart >= 0 && pathsEnd < 0 && /^\S/.test(lines[i]) && i > pathsStart) pathsEnd = i;
+  if (/^components:\s*$/.test(lines[i])) componentsStart = i;
+}
+if (pathsEnd < 0) pathsEnd = lines.length;
+
+// Find the target path + method block
+let targetStart = -1, targetEnd = -1;
+let currentPath = null;
+
+for (let i = pathsStart + 1; i < pathsEnd; i++) {
+  const line = lines[i];
+
+  // Path line: exactly 2 spaces + /
+  if (/^ {2}\/\S/.test(line)) {
+    currentPath = line.trim().replace(/:$/, "");
+    continue;
+  }
+
+  // Method line: exactly 4 spaces + method name
+  const methodMatch = line.match(/^ {4}(\w+):\s*$/);
+  if (methodMatch && httpMethods.includes(methodMatch[1])) {
+    if (currentPath === endpoint && methodMatch[1] === method) {
+      targetStart = i;
+      // Find end of this method block
+      for (let j = i + 1; j < pathsEnd; j++) {
+        const nextLine = lines[j];
+        // New method or new path
+        if (/^ {2}\/\S/.test(nextLine) || (/^ {4}\w+:\s*$/.test(nextLine) && httpMethods.some(m => nextLine.trim().startsWith(m + ":")))) {
+          targetEnd = j;
+          break;
+        }
+      }
+      if (targetEnd < 0) targetEnd = pathsEnd;
+      break;
+    }
+  }
+}
+
+if (targetStart < 0) {
+  console.error(`Endpoint not found: ${method.toUpperCase()} ${endpoint}`);
+  process.exit(1);
+}
+
+const blockLines = lines.slice(targetStart, targetEnd);
+
+// Collect all $refs from the block
+const allRefs = new Set();
+for (const bl of blockLines) {
+  const refMatch = bl.match(/\$ref:\s*['"]?(#\/[^'"}\s]+)['"]?/);
+  if (refMatch) allRefs.add(refMatch[1]);
+}
+
+// Resolve a $ref path to the raw YAML lines for that component
+function resolveRef(ref) {
+  const parts = ref.replace("#/", "").split("/");
+  // Find the component in the file by walking indentation
+  let searchStart = 0;
+  for (let p = 0; p < parts.length; p++) {
+    const indent = p * 2;
+    const target = " ".repeat(indent) + parts[p] + ":";
+    let found = false;
+    for (let i = searchStart; i < lines.length; i++) {
+      if (lines[i].startsWith(target) && (lines[i] === target || lines[i][target.length] === " ")) {
+        searchStart = i + 1;
+        found = true;
+        break;
+      }
+    }
+    if (!found) return null;
+  }
+
+  // Collect lines for this component (until same or lower indent)
+  const componentStart = searchStart - 1;
+  const baseIndent = parts.length * 2;
+  const result = [];
+  for (let i = searchStart; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.trim() === "") { result.push(line); continue; }
+    const lineIndent = line.length - line.trimStart().length;
+    if (lineIndent < baseIndent) break;
+    result.push(line);
+  }
+  return result;
+}
+
+// Recursively resolve refs from component bodies
+function collectDeepRefs(refSet, visited) {
+  const toProcess = [...refSet].filter(r => !visited.has(r));
+  for (const ref of toProcess) {
+    visited.add(ref);
+    const body = resolveRef(ref);
+    if (!body) continue;
+    for (const bl of body) {
+      const refMatch = bl.match(/\$ref:\s*['"]?(#\/[^'"}\s]+)['"]?/);
+      if (refMatch && !visited.has(refMatch[1])) {
+        refSet.add(refMatch[1]);
+      }
+    }
+  }
+  // Recurse if new refs were found
+  const newRefs = [...refSet].filter(r => !visited.has(r));
+  if (newRefs.length > 0) collectDeepRefs(refSet, visited);
+}
+
+collectDeepRefs(allRefs, new Set());
+
+// Output
+console.log(`## \`${method.toUpperCase()}\` \`${endpoint}\`\n`);
+console.log("### Endpoint Definition\n");
+console.log("```yaml");
+for (const bl of blockLines) {
+  console.log(bl);
+}
+console.log("```\n");
+
+if (allRefs.size > 0) {
+  console.log(`### Referenced Components (${allRefs.size})\n`);
+  const sorted = [...allRefs].sort();
+  for (const ref of sorted) {
+    const name = ref.split("/").pop();
+    const category = ref.replace("#/", "").split("/").slice(0, -1).join("/");
+    console.log(`#### \`${name}\` (${category})\n`);
+    const body = resolveRef(ref);
+    if (body) {
+      console.log("```yaml");
+      for (const bl of body) console.log(bl);
+      console.log("```\n");
+    } else {
+      console.log("_(could not resolve)_\n");
+    }
+  }
+}
+SCRIPT

--- a/.agents/skills/clerk-backend-api/scripts/extract-tag-endpoints.sh
+++ b/.agents/skills/clerk-backend-api/scripts/extract-tag-endpoints.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# extract-tag-endpoints.sh
+#
+# Extracts all endpoints for a given tag from an OpenAPI YAML spec (stdin),
+# along with any $ref'd schemas/components.
+#
+# Usage:
+#   curl -s <spec-url> | bash extract-tag-endpoints.sh "Billing"
+
+set -euo pipefail
+
+TAG="${1:?Usage: extract-tag-endpoints.sh <tag-name>}"
+TMPDIR_WORK=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_WORK"' EXIT
+
+SPEC="$TMPDIR_WORK/spec.yml"
+cat > "$SPEC"
+
+# 1. Find all path+method blocks that have a matching tag
+#    Strategy: find line numbers of path entries (lines starting with "  /"),
+#    then for each method block under that path, check if it contains the tag.
+
+node - "$TAG" "$SPEC" <<'SCRIPT'
+const fs = require("fs");
+const tag = process.argv[2];
+const specFile = process.argv[3];
+const lines = fs.readFileSync(specFile, "utf8").split("\n");
+
+const tagLower = tag.toLowerCase();
+
+// Phase 1: Find all path definitions and their method blocks
+// Paths start at indent 2 with "  /"
+// Methods start at indent 4 with "    get:", "    post:", etc.
+const methods = ["get", "post", "put", "patch", "delete", "options", "head"];
+const endpoints = [];
+const refs = new Set();
+
+let currentPath = null;
+let currentMethod = null;
+let blockStart = -1;
+let blockLines = [];
+let inPaths = false;
+let inComponents = false;
+
+// First pass: locate the "paths:" and "components:" top-level keys
+let pathsStart = -1;
+let pathsEnd = -1;
+let componentsStart = -1;
+
+for (let i = 0; i < lines.length; i++) {
+  const line = lines[i];
+  if (/^paths:\s*$/.test(line)) {
+    pathsStart = i;
+  } else if (pathsStart >= 0 && pathsEnd < 0 && /^\S/.test(line) && i > pathsStart) {
+    pathsEnd = i;
+  }
+  if (/^components:\s*$/.test(line)) {
+    componentsStart = i;
+  }
+}
+if (pathsEnd < 0) pathsEnd = lines.length;
+
+// Second pass: extract endpoints matching the tag
+function flushBlock() {
+  if (!currentPath || !currentMethod || blockLines.length === 0) return;
+
+  // Check if this block has the target tag
+  let inTags = false;
+  let hasTag = false;
+  const blockRefs = [];
+
+  for (const bl of blockLines) {
+    const trimmed = bl.trim();
+
+    // Detect tags section
+    if (/^tags:\s*$/.test(trimmed)) {
+      inTags = true;
+      continue;
+    }
+    if (inTags) {
+      if (/^- /.test(trimmed)) {
+        const tagVal = trimmed.replace(/^- /, "").trim().replace(/^['"]|['"]$/g, "");
+        if (tagVal.toLowerCase() === tagLower) hasTag = true;
+      } else {
+        inTags = false;
+      }
+    }
+
+    // Collect $ref values
+    const refMatch = bl.match(/\$ref:\s*['"]?(#\/[^'"}\s]+)['"]?/);
+    if (refMatch) blockRefs.push(refMatch[1]);
+  }
+
+  if (hasTag) {
+    // Extract summary, operationId, description
+    let summary = "";
+    let operationId = "";
+    let description = "";
+    let params = [];
+    let inDesc = false;
+    let inParams = false;
+
+    for (const bl of blockLines) {
+      const trimmed = bl.trim();
+      const indent = bl.length - bl.trimStart().length;
+
+      // Only capture operation-level keys (indent 6 = direct children of the method block)
+      if (indent === 6) {
+        const sumMatch = trimmed.match(/^summary:\s*(.+)/);
+        if (sumMatch) summary = sumMatch[1].replace(/^['"]|['"]$/g, "");
+
+        const opMatch = trimmed.match(/^operationId:\s*(.+)/);
+        if (opMatch) operationId = opMatch[1].replace(/^['"]|['"]$/g, "");
+
+        const descMatch = trimmed.match(/^description:\s*(.+)/);
+        if (descMatch && !inDesc) {
+          const val = descMatch[1].trim();
+          if (val === "|-" || val === "|" || val === ">-" || val === ">") {
+            inDesc = true;
+          } else {
+            description = val.replace(/^['"]|['"]$/g, "");
+          }
+          continue;
+        }
+      }
+
+      if (inDesc) {
+        // Continuation lines of description — grab first non-empty line
+        if (!description && trimmed.length > 0) {
+          description = trimmed;
+        }
+        // Stop when we hit the next operation-level key
+        if (indent === 6 && trimmed.length > 0 && !/^description:/.test(trimmed)) {
+          inDesc = false;
+        }
+      }
+    }
+
+    endpoints.push({
+      method: currentMethod.toUpperCase(),
+      path: currentPath,
+      operationId,
+      summary,
+      description,
+      refs: blockRefs,
+    });
+
+    for (const r of blockRefs) refs.add(r);
+  }
+}
+
+for (let i = pathsStart + 1; i < pathsEnd; i++) {
+  const line = lines[i];
+
+  // Path line: exactly 2 spaces + /
+  if (/^ {2}\/\S/.test(line)) {
+    flushBlock();
+    currentPath = line.trim().replace(/:$/, "");
+    currentMethod = null;
+    blockLines = [];
+    continue;
+  }
+
+  // Method line: exactly 4 spaces + method name
+  const methodMatch = line.match(/^ {4}(\w+):\s*$/);
+  if (methodMatch && methods.includes(methodMatch[1])) {
+    flushBlock();
+    currentMethod = methodMatch[1];
+    blockLines = [];
+    continue;
+  }
+
+  if (currentMethod) {
+    blockLines.push(line);
+  }
+}
+flushBlock();
+
+// Output endpoints
+if (endpoints.length === 0) {
+  console.error(`No endpoints found for tag: "${tag}"`);
+  process.exit(1);
+}
+
+console.log(`## Endpoints for "${tag}" (${endpoints.length} total)\n`);
+for (const ep of endpoints) {
+  console.log(`### \`${ep.method}\` \`${ep.path}\``);
+  if (ep.operationId) console.log(`- **operationId**: \`${ep.operationId}\``);
+  if (ep.summary) console.log(`- **summary**: ${ep.summary}`);
+  if (ep.description && ep.description !== ep.summary)
+    console.log(`- **description**: ${ep.description}`);
+  if (ep.refs.length > 0) {
+    console.log(`- **refs**: ${ep.refs.map(r => "\`" + r.split("/").pop() + "\`").join(", ")}`);
+  }
+  console.log();
+}
+
+// Output unique refs list
+if (refs.size > 0) {
+  console.log(`## Referenced Components (${refs.size} unique)\n`);
+  const sorted = [...refs].sort();
+  for (const r of sorted) {
+    const name = r.split("/").pop();
+    const category = r.split("/").slice(0, -1).join("/").replace("#/", "");
+    console.log(`- \`${name}\` (${category})`);
+  }
+}
+SCRIPT

--- a/.agents/skills/clerk-backend-api/scripts/extract-tags.js
+++ b/.agents/skills/clerk-backend-api/scripts/extract-tags.js
@@ -1,0 +1,17 @@
+let input = "";
+process.stdin.on("data", (d) => (input += d));
+process.stdin.on("end", () => {
+  const lines = input.replace(/\r/g, "").split("\n");
+  let inTags = false;
+  for (const line of lines) {
+    if (line === "tags:") {
+      inTags = true;
+      continue;
+    }
+    if (inTags && line.length > 0 && line[0] !== " ") break;
+    if (inTags) {
+      const m = line.match(/^\s{2}- name:\s*(.+)/);
+      if (m) console.log(m[1]);
+    }
+  }
+});

--- a/.agents/skills/clerk-custom-ui/SKILL.md
+++ b/.agents/skills/clerk-custom-ui/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: clerk-custom-ui
+description: Custom authentication flows and component appearance - hooks (useSignIn,
+  useSignUp), themes, colors, fonts, CSS. Use for custom sign-in/sign-up flows, appearance
+  styling, visual customization, branding.
+allowed-tools: WebFetch
+license: MIT
+metadata:
+  author: clerk
+  version: 2.3.0
+---
+
+# Custom UI
+
+> **Prerequisite**: Ensure `ClerkProvider` wraps your app. See `clerk-setup` skill.
+>
+> **Version**: Check `package.json` for the SDK version — see `clerk` skill for the version table. This determines which custom flow references to use below.
+
+This skill covers two areas:
+
+1. **Custom authentication flows** — build your own sign-in/sign-up UI with hooks
+2. **Appearance customization** — theme, style, and brand Clerk's pre-built components
+
+## What Do You Need?
+
+| Task                                 | Reference                |
+| ------------------------------------ | ------------------------ |
+| Custom sign-in (Core 2 / LTS)        | core-2/custom-sign-in.md |
+| Custom sign-up (Core 2 / LTS)        | core-2/custom-sign-up.md |
+| Custom sign-in (Current SDK v7+)     | core-3/custom-sign-in.md |
+| Custom sign-up (Current SDK v7+)     | core-3/custom-sign-up.md |
+| Show component pattern (Current SDK) | core-3/show-component.md |
+
+## Custom Flow References
+
+| Task                       | Core 2                                           | Current                    |
+| -------------------------- | ------------------------------------------------ | -------------------------- |
+| Custom sign-in (useSignIn) | `core-2/custom-sign-in.md`                       | `core-3/custom-sign-in.md` |
+| Custom sign-up (useSignUp) | `core-2/custom-sign-up.md`                       | `core-3/custom-sign-up.md` |
+| `<Show>` component         | _(use `<SignedIn>`, `<SignedOut>`, `<Protect>`)_ | `core-3/show-component.md` |
+
+---
+
+## Appearance Customization
+
+Appearance customization applies to both Core 2 and the current SDK.
+
+### Component Customization Options
+
+| Task                               | Documentation                                                                             |
+| ---------------------------------- | ----------------------------------------------------------------------------------------- |
+| Appearance prop overview           | https://clerk.com/docs/nextjs/guides/customizing-clerk/appearance-prop/overview           |
+| Options (structure, logo, buttons) | https://clerk.com/docs/nextjs/guides/customizing-clerk/appearance-prop/layout             |
+| Themes (pre-built dark/light)      | https://clerk.com/docs/nextjs/guides/customizing-clerk/appearance-prop/themes             |
+| Variables (colors, fonts, spacing) | https://clerk.com/docs/nextjs/guides/customizing-clerk/appearance-prop/variables          |
+| CAPTCHA configuration              | https://clerk.com/docs/nextjs/guides/customizing-clerk/appearance-prop/captcha            |
+| Bring your own CSS                 | https://clerk.com/docs/nextjs/guides/customizing-clerk/appearance-prop/bring-your-own-css |
+
+### Appearance Pattern
+
+```typescript
+<SignIn
+  appearance={{
+    variables: {
+      colorPrimary: '#0000ff',
+      borderRadius: '0.5rem',
+    },
+    options: {
+      logoImageUrl: '/logo.png',
+      socialButtonsVariant: 'iconButton',
+    },
+  }}
+/>
+```
+
+> **Core 2 ONLY (skip if current SDK):** The `options` property was named `layout`. Use `layout: { logoImageUrl: '...', socialButtonsVariant: '...' }` instead of `options`.
+
+### variables (colors, typography, borders)
+
+| Property          | Description                         |
+| ----------------- | ----------------------------------- |
+| `colorPrimary`    | Primary color throughout            |
+| `colorBackground` | Background color                    |
+| `borderRadius`    | Border radius (default: `0.375rem`) |
+
+**Opacity change:** `colorRing` and `colorModalBackdrop` now render at full opacity. Use explicit `rgba()` values if you need transparency.
+
+> **Core 2 ONLY (skip if current SDK):** `colorRing` and `colorModalBackdrop` rendered at 15% opacity by default.
+
+### options (structure, logo, social buttons)
+
+| Property                 | Description                                   |
+| ------------------------ | --------------------------------------------- |
+| `logoImageUrl`           | URL to custom logo                            |
+| `socialButtonsVariant`   | `'blockButton'` \| `'iconButton'` \| `'auto'` |
+| `socialButtonsPlacement` | `'top'` \| `'bottom'`                         |
+| `showOptionalFields`     | Show optional fields (default: `false`)       |
+
+> **Core 2 ONLY (skip if current SDK):** This property is called `layout`, not `options`. Also, `showOptionalFields` defaulted to `true`.
+
+### Themes
+
+Install themes from `@clerk/ui`:
+
+```bash
+npm install @clerk/ui
+```
+
+```typescript
+import { dark } from '@clerk/ui/themes'
+
+<ClerkProvider appearance={{ theme: dark }} />
+```
+
+> **Core 2 ONLY (skip if current SDK):** Themes are imported from `@clerk/themes` (install `@clerk/themes` instead of `@clerk/ui`). Example: `import { dark } from '@clerk/themes'`.
+
+**Theme stacking** — pass an array where the last theme takes precedence:
+
+```typescript
+import { dark, neobrutalism } from '@clerk/ui/themes'
+
+<ClerkProvider appearance={{ theme: [dark, neobrutalism] }} />
+```
+
+**CSS `color-scheme` support** — the default theme respects the CSS `color-scheme` property for automatic light/dark mode toggling.
+
+**Available themes:** `dark`, `neobrutalism`, `shadcn`, `simple`
+
+#### shadcn Theme
+
+> **IMPORTANT:** If the project has `components.json` (shadcn/ui installed), ALWAYS apply the shadcn theme as the FIRST customization step. This ensures Clerk components visually match the existing shadcn design system. Skip this only if the user explicitly requests a different theme.
+
+**If the project uses shadcn/ui** (check for `components.json` in the project root), **always use the shadcn theme**:
+
+```typescript
+import { shadcn } from '@clerk/ui/themes'
+
+<ClerkProvider appearance={{ theme: shadcn }} />
+```
+
+Also import shadcn CSS in your global styles:
+
+```css
+@import "tailwindcss";
+@import "@clerk/ui/themes/shadcn.css";
+```
+
+> **Core 2 ONLY (skip if current SDK):** Import from `@clerk/themes` and `@clerk/themes/shadcn.css`:
+>
+> ```typescript
+> import { shadcn } from "@clerk/themes";
+> ```
+>
+> ```css
+> @import "@clerk/themes/shadcn.css";
+> ```
+
+## Workflow
+
+1. Identify customization needs (custom flow or appearance)
+2. For custom flows: check SDK version → read appropriate `core-2/` or `core-3/` reference
+3. For appearance: WebFetch the appropriate documentation from table above
+4. Apply appearance prop to your Clerk components or build custom flow with hooks
+
+## Common Pitfalls
+
+| Issue                        | Solution                                                                                      |
+| ---------------------------- | --------------------------------------------------------------------------------------------- |
+| Colors not applying          | Use `colorPrimary` not `primaryColor`                                                         |
+| Logo not showing             | Put `logoImageUrl` inside `options: {}` (or `layout: {}` in Core 2)                           |
+| Social buttons wrong         | Add `socialButtonsVariant: 'iconButton'` in `options` (or `layout` in Core 2)                 |
+| Styling not working          | Use appearance prop, not direct CSS (unless with bring-your-own-css)                          |
+| Hook returns different shape | Check SDK version — Core 2 and current have completely different `useSignIn`/`useSignUp` APIs |
+
+## See Also
+
+- `clerk-setup` - Initial Clerk install
+- `clerk-nextjs-patterns` - Next.js patterns
+- `clerk-orgs` - B2B organizations

--- a/.agents/skills/clerk-custom-ui/core-2/custom-sign-in.md
+++ b/.agents/skills/clerk-custom-ui/core-2/custom-sign-in.md
@@ -1,0 +1,224 @@
+# Custom Sign-In Flow (Core 2)
+
+> This document covers the **older SDK** (`@clerk/nextjs` v5–v6, `@clerk/clerk-react` v5–v6, `@clerk/clerk-expo` v1–v2). For the current SDK, see `core-3/custom-sign-in.md`.
+
+Build a custom sign-in experience using the `useSignIn()` hook.
+
+## Hook API
+
+```typescript
+import { useSignIn } from "@clerk/nextjs"; // or @clerk/clerk-react, @clerk/clerk-expo
+
+const { signIn, isLoaded, setActive } = useSignIn();
+```
+
+| Property    | Type                  | Description                 |
+| ----------- | --------------------- | --------------------------- |
+| `signIn`    | `SignIn`              | Sign-in object with methods |
+| `isLoaded`  | `boolean`             | Whether the hook has loaded |
+| `setActive` | `(params) => Promise` | Sets the active session     |
+
+## Sign-In Flow
+
+### 1. Create Sign-In
+
+```typescript
+const result = await signIn.create({
+  identifier: "user@example.com",
+  password: "securePassword123",
+});
+```
+
+### 2. First Factor Verification
+
+If additional verification is needed (email code, phone code):
+
+```typescript
+// Prepare first factor
+await signIn.prepareFirstFactor({
+  strategy: "email_code", // or 'phone_code'
+});
+
+// Attempt first factor
+const result = await signIn.attemptFirstFactor({
+  strategy: "email_code",
+  code: "123456",
+});
+```
+
+### 3. Second Factor (MFA)
+
+If the sign-in requires MFA:
+
+```typescript
+// Prepare second factor
+await signIn.prepareSecondFactor({
+  strategy: "email_code", // or 'phone_code'
+});
+
+// Attempt second factor
+const result = await signIn.attemptSecondFactor({
+  strategy: "totp", // or 'email_code', 'phone_code', 'backup_code'
+  code: "123456",
+});
+```
+
+### 4. Finalize
+
+Set the active session after successful authentication:
+
+```typescript
+await setActive({ session: signIn.createdSessionId });
+```
+
+### Password Reset
+
+```typescript
+// 1. Start reset flow
+await signIn.create({ strategy: "reset_password_email_code", identifier: "user@example.com" });
+
+// or prepare after initial create:
+await signIn.prepareFirstFactor({ strategy: "reset_password_email_code" });
+
+// 2. Verify reset code
+await signIn.attemptFirstFactor({ strategy: "reset_password_email_code", code: "123456" });
+
+// 3. Set new password
+await signIn.resetPassword({ password: "newSecurePassword123" });
+```
+
+### SSO (OAuth)
+
+```typescript
+await signIn.authenticateWithRedirect({
+  strategy: "oauth_google", // or 'oauth_github', etc.
+  redirectUrl: "/sso-callback",
+  redirectUrlComplete: "/",
+});
+```
+
+## Error Handling
+
+Use try/catch with `isClerkAPIResponseError()`:
+
+```typescript
+import { isClerkAPIResponseError } from "@clerk/nextjs/errors";
+
+try {
+  await signIn.create({ identifier, password });
+} catch (err) {
+  if (isClerkAPIResponseError(err)) {
+    err.errors.forEach((e) => {
+      console.log(e.code); // e.g. 'form_identifier_not_found'
+      console.log(e.message); // Human-readable message
+      console.log(e.longMessage); // Detailed message
+    });
+  }
+}
+```
+
+## Complete Example: Email/Password with MFA
+
+```tsx
+"use client";
+import { useState } from "react";
+import { useSignIn } from "@clerk/nextjs";
+import { isClerkAPIResponseError } from "@clerk/nextjs/errors";
+import { useRouter } from "next/navigation";
+
+export default function SignInPage() {
+  const { signIn, isLoaded, setActive } = useSignIn();
+  const router = useRouter();
+
+  const [identifier, setIdentifier] = useState("");
+  const [password, setPassword] = useState("");
+  const [mfaCode, setMfaCode] = useState("");
+  const [step, setStep] = useState<"credentials" | "mfa">("credentials");
+  const [error, setError] = useState("");
+
+  if (!isLoaded) return <div>Loading...</div>;
+
+  async function handleSignIn(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+
+    try {
+      const result = await signIn.create({ identifier, password });
+
+      if (result.status === "needs_second_factor") {
+        setStep("mfa");
+        return;
+      }
+
+      if (result.status === "complete") {
+        await setActive({ session: result.createdSessionId });
+        router.push("/");
+      }
+    } catch (err) {
+      if (isClerkAPIResponseError(err)) {
+        setError(err.errors[0]?.message || "Sign in failed");
+      }
+    }
+  }
+
+  async function handleMFA(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+
+    try {
+      const result = await signIn.attemptSecondFactor({
+        strategy: "totp",
+        code: mfaCode,
+      });
+
+      if (result.status === "complete") {
+        await setActive({ session: result.createdSessionId });
+        router.push("/");
+      }
+    } catch (err) {
+      if (isClerkAPIResponseError(err)) {
+        setError(err.errors[0]?.message || "Verification failed");
+      }
+    }
+  }
+
+  if (step === "mfa") {
+    return (
+      <form onSubmit={handleMFA}>
+        <input
+          type="text"
+          value={mfaCode}
+          onChange={(e) => setMfaCode(e.target.value)}
+          placeholder="Enter MFA code"
+        />
+        {error && <p>{error}</p>}
+        <button type="submit">Verify</button>
+      </form>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSignIn}>
+      <input
+        type="email"
+        value={identifier}
+        onChange={(e) => setIdentifier(e.target.value)}
+        placeholder="Email"
+      />
+      <input
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        placeholder="Password"
+      />
+      {error && <p>{error}</p>}
+      <button type="submit">Sign In</button>
+    </form>
+  );
+}
+```
+
+## Docs
+
+- [Custom sign-in flow](https://clerk.com/docs/custom-flows/overview)
+- [useSignIn() reference](https://clerk.com/docs/references/react/use-sign-in)

--- a/.agents/skills/clerk-custom-ui/core-2/custom-sign-up.md
+++ b/.agents/skills/clerk-custom-ui/core-2/custom-sign-up.md
@@ -1,0 +1,190 @@
+# Custom Sign-Up Flow (Core 2)
+
+> This document covers the **older SDK** (`@clerk/nextjs` v5–v6, `@clerk/clerk-react` v5–v6, `@clerk/clerk-expo` v1–v2). For the current SDK, see `core-3/custom-sign-up.md`.
+
+Build a custom sign-up experience using the `useSignUp()` hook.
+
+## Hook API
+
+```typescript
+import { useSignUp } from "@clerk/nextjs"; // or @clerk/clerk-react, @clerk/clerk-expo
+
+const { signUp, isLoaded, setActive } = useSignUp();
+```
+
+| Property    | Type                  | Description                 |
+| ----------- | --------------------- | --------------------------- |
+| `signUp`    | `SignUp`              | Sign-up object with methods |
+| `isLoaded`  | `boolean`             | Whether the hook has loaded |
+| `setActive` | `(params) => Promise` | Sets the active session     |
+
+## Sign-Up Flow
+
+### 1. Create Sign-Up
+
+```typescript
+const result = await signUp.create({
+  emailAddress: "user@example.com",
+  password: "securePassword123",
+  firstName: "Jane", // optional
+  lastName: "Doe", // optional
+});
+```
+
+### 2. Prepare Verification
+
+Send a verification code to the user's email or phone:
+
+```typescript
+await signUp.prepareVerification({
+  strategy: "email_code", // or 'phone_code', 'email_link'
+});
+```
+
+### 3. Attempt Verification
+
+Verify the code the user received:
+
+```typescript
+const result = await signUp.attemptVerification({
+  strategy: "email_code",
+  code: "123456",
+});
+```
+
+### 4. Finalize
+
+Set the active session after successful sign-up:
+
+```typescript
+await setActive({ session: signUp.createdSessionId });
+```
+
+### SSO (OAuth)
+
+```typescript
+await signUp.authenticateWithRedirect({
+  strategy: "oauth_google",
+  redirectUrl: "/sso-callback",
+  redirectUrlComplete: "/",
+});
+```
+
+## Error Handling
+
+Use try/catch with `isClerkAPIResponseError()`:
+
+```typescript
+import { isClerkAPIResponseError } from "@clerk/nextjs/errors";
+
+try {
+  await signUp.create({ emailAddress, password });
+} catch (err) {
+  if (isClerkAPIResponseError(err)) {
+    err.errors.forEach((e) => {
+      console.log(e.code); // e.g. 'form_password_pwned'
+      console.log(e.message); // Human-readable message
+      console.log(e.longMessage); // Detailed message
+    });
+  }
+}
+```
+
+## Complete Example: Email/Password with Email Verification
+
+```tsx
+"use client";
+import { useState } from "react";
+import { useSignUp } from "@clerk/nextjs";
+import { isClerkAPIResponseError } from "@clerk/nextjs/errors";
+import { useRouter } from "next/navigation";
+
+export default function SignUpPage() {
+  const { signUp, isLoaded, setActive } = useSignUp();
+  const router = useRouter();
+
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [code, setCode] = useState("");
+  const [step, setStep] = useState<"register" | "verify">("register");
+  const [error, setError] = useState("");
+
+  if (!isLoaded) return <div>Loading...</div>;
+
+  async function handleRegister(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+
+    try {
+      await signUp.create({ emailAddress: email, password });
+      await signUp.prepareVerification({ strategy: "email_code" });
+      setStep("verify");
+    } catch (err) {
+      if (isClerkAPIResponseError(err)) {
+        setError(err.errors[0]?.message || "Sign up failed");
+      }
+    }
+  }
+
+  async function handleVerify(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+
+    try {
+      const result = await signUp.attemptVerification({
+        strategy: "email_code",
+        code,
+      });
+
+      if (result.status === "complete") {
+        await setActive({ session: result.createdSessionId });
+        router.push("/");
+      }
+    } catch (err) {
+      if (isClerkAPIResponseError(err)) {
+        setError(err.errors[0]?.message || "Verification failed");
+      }
+    }
+  }
+
+  if (step === "verify") {
+    return (
+      <form onSubmit={handleVerify}>
+        <p>Check your email for a verification code.</p>
+        <input
+          type="text"
+          value={code}
+          onChange={(e) => setCode(e.target.value)}
+          placeholder="Verification code"
+        />
+        {error && <p>{error}</p>}
+        <button type="submit">Verify Email</button>
+      </form>
+    );
+  }
+
+  return (
+    <form onSubmit={handleRegister}>
+      <input
+        type="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="Email"
+      />
+      <input
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        placeholder="Password"
+      />
+      {error && <p>{error}</p>}
+      <button type="submit">Sign Up</button>
+    </form>
+  );
+}
+```
+
+## Docs
+
+- [Custom sign-up flow](https://clerk.com/docs/custom-flows/overview)
+- [useSignUp() reference](https://clerk.com/docs/references/react/use-sign-up)

--- a/.agents/skills/clerk-custom-ui/core-3/custom-sign-in.md
+++ b/.agents/skills/clerk-custom-ui/core-3/custom-sign-in.md
@@ -1,0 +1,313 @@
+# Custom Sign-In Flow
+
+Build a custom sign-in experience using the `useSignIn()` hook.
+
+## Hook API
+
+```typescript
+import { useSignIn } from "@clerk/nextjs"; // or @clerk/react, @clerk/expo
+
+const { signIn, errors, fetchStatus } = useSignIn();
+```
+
+| Property      | Type                   | Description                            |
+| ------------- | ---------------------- | -------------------------------------- |
+| `signIn`      | `SignInFuture`         | Sign-in object with namespaced methods |
+| `errors`      | `Errors<SignInFields>` | Structured error object                |
+| `fetchStatus` | `'idle' \| 'fetching'` | Network request status                 |
+
+## Sign-In Methods
+
+### Password
+
+```typescript
+const { error } = await signIn.password({
+  identifier: "user@example.com",
+  password: "securePassword123",
+});
+```
+
+### SSO (OAuth / Enterprise)
+
+```typescript
+const { error } = await signIn.sso({
+  strategy: "oauth_google", // or 'oauth_github', 'enterprise_sso', etc.
+  redirectUrl: "/dashboard", // where to go after SSO completes
+  redirectCallbackUrl: "/sso-callback", // intermediate callback route
+});
+```
+
+### Passkey
+
+```typescript
+const { error } = await signIn.passkey({ flow: "discoverable" });
+```
+
+### Web3
+
+```typescript
+const { error } = await signIn.web3({ strategy: "web3_solana_signature" });
+// or
+const { error } = await signIn.web3({ strategy: "web3_base_signature" });
+```
+
+### Ticket (Invitation link)
+
+```typescript
+const { error } = await signIn.ticket({ ticket: "ticket_abc123" });
+```
+
+### Email Code
+
+```typescript
+// Send code (emailAddress is optional if a signIn already exists from a prior method call)
+const { error } = await signIn.emailCode.sendCode({ emailAddress: "user@example.com" });
+
+// Verify code
+const { error } = await signIn.emailCode.verifyCode({ code: "123456" });
+```
+
+### Phone Code
+
+```typescript
+// Send code (phoneNumber is optional if a signIn already exists from a prior method call)
+const { error } = await signIn.phoneCode.sendCode({ phoneNumber: "+12015551234" });
+
+// Verify code
+const { error } = await signIn.phoneCode.verifyCode({ code: "123456" });
+```
+
+## MFA (Second Factor)
+
+A second factor is required when `signIn.status` is one of:
+
+- `'needs_second_factor'` — user has MFA enabled (TOTP, backup codes, etc.)
+- `'needs_client_trust'` — new device sign-in without MFA; requires email or phone code verification
+
+```typescript
+// TOTP (Authenticator app)
+const { error } = await signIn.mfa.verifyTOTP({ code: "123456" });
+
+// Backup code
+const { error } = await signIn.mfa.verifyBackupCode({ code: "backup-code-here" });
+
+// Email code
+const { error: sendErr } = await signIn.mfa.sendEmailCode();
+const { error: verifyErr } = await signIn.mfa.verifyEmailCode({ code: "123456" });
+
+// Phone code
+const { error: sendErr } = await signIn.mfa.sendPhoneCode();
+const { error: verifyErr } = await signIn.mfa.verifyPhoneCode({ code: "123456" });
+```
+
+## Password Reset
+
+```typescript
+// 1. Send reset code
+const { error } = await signIn.resetPasswordEmailCode.sendCode();
+
+// 2. Verify the code
+const { error } = await signIn.resetPasswordEmailCode.verifyCode({ code: "123456" });
+
+// 3. Submit new password
+const { error } = await signIn.resetPasswordEmailCode.submitPassword({
+  password: "newSecurePassword123",
+});
+```
+
+## Client Trust
+
+When a user signs in with a valid password from a new device without MFA enabled, the sign-in status becomes `needs_client_trust`. This requires an additional verification step:
+
+```typescript
+if (signIn.status === "needs_client_trust") {
+  // Check supportedSecondFactors for available methods (email_code or phone_code)
+  const factors = signIn.supportedSecondFactors;
+  // Use the appropriate mfa method to verify
+}
+```
+
+## Finalizing Sign-In
+
+After successful authentication, call `finalize()` to activate the session:
+
+```typescript
+await signIn.finalize({
+  navigate: async ({ session, decorateUrl }) => {
+    const destination = session.currentTask ? `/sign-in/tasks/${session.currentTask.key}` : "/";
+    const url = decorateUrl(destination);
+    // decorateUrl may return an absolute URL for Safari ITP
+    if (url.startsWith("http")) {
+      window.location.href = url;
+    } else {
+      router.push(url);
+    }
+  },
+});
+```
+
+- `decorateUrl(path)` — decorates the URL with session info (required to support Safari's Intelligent Tracking Prevention). May return an absolute URL.
+- `session.currentTask` — check for pending session tasks before redirecting
+
+### Reset State
+
+Clear local sign-in state and start over:
+
+```typescript
+signIn.reset();
+```
+
+## Error Handling
+
+All methods return `Promise<{ error: ClerkError | null }>`. Errors are also available reactively on the hook:
+
+```typescript
+const { signIn, errors } = useSignIn();
+
+// Field-level errors
+errors?.fields?.identifier; // { code, message, longMessage? }
+errors?.fields?.password; // { code, message, longMessage? }
+errors?.fields?.code; // { code, message, longMessage? }
+
+// Global errors (not tied to a field)
+errors?.global; // ClerkGlobalHookError[] | null
+
+// Raw error array
+errors?.raw; // ClerkError[] | null
+```
+
+## Complete Example: Email/Password with MFA
+
+From [the docs](https://clerk.com/docs/guides/development/custom-flows/authentication/multi-factor-authentication). Supports SMS verification codes, authenticator app (TOTP), and backup codes.
+
+```tsx
+"use client";
+
+import { useSignIn } from "@clerk/nextjs";
+import { useRouter } from "next/navigation";
+
+export default function Page() {
+  const { signIn, errors, fetchStatus } = useSignIn();
+  const router = useRouter();
+
+  const handleSubmit = async (formData: FormData) => {
+    const emailAddress = formData.get("email") as string;
+    const password = formData.get("password") as string;
+
+    await signIn.password({
+      emailAddress,
+      password,
+    });
+
+    // If you're using the authenticator app strategy, remove this check.
+    if (signIn.status === "needs_second_factor") {
+      await signIn.mfa.sendPhoneCode();
+    }
+
+    if (signIn.status === "complete") {
+      await signIn.finalize({
+        navigate: ({ session, decorateUrl }) => {
+          if (session?.currentTask) {
+            // Handle pending session tasks
+            // See https://clerk.com/docs/guides/development/custom-flows/authentication/session-tasks
+            console.log(session?.currentTask);
+            return;
+          }
+
+          const url = decorateUrl("/");
+          if (url.startsWith("http")) {
+            window.location.href = url;
+          } else {
+            router.push(url);
+          }
+        },
+      });
+    }
+  };
+
+  const handleMFAVerification = async (formData: FormData) => {
+    const code = formData.get("code") as string;
+    const useBackupCode = formData.get("useBackupCode") === "on";
+
+    if (useBackupCode) {
+      await signIn.mfa.verifyBackupCode({ code });
+    } else {
+      await signIn.mfa.verifyPhoneCode({ code });
+      // If you're using the authenticator app strategy, use the following method instead:
+      // await signIn.mfa.verifyTOTP({ code })
+    }
+
+    if (signIn.status === "complete") {
+      await signIn.finalize({
+        navigate: ({ session, decorateUrl }) => {
+          if (session?.currentTask) {
+            // Handle pending session tasks
+            // See https://clerk.com/docs/guides/development/custom-flows/authentication/session-tasks
+            console.log(session?.currentTask);
+            return;
+          }
+
+          const url = decorateUrl("/");
+          if (url.startsWith("http")) {
+            window.location.href = url;
+          } else {
+            router.push(url);
+          }
+        },
+      });
+    }
+  };
+
+  if (signIn.status === "needs_second_factor") {
+    return (
+      <div>
+        <h1>Verify your account</h1>
+        <form action={handleMFAVerification}>
+          <div>
+            <label htmlFor="code">Code</label>
+            <input id="code" name="code" type="text" />
+            {errors.fields.code && <p>{errors.fields.code.message}</p>}
+          </div>
+          <div>
+            <label>
+              Use backup code
+              <input type="checkbox" name="useBackupCode" />
+            </label>
+          </div>
+          <button type="submit" disabled={fetchStatus === "fetching"}>
+            Verify
+          </button>
+        </form>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <h1>Sign in</h1>
+      <form action={handleSubmit}>
+        <div>
+          <label htmlFor="email">Enter email address</label>
+          <input id="email" name="email" type="email" />
+          {errors.fields.identifier && <p>{errors.fields.identifier.message}</p>}
+        </div>
+        <div>
+          <label htmlFor="password">Enter password</label>
+          <input id="password" name="password" type="password" />
+          {errors.fields.password && <p>{errors.fields.password.message}</p>}
+        </div>
+        <button type="submit" disabled={fetchStatus === "fetching"}>
+          Continue
+        </button>
+      </form>
+      {errors && <p>{JSON.stringify(errors, null, 2)}</p>}
+    </>
+  );
+}
+```
+
+## Docs
+
+- [Custom sign-in flow](https://clerk.com/docs/custom-flows/overview)
+- [MFA custom flow](https://clerk.com/docs/guides/development/custom-flows/authentication/multi-factor-authentication)
+- [useSignIn() reference](https://clerk.com/docs/references/react/use-sign-in)

--- a/.agents/skills/clerk-custom-ui/core-3/custom-sign-up.md
+++ b/.agents/skills/clerk-custom-ui/core-3/custom-sign-up.md
@@ -1,0 +1,257 @@
+# Custom Sign-Up Flow
+
+Build a custom sign-up experience using the `useSignUp()` hook.
+
+## Hook API
+
+```typescript
+import { useSignUp } from "@clerk/nextjs"; // or @clerk/react, @clerk/expo
+
+const { signUp, errors, fetchStatus } = useSignUp();
+```
+
+| Property      | Type                   | Description                            |
+| ------------- | ---------------------- | -------------------------------------- |
+| `signUp`      | `SignUpFuture`         | Sign-up object with namespaced methods |
+| `errors`      | `Errors<SignUpFields>` | Structured error object                |
+| `fetchStatus` | `'idle' \| 'fetching'` | Network request status                 |
+
+## Sign-Up Methods
+
+### Password (Email/Password)
+
+```typescript
+const { error } = await signUp.password({
+  emailAddress: "user@example.com",
+  password: "securePassword123",
+  firstName: "Jane", // optional
+  lastName: "Doe", // optional
+});
+```
+
+### SSO (OAuth)
+
+```typescript
+const { error } = await signUp.sso({
+  strategy: "oauth_google", // or 'oauth_github', etc.
+  redirectUrl: "/dashboard", // where to go after SSO completes
+  redirectCallbackUrl: "/sso-callback", // intermediate callback route
+});
+```
+
+### Web3
+
+```typescript
+const { error } = await signUp.web3({ strategy: "web3_solana_signature" });
+```
+
+### Update (add fields to existing sign-up)
+
+Use `update()` to add optional fields (name, metadata, legal acceptance, locale) to an existing sign-up before finalization.
+
+```typescript
+const { error } = await signUp.update({
+  firstName: "Jane",
+  lastName: "Doe",
+  unsafeMetadata: { referralSource: "twitter" },
+  legalAccepted: true,
+});
+```
+
+## Email / Phone Verification
+
+After creating a sign-up, verify the user's email or phone:
+
+### Email Code
+
+```typescript
+// Send verification code
+const { error } = await signUp.verifications.sendEmailCode();
+
+// Verify the code
+const { error } = await signUp.verifications.verifyEmailCode({ code: "123456" });
+```
+
+### Phone Code
+
+```typescript
+// Send verification code
+const { error } = await signUp.verifications.sendPhoneCode();
+
+// Verify the code
+const { error } = await signUp.verifications.verifyPhoneCode({ code: "123456" });
+```
+
+### Email Link
+
+```typescript
+// verificationUrl: where the user lands after clicking the email link (relative or absolute)
+const { error } = await signUp.verifications.sendEmailLink({ verificationUrl: "/verify" });
+// User clicks the link in their email to verify
+```
+
+## Finalizing Sign-Up
+
+After successful sign-up and verification, call `finalize()` to activate the session:
+
+```typescript
+await signUp.finalize({
+  navigate: async ({ session, decorateUrl }) => {
+    const destination = session.currentTask ? `/sign-up/tasks/${session.currentTask.key}` : "/";
+    const url = decorateUrl(destination);
+    // decorateUrl may return an absolute URL for Safari ITP
+    if (url.startsWith("http")) {
+      window.location.href = url;
+    } else {
+      router.push(url);
+    }
+  },
+});
+```
+
+### Transferable Sign-Ups
+
+If `signUp.isTransferable` is `true`, the identifier matches an existing user and the sign-up should be transferred to a sign-in flow. This involves coordinating between sign-up and sign-in resources. See the [transferable sign-up docs](https://clerk.com/docs/custom-flows/overview) for the full implementation.
+
+### Reset State
+
+Clear local sign-up state and start over:
+
+```typescript
+signUp.reset();
+```
+
+## Error Handling
+
+All methods return `Promise<{ error: ClerkError | null }>`. Errors are also available reactively on the hook:
+
+```typescript
+const { signUp, errors } = useSignUp();
+
+// Field-level errors
+errors?.fields?.emailAddress; // { code, message, longMessage? }
+errors?.fields?.password; // { code, message, longMessage? }
+errors?.fields?.firstName; // { code, message, longMessage? }
+errors?.fields?.lastName; // { code, message, longMessage? }
+errors?.fields?.phoneNumber; // { code, message, longMessage? }
+errors?.fields?.username; // { code, message, longMessage? }
+errors?.fields?.code; // { code, message, longMessage? }
+
+// Global errors
+errors?.global; // ClerkGlobalHookError[] | null
+
+// Raw error array
+errors?.raw; // ClerkError[] | null
+```
+
+## Complete Example: Phone OTP Sign-Up
+
+From [the docs](https://clerk.com/docs/guides/development/custom-flows/authentication/email-sms-otp). Uses phone OTP with inline comments for adapting to email OTP.
+
+```tsx
+"use client";
+
+import * as React from "react";
+import { useAuth, useSignUp } from "@clerk/nextjs";
+import { useRouter } from "next/navigation";
+
+export default function SignUpPage() {
+  const { signUp, errors, fetchStatus } = useSignUp();
+  const { isSignedIn } = useAuth();
+  const router = useRouter();
+
+  const handleSubmit = async (formData: FormData) => {
+    // For email OTP: collect the email address instead of the phone number
+    const phoneNumber = formData.get("phoneNumber") as string;
+
+    // For email OTP: change create({ phoneNumber }) to create({ emailAddress })
+    const error = await signUp.create({ phoneNumber });
+
+    // For email OTP: change sendPhoneCode() to sendEmailCode()
+    if (!error) await signUp.verifications.sendPhoneCode();
+  };
+
+  const handleVerify = async (formData: FormData) => {
+    const code = formData.get("code") as string;
+
+    // For email OTP: change verifyPhoneCode() to verifyEmailCode()
+    await signUp.verifications.verifyPhoneCode({ code });
+
+    if (signUp.status === "complete") {
+      await signUp.finalize({
+        navigate: ({ session, decorateUrl }) => {
+          if (session?.currentTask) {
+            // Handle pending session tasks
+            // See https://clerk.com/docs/guides/development/custom-flows/authentication/session-tasks
+            console.log(session?.currentTask);
+            return;
+          }
+
+          const url = decorateUrl("/");
+          if (url.startsWith("http")) {
+            window.location.href = url;
+          } else {
+            router.push(url);
+          }
+        },
+      });
+    }
+  };
+
+  if (signUp.status === "complete" || isSignedIn) {
+    return null;
+  }
+
+  if (
+    signUp.status === "missing_requirements" &&
+    // For email OTP: check for phone_number instead of email_address
+    signUp.unverifiedFields.includes("phone_number") &&
+    signUp.missingFields.length === 0
+  ) {
+    return (
+      <>
+        <h1>Verify your account</h1>
+        <form action={handleVerify}>
+          <div>
+            <label htmlFor="code">Code</label>
+            <input id="code" name="code" type="text" />
+          </div>
+          {errors.fields.code && <p>{errors.fields.code.message}</p>}
+          <button type="submit" disabled={fetchStatus === "fetching"}>
+            Verify
+          </button>
+        </form>
+        {/* For email OTP: change sendPhoneCode() to sendEmailCode() */}
+        <button onClick={() => signUp.verifications.sendPhoneCode()}>I need a new code</button>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <h1>Sign up</h1>
+      <form action={handleSubmit}>
+        {/* For email OTP: collect the emailAddress instead */}
+        <div>
+          <label htmlFor="phoneNumber">Phone number</label>
+          <input id="phoneNumber" name="phoneNumber" type="tel" />
+          {errors.fields.phoneNumber && <p>{errors.fields.phoneNumber.message}</p>}
+        </div>
+        <button type="submit" disabled={fetchStatus === "fetching"}>
+          Continue
+        </button>
+      </form>
+      {errors && <p>{JSON.stringify(errors, null, 2)}</p>}
+
+      {/* Required for sign-up flows. Clerk's bot sign-up protection is enabled by default */}
+      <div id="clerk-captcha" />
+    </>
+  );
+}
+```
+
+## Docs
+
+- [Custom sign-up flow](https://clerk.com/docs/custom-flows/overview)
+- [Email/phone OTP custom flow](https://clerk.com/docs/guides/development/custom-flows/authentication/email-sms-otp)
+- [useSignUp() reference](https://clerk.com/docs/references/react/use-sign-up)

--- a/.agents/skills/clerk-custom-ui/core-3/show-component.md
+++ b/.agents/skills/clerk-custom-ui/core-3/show-component.md
@@ -1,0 +1,125 @@
+# `<Show>` Component
+
+The `<Show>` component conditionally renders content based on authentication state, roles, permissions, billing plans, and features.
+
+> **Core 2 ONLY (skip if current SDK):** The `<Show>` component does not exist in Core 2. Use `<SignedIn>`, `<SignedOut>`, and `<Protect>` instead. See migration table below.
+
+## Import
+
+```typescript
+import { Show } from "@clerk/nextjs"; // Next.js
+import { Show } from "@clerk/react"; // React
+import { Show } from "@clerk/react-router"; // React Router
+import { Show } from "@clerk/expo"; // Expo
+```
+
+## Props
+
+| Prop                       | Type                           | Description                                            |
+| -------------------------- | ------------------------------ | ------------------------------------------------------ |
+| `when`                     | `string \| object \| function` | Condition for rendering children                       |
+| `fallback?`                | `ReactNode`                    | Content shown when condition fails                     |
+| `treatPendingAsSignedOut?` | `boolean`                      | Treat pending sessions as signed-out (default: `true`) |
+
+## `when` Prop Variants
+
+### Authentication State
+
+```tsx
+// Show content only when signed in
+<Show when="signed-in">
+  <p>Welcome back!</p>
+</Show>
+
+// Show content only when signed out
+<Show when="signed-out">
+  <p>Please sign in.</p>
+</Show>
+```
+
+### Role Check
+
+```tsx
+<Show when={{ role: "org:admin" }}>
+  <AdminPanel />
+</Show>
+```
+
+### Permission Check
+
+```tsx
+<Show when={{ permission: "org:billing:manage" }}>
+  <BillingSettings />
+</Show>
+```
+
+### Billing Feature Check
+
+```tsx
+<Show when={{ feature: "widgets" }}>
+  <WidgetBuilder />
+</Show>
+```
+
+### Billing Plan Check
+
+```tsx
+<Show when={{ plan: "gold" }}>
+  <PremiumContent />
+</Show>
+```
+
+### Custom Condition (Function)
+
+```tsx
+<Show when={(has) => has({ role: "org:admin" }) || has({ permission: "org:billing:manage" })}>
+  <SettingsPanel />
+</Show>
+```
+
+## Fallback Content
+
+Show alternative content when the condition fails:
+
+```tsx
+<Show when="signed-in" fallback={<p>Please sign in to continue.</p>}>
+  <Dashboard />
+</Show>
+```
+
+## Session Tasks and Pending State
+
+The `treatPendingAsSignedOut` prop controls how pending sessions (sessions with incomplete tasks) are handled:
+
+```tsx
+// Default: pending sessions are treated as signed-out
+<Show when="signed-in" treatPendingAsSignedOut>
+  <Dashboard />
+</Show>
+
+// Treat pending sessions as signed-in (e.g., to show task completion UI)
+<Show when="signed-in" treatPendingAsSignedOut={false}>
+  <TaskCompletionFlow />
+</Show>
+```
+
+## Security Caveat
+
+**`<Show>` only visually hides content** — it remains in browser source. It is not a security boundary. For protecting sensitive data, always verify authentication server-side with `auth()` or use `auth.protect()` in middleware.
+
+## Migration from Core 2
+
+| Core 2                                      | Current                                              |
+| ------------------------------------------- | ---------------------------------------------------- |
+| `<SignedIn>`                                | `<Show when="signed-in">`                            |
+| `<SignedOut>`                               | `<Show when="signed-out">`                           |
+| `<Protect role="org:admin">`                | `<Show when={{ role: 'org:admin' }}>`                |
+| `<Protect permission="org:billing:manage">` | `<Show when={{ permission: 'org:billing:manage' }}>` |
+| `<Protect condition={(has) => expr}>`       | `<Show when={(has) => expr}>`                        |
+| `<Protect fallback={...}>`                  | `<Show when={...} fallback={...}>`                   |
+| _(no equivalent)_                           | `<Show when={{ feature: 'widgets' }}>`               |
+| _(no equivalent)_                           | `<Show when={{ plan: 'gold' }}>`                     |
+
+## Docs
+
+- [Show component reference](https://clerk.com/docs/components/control/show)

--- a/.agents/skills/clerk-expo-patterns/SKILL.md
+++ b/.agents/skills/clerk-expo-patterns/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: clerk-expo-patterns
+description: "Expo / React Native patterns with Clerk — SecureStore token cache, OAuth
+  deep linking, useAuth in native, Expo Router protected routes, push notifications
+  with user context. Triggers on: expo clerk, clerk react native, SecureStore token
+  cache, expo router auth, OAuth deep link clerk, mobile auth clerk."
+license: MIT
+allowed-tools: WebFetch
+metadata:
+  author: clerk
+  version: 1.0.0
+compatibility: Requires Expo CLI and expo-secure-store package
+---
+
+# Expo Patterns
+
+SDK: `@clerk/expo` v3+. Requires Expo 53+, React Native 0.73+.
+
+## What Do You Need?
+
+| Task                               | Reference                        |
+| ---------------------------------- | -------------------------------- |
+| Persist tokens with SecureStore    | references/token-storage.md      |
+| OAuth (Google, Apple, GitHub)      | references/oauth-deep-linking.md |
+| Protected screens with Expo Router | references/protected-routes.md   |
+| Push notifications with user data  | references/push-notifications.md |
+
+## Mental Model
+
+Clerk stores the session token in memory by default. In native apps:
+
+- **SecureStore** — encrypt token in device keychain (recommended for production)
+- **`tokenCache`** — prop on `<ClerkProvider>` that provides custom storage
+- **`useAuth`** — same API as web, works in any component
+- **OAuth** — requires `useSSO` + deep link scheme configured in `app.json`
+
+## Minimal Setup
+
+### app/\_layout.tsx
+
+```tsx
+import { ClerkProvider } from "@clerk/expo";
+import { tokenCache } from "@clerk/expo/token-cache";
+import { Stack } from "expo-router";
+
+const publishableKey = process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY!;
+
+export default function RootLayout() {
+  return (
+    <ClerkProvider publishableKey={publishableKey} tokenCache={tokenCache}>
+      <Stack />
+    </ClerkProvider>
+  );
+}
+```
+
+> **CRITICAL**: Use `EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY` — not `NEXT_PUBLIC_`. Env vars inside `node_modules` are not inlined in production builds. Always pass `publishableKey` explicitly.
+
+## Built-in Token Cache
+
+```tsx
+import { tokenCache } from "@clerk/expo/token-cache";
+```
+
+This uses `expo-secure-store` with `keychainAccessible: AFTER_FIRST_UNLOCK`. Install the peer dep:
+
+```bash
+npx expo install expo-secure-store
+```
+
+## Auth Hooks
+
+```tsx
+import { useAuth, useUser, useSignIn, useSignUp, useClerk } from "@clerk/expo";
+
+export function ProfileScreen() {
+  const { isSignedIn, userId, signOut } = useAuth();
+  const { user } = useUser();
+
+  if (!isSignedIn) return <Redirect href="/sign-in" />;
+  return (
+    <View>
+      <Text>{user?.fullName}</Text>
+      <Button title="Sign Out" onPress={() => signOut()} />
+    </View>
+  );
+}
+```
+
+## OAuth Flow (Google)
+
+```tsx
+import { useSSO } from "@clerk/expo";
+import * as WebBrowser from "expo-web-browser";
+
+WebBrowser.maybeCompleteAuthSession();
+
+export function GoogleSignIn() {
+  const { startSSOFlow } = useSSO();
+
+  const handlePress = async () => {
+    try {
+      const { createdSessionId, setActive } = await startSSOFlow({
+        strategy: "oauth_google",
+        redirectUrl: "myapp://oauth-callback",
+      });
+      if (createdSessionId) await setActive!({ session: createdSessionId });
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return <Button title="Continue with Google" onPress={handlePress} />;
+}
+```
+
+## Org Switching
+
+```tsx
+import { useOrganization, useOrganizationList } from "@clerk/expo";
+
+export function OrgSwitcher() {
+  const { organization } = useOrganization();
+  const { setActive, userMemberships } = useOrganizationList();
+
+  return (
+    <View>
+      <Text>Current: {organization?.name ?? "Personal"}</Text>
+      {userMemberships.data?.map((mem) => (
+        <Button
+          key={mem.organization.id}
+          title={mem.organization.name}
+          onPress={() => setActive({ organization: mem.organization.id })}
+        />
+      ))}
+    </View>
+  );
+}
+```
+
+## Common Pitfalls
+
+| Symptom                               | Cause                                | Fix                                                   |
+| ------------------------------------- | ------------------------------------ | ----------------------------------------------------- |
+| `publishableKey` undefined in prod    | Using env var without `EXPO_PUBLIC_` | Rename to `EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY`         |
+| Token lost on app restart             | No `tokenCache`                      | Pass `tokenCache` from `@clerk/expo/token-cache`      |
+| OAuth redirect not working            | Missing scheme in `app.json`         | Add `"scheme": "myapp"` to `app.json`                 |
+| `WebBrowser.maybeCompleteAuthSession` | Not called                           | Call it at the top level of the OAuth callback screen |
+| `useSSO` not found                    | Old `@clerk/expo` version            | `useSSO` replaced `useOAuth` in v3+                   |
+
+## Import Map
+
+| What                                     | Import From               |
+| ---------------------------------------- | ------------------------- |
+| `ClerkProvider`                          | `@clerk/expo`             |
+| `tokenCache`                             | `@clerk/expo/token-cache` |
+| `useAuth`, `useUser`, `useSignIn`        | `@clerk/expo`             |
+| `useSSO`                                 | `@clerk/expo`             |
+| `useOrganization`, `useOrganizationList` | `@clerk/expo`             |
+
+## See Also
+
+- `clerk-setup` - Initial Clerk install
+- `clerk-custom-ui` - Custom flows & appearance
+- `clerk-orgs` - B2B organizations
+
+## Docs
+
+[Expo SDK](https://clerk.com/docs/expo/getting-started/quickstart)

--- a/.agents/skills/clerk-expo-patterns/evals/evals.json
+++ b/.agents/skills/clerk-expo-patterns/evals/evals.json
@@ -1,0 +1,83 @@
+{
+  "skill_name": "clerk-expo-patterns",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "i'm building an expo app and want to add clerk. show me how to wrap the app with ClerkProvider and configure the SecureStore token cache so the session persists after app restarts.",
+      "expected_output": "Wraps app in ClerkProvider with publishableKey from EXPO_PUBLIC_ env, passes tokenCache from @clerk/expo/token-cache",
+      "scaffold": "expo-basic-auth",
+      "expectations": [
+        "Imports ClerkProvider from @clerk/expo",
+        "Imports tokenCache from @clerk/expo/token-cache",
+        "Reads publishableKey from process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY",
+        "Passes tokenCache prop to ClerkProvider",
+        "Does NOT use NEXT_PUBLIC_ prefix for the env variable"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "i want users to sign in with Google in my expo app. implement the OAuth flow using useSSO and handle the deep link redirect.",
+      "expected_output": "Uses useSSO hook with startSSOFlow, passes redirectUrl with app scheme, calls WebBrowser.maybeCompleteAuthSession",
+      "scaffold": "expo-basic-auth",
+      "expectations": [
+        "Imports useSSO from @clerk/expo",
+        "Calls startSSOFlow with strategy: 'oauth_google'",
+        "Passes redirectUrl with the app's custom scheme (e.g. myapp://oauth-callback)",
+        "Calls WebBrowser.maybeCompleteAuthSession() at the top level of the callback screen",
+        "Calls setActive with the createdSessionId after successful OAuth"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "my expo router app has a (tabs) group that should only be accessible to signed-in users. redirect unauthenticated users to the sign-in screen.",
+      "expected_output": "Uses useAuth in the tabs layout, redirects to /sign-in with Redirect component when not signed in",
+      "scaffold": "expo-basic-auth",
+      "expectations": [
+        "Imports useAuth from @clerk/expo",
+        "Checks isSignedIn and isLoaded from useAuth",
+        "Returns null or loading indicator when isLoaded is false",
+        "Redirects to the sign-in screen when isSignedIn is false",
+        "Uses Expo Router's Redirect component or router.replace for the redirect"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "i need the clerk session token to survive app restarts. show me how to implement a custom token cache using expo-secure-store directly instead of the built-in one.",
+      "expected_output": "Creates a TokenCache object with getToken and saveToken using SecureStore.getItemAsync and setItemAsync",
+      "scaffold": "expo-basic-auth",
+      "expectations": [
+        "Creates an object implementing TokenCache interface with getToken and saveToken methods",
+        "Uses SecureStore.getItemAsync in getToken",
+        "Uses SecureStore.setItemAsync in saveToken",
+        "Handles errors in getToken by deleting the corrupted item and returning null",
+        "Passes the custom cache as tokenCache prop to ClerkProvider"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "i want to show the user's profile information (name, avatar, email) in a profile screen in my expo app.",
+      "expected_output": "Uses useUser hook to access user data, renders user.fullName, user.imageUrl, and primary email",
+      "scaffold": "expo-basic-auth",
+      "expectations": [
+        "Imports useUser from @clerk/expo",
+        "Destructures user from useUser()",
+        "Shows user.fullName or user.firstName",
+        "Handles the case where user is null (not yet loaded)",
+        "Accesses email via user.primaryEmailAddress?.emailAddress"
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "my expo app supports organizations. i need a screen where users can see their organizations and switch the active one.",
+      "expected_output": "Uses useOrganizationList to list memberships and setActive, uses useOrganization to show current org",
+      "scaffold": "expo-basic-auth",
+      "expectations": [
+        "Imports useOrganization and useOrganizationList from @clerk/expo",
+        "Calls setActive from useOrganizationList to switch organizations",
+        "Lists available orgs from userMemberships.data",
+        "Shows the currently active organization name",
+        "Handles the case where userMemberships.data is undefined or loading"
+      ]
+    }
+  ]
+}

--- a/.agents/skills/clerk-expo-patterns/references/oauth-deep-linking.md
+++ b/.agents/skills/clerk-expo-patterns/references/oauth-deep-linking.md
@@ -1,0 +1,79 @@
+# OAuth Deep Linking
+
+## Prerequisites
+
+1. Add scheme to `app.json`:
+
+```json
+{
+  "expo": {
+    "scheme": "myapp"
+  }
+}
+```
+
+2. Install deps: `npx expo install expo-web-browser expo-auth-session`
+
+## OAuth with useSSO
+
+```tsx
+import { useSSO } from "@clerk/expo";
+import * as WebBrowser from "expo-web-browser";
+import { useEffect } from "react";
+
+WebBrowser.maybeCompleteAuthSession();
+
+export function SignInScreen() {
+  const { startSSOFlow } = useSSO();
+
+  const handleGoogle = async () => {
+    try {
+      const { createdSessionId, setActive, signIn, signUp } = await startSSOFlow({
+        strategy: "oauth_google",
+        redirectUrl: "myapp://oauth-callback",
+      });
+
+      if (createdSessionId) {
+        await setActive!({ session: createdSessionId });
+      } else if (signUp?.status === "missing_requirements") {
+        // Handle missing fields (e.g. username)
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return <Button onPress={handleGoogle} title="Sign in with Google" />;
+}
+```
+
+## Supported Strategies
+
+| Provider  | Strategy          |
+| --------- | ----------------- |
+| Google    | `oauth_google`    |
+| Apple     | `oauth_apple`     |
+| GitHub    | `oauth_github`    |
+| Microsoft | `oauth_microsoft` |
+| Facebook  | `oauth_facebook`  |
+
+## Callback Screen
+
+Create `app/oauth-callback.tsx`:
+
+```tsx
+import { useEffect } from "react";
+import * as WebBrowser from "expo-web-browser";
+
+WebBrowser.maybeCompleteAuthSession();
+
+export default function OAuthCallback() {
+  return null;
+}
+```
+
+## CRITICAL
+
+- `WebBrowser.maybeCompleteAuthSession()` must be called at the TOP LEVEL of the callback screen (not inside a hook or effect)
+- `redirectUrl` must match the scheme in `app.json` exactly
+- `useSSO` replaces `useOAuth` from older `@clerk/expo` versions

--- a/.agents/skills/clerk-expo-patterns/references/protected-routes.md
+++ b/.agents/skills/clerk-expo-patterns/references/protected-routes.md
@@ -1,0 +1,66 @@
+# Protected Routes (Expo Router)
+
+## Layout-Level Guard
+
+Protect an entire group in `app/(auth)/_layout.tsx`:
+
+```tsx
+import { useAuth } from "@clerk/expo";
+import { Redirect, Stack } from "expo-router";
+
+export default function AuthLayout() {
+  const { isSignedIn, isLoaded } = useAuth();
+
+  if (!isLoaded) return null;
+
+  if (!isSignedIn) return <Redirect href="/sign-in" />;
+
+  return <Stack />;
+}
+```
+
+## Screen-Level Guard
+
+For a single screen:
+
+```tsx
+import { useAuth } from "@clerk/expo";
+import { Redirect } from "expo-router";
+import { View, Text } from "react-native";
+
+export default function ProfileScreen() {
+  const { isSignedIn, isLoaded, userId } = useAuth();
+
+  if (!isLoaded) return null;
+  if (!isSignedIn) return <Redirect href="/sign-in" />;
+
+  return (
+    <View>
+      <Text>User: {userId}</Text>
+    </View>
+  );
+}
+```
+
+## Recommended File Structure
+
+```
+app/
+├── _layout.tsx           # Root layout with ClerkProvider
+├── (public)/
+│   ├── sign-in.tsx
+│   └── sign-up.tsx
+└── (protected)/
+    ├── _layout.tsx       # Auth guard here
+    ├── (tabs)/
+    │   ├── _layout.tsx
+    │   ├── home.tsx
+    │   └── profile.tsx
+    └── settings.tsx
+```
+
+## CRITICAL
+
+- Always check `isLoaded` before checking `isSignedIn` — Clerk needs time to restore the session from the token cache
+- Returning `null` while loading prevents a flash of the sign-in screen
+- Use `<Redirect>` from `expo-router`, not `router.push` in effects, to avoid React render warnings

--- a/.agents/skills/clerk-expo-patterns/references/push-notifications.md
+++ b/.agents/skills/clerk-expo-patterns/references/push-notifications.md
@@ -1,0 +1,65 @@
+# Push Notifications with User Context
+
+Store the Expo push token against the Clerk user using `publicMetadata` or your own database.
+
+## Register Push Token After Sign-In
+
+```tsx
+import { useUser } from "@clerk/expo";
+import * as Notifications from "expo-notifications";
+import { useEffect } from "react";
+
+export function PushTokenRegistrar() {
+  const { user, isLoaded } = useUser();
+
+  useEffect(() => {
+    if (!isLoaded || !user) return;
+
+    async function register() {
+      const { status } = await Notifications.requestPermissionsAsync();
+      if (status !== "granted") return;
+
+      const token = (await Notifications.getExpoPushTokenAsync()).data;
+
+      await user.update({
+        unsafeMetadata: {
+          ...user.unsafeMetadata,
+          expoPushToken: token,
+        },
+      });
+    }
+
+    register();
+  }, [isLoaded, user]);
+
+  return null;
+}
+```
+
+> Use `unsafeMetadata` for client-writable data. Use `publicMetadata` (server-only write) for verified data.
+
+## Send Notification to User (Server)
+
+```tsx
+import { clerkClient } from "@clerk/nextjs/server";
+
+async function sendNotification(userId: string, title: string, body: string) {
+  const client = await clerkClient();
+  const user = await client.users.getUser(userId);
+  const token = user.unsafeMetadata?.expoPushToken as string | undefined;
+
+  if (!token) return;
+
+  await fetch("https://exp.host/--/api/v2/push/send", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ to: token, title, body }),
+  });
+}
+```
+
+## CRITICAL
+
+- `user.update()` is client-side — it writes `unsafeMetadata` without server auth
+- For verified/sensitive data, use the Clerk Backend SDK from your server to write `publicMetadata`
+- Re-register the push token if `user.id` changes (org switch does not change user.id, but sign-out/sign-in as different user does)

--- a/.agents/skills/clerk-expo-patterns/references/token-storage.md
+++ b/.agents/skills/clerk-expo-patterns/references/token-storage.md
@@ -1,0 +1,60 @@
+# Token Storage
+
+Clerk stores the active session token in memory by default. In native apps, use a persistent token cache so sessions survive app restarts.
+
+## Built-in Cache (Recommended)
+
+```tsx
+import { tokenCache } from '@clerk/expo/token-cache'
+
+<ClerkProvider publishableKey={key} tokenCache={tokenCache}>
+```
+
+Uses `expo-secure-store` with `keychainAccessible: AFTER_FIRST_UNLOCK`.
+
+Install peer dep: `npx expo install expo-secure-store`
+
+## Custom Cache
+
+Implement the `TokenCache` interface:
+
+```tsx
+import * as SecureStore from "expo-secure-store";
+import type { TokenCache } from "@clerk/expo/token-cache";
+
+const tokenCache: TokenCache = {
+  async getToken(key: string) {
+    try {
+      return await SecureStore.getItemAsync(key, {
+        keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK,
+      });
+    } catch {
+      await SecureStore.deleteItemAsync(key);
+      return null;
+    }
+  },
+  saveToken(key: string, token: string) {
+    return SecureStore.setItemAsync(key, token, {
+      keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK,
+    });
+  },
+};
+```
+
+## Expo Web
+
+`expo-secure-store` is not available on web. Provide separate implementations:
+
+```tsx
+import { Platform } from 'react-native'
+import { tokenCache as nativeCache } from '@clerk/expo/token-cache'
+
+const cache = Platform.OS === 'web' ? undefined : nativeCache
+<ClerkProvider tokenCache={cache} ... />
+```
+
+## CRITICAL
+
+- `AFTER_FIRST_UNLOCK` means the token is inaccessible until the user unlocks the device at least once after a restart
+- Always delete the item on `getToken` error — corrupted keychain entries cause silent auth failures
+- Never store tokens in AsyncStorage — it is not encrypted

--- a/.agents/skills/clerk-expo-patterns/templates/expo-basic-auth/app.json
+++ b/.agents/skills/clerk-expo-patterns/templates/expo-basic-auth/app.json
@@ -1,0 +1,8 @@
+{
+  "expo": {
+    "name": "clerk-expo",
+    "slug": "clerk-expo",
+    "scheme": "clerkexpo",
+    "plugins": ["expo-secure-store", "@clerk/expo"]
+  }
+}

--- a/.agents/skills/clerk-expo-patterns/templates/expo-basic-auth/app/(auth)/_layout.tsx
+++ b/.agents/skills/clerk-expo-patterns/templates/expo-basic-auth/app/(auth)/_layout.tsx
@@ -1,0 +1,9 @@
+import { useAuth } from "@clerk/expo";
+import { Redirect, Stack } from "expo-router";
+
+export default function AuthRoutesLayout() {
+  const { isSignedIn, isLoaded } = useAuth();
+  if (!isLoaded) return null;
+  if (isSignedIn) return <Redirect href={"/"} />;
+  return <Stack />;
+}

--- a/.agents/skills/clerk-expo-patterns/templates/expo-basic-auth/app/(home)/_layout.tsx
+++ b/.agents/skills/clerk-expo-patterns/templates/expo-basic-auth/app/(home)/_layout.tsx
@@ -1,0 +1,9 @@
+import { useAuth } from "@clerk/expo";
+import { Redirect, Stack } from "expo-router";
+
+export default function Layout() {
+  const { isSignedIn, isLoaded } = useAuth();
+  if (!isLoaded) return null;
+  if (!isSignedIn) return <Redirect href="/(auth)/sign-in" />;
+  return <Stack />;
+}

--- a/.agents/skills/clerk-expo-patterns/templates/expo-basic-auth/app/(home)/index.tsx
+++ b/.agents/skills/clerk-expo-patterns/templates/expo-basic-auth/app/(home)/index.tsx
@@ -1,0 +1,42 @@
+import { Show, useUser } from "@clerk/expo";
+import { useClerk } from "@clerk/expo";
+import { Link } from "expo-router";
+import { Text, View, Pressable, StyleSheet } from "react-native";
+
+export default function Page() {
+  const { user } = useUser();
+  const { signOut } = useClerk();
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Welcome!</Text>
+      <Show when="signed-out">
+        <Link href="/(auth)/sign-in">
+          <Text>Sign in</Text>
+        </Link>
+        <Link href="/(auth)/sign-up">
+          <Text>Sign up</Text>
+        </Link>
+      </Show>
+      <Show when="signed-in">
+        <Text>Hello {user?.id}</Text>
+        <Pressable style={styles.button} onPress={() => signOut()}>
+          <Text style={styles.buttonText}>Sign out</Text>
+        </Pressable>
+      </Show>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 20, paddingTop: 60, gap: 16 },
+  title: { fontSize: 24, fontWeight: "bold" },
+  button: {
+    backgroundColor: "#0a7ea4",
+    paddingVertical: 12,
+    paddingHorizontal: 24,
+    borderRadius: 8,
+    alignItems: "center",
+  },
+  buttonText: { color: "#fff", fontWeight: "600" },
+});

--- a/.agents/skills/clerk-expo-patterns/templates/expo-basic-auth/app/_layout.tsx
+++ b/.agents/skills/clerk-expo-patterns/templates/expo-basic-auth/app/_layout.tsx
@@ -1,0 +1,17 @@
+import { ClerkProvider } from "@clerk/expo";
+import { tokenCache } from "@clerk/expo/token-cache";
+import { Slot } from "expo-router";
+
+const publishableKey = process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY!;
+
+if (!publishableKey) {
+  throw new Error("Add your Clerk Publishable Key to the .env file");
+}
+
+export default function RootLayout() {
+  return (
+    <ClerkProvider publishableKey={publishableKey} tokenCache={tokenCache}>
+      <Slot />
+    </ClerkProvider>
+  );
+}

--- a/.agents/skills/clerk-expo-patterns/templates/expo-basic-auth/package.json
+++ b/.agents/skills/clerk-expo-patterns/templates/expo-basic-auth/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "clerk-expo",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "@clerk/expo": "latest",
+    "expo": "latest",
+    "expo-router": "latest",
+    "expo-secure-store": "latest",
+    "react": "latest",
+    "react-native": "latest"
+  }
+}

--- a/.agents/skills/clerk-expo-patterns/templates/expo-basic-auth/tsconfig.json
+++ b/.agents/skills/clerk-expo-patterns/templates/expo-basic-auth/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}

--- a/.agents/skills/clerk-webhooks/SKILL.md
+++ b/.agents/skills/clerk-webhooks/SKILL.md
@@ -1,0 +1,367 @@
+---
+name: clerk-webhooks
+description: Clerk webhooks for real-time events and data syncing. Always output complete,
+  copy-paste-ready webhook handlers with verifyWebhook(req) verification. Listen for
+  user creation, updates, deletion, and organization events. Build event-driven features
+  like database sync, notifications, integrations.
+allowed-tools: WebFetch
+license: MIT
+metadata:
+  author: clerk
+  version: 1.2.0
+compatibility: Requires CLERK_WEBHOOK_SECRET (svix signing secret from Clerk dashboard)
+---
+
+# Webhooks
+
+Always output complete, working, copy-paste-ready webhook handlers. Never output stubs, placeholders, or partial implementations. Include `verifyWebhook(req)` in every handler.
+
+## CRITICAL: Always Verify Webhooks
+
+**NEVER skip signature verification**, even for notification-only handlers. Always use `verifyWebhook(req)` from `@clerk/nextjs/webhooks`. This uses the `CLERK_WEBHOOK_SECRET` env var automatically.
+
+## CRITICAL: Make Webhook Route Public
+
+Webhook routes MUST be excluded from Clerk middleware protection. Without this, Clerk returns 401.
+
+```typescript
+// proxy.ts (Next.js <=15: middleware.ts)
+import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
+
+const isPublicRoute = createRouteMatcher(["/api/webhooks(.*)"]);
+
+export default clerkMiddleware((auth, req) => {
+  if (!isPublicRoute(req)) auth().protect();
+});
+```
+
+## Complete Webhook Handler (Next.js App Router)
+
+```typescript
+// app/api/webhooks/route.ts
+import { verifyWebhook } from "@clerk/nextjs/webhooks";
+import { NextRequest } from "next/server";
+import { db } from "@/lib/db";
+
+export async function POST(req: NextRequest) {
+  // ALWAYS verify - never skip, even for notification-only handlers
+  let evt;
+  try {
+    evt = await verifyWebhook(req); // uses CLERK_WEBHOOK_SECRET automatically
+  } catch (err) {
+    console.error("Webhook verification failed:", err);
+    return new Response("Verification failed", { status: 400 });
+  }
+
+  if (evt.type === "user.created") {
+    const { id, email_addresses, first_name, last_name } = evt.data;
+    const email = email_addresses[0]?.email_address;
+    const name = `${first_name ?? ""} ${last_name ?? ""}`.trim();
+    await db.users.create({ data: { clerkId: id, email, name } });
+  }
+
+  if (evt.type === "user.updated") {
+    const { id, email_addresses, first_name, last_name } = evt.data;
+    const email = email_addresses[0]?.email_address;
+    await db.users.update({ where: { clerkId: id }, data: { email, first_name, last_name } });
+  }
+
+  if (evt.type === "user.deleted") {
+    const { id } = evt.data;
+    await db.users.delete({ where: { clerkId: id } });
+  }
+
+  if (evt.type === "organizationMembership.created") {
+    const { organization, public_user_data, role } = evt.data;
+    const orgId = organization.id;
+    const userId = public_user_data.user_id;
+    await db.teamMembers.create({ data: { orgId, userId, role } });
+  }
+
+  if (evt.type === "organizationMembership.deleted") {
+    const { organization, public_user_data } = evt.data;
+    const orgId = organization.id;
+    const userId = public_user_data.user_id;
+    await db.teamMembers.delete({ where: { orgId_userId: { orgId, userId } } });
+  }
+
+  return new Response("OK", { status: 200 });
+}
+```
+
+## Full Example: Welcome Email (Resend) + Slack Notification on user.created
+
+**ALWAYS use this COMPLETE pattern — never stub it out:**
+
+```typescript
+// app/api/webhooks/route.ts
+import { verifyWebhook } from "@clerk/nextjs/webhooks";
+import { NextRequest } from "next/server";
+import { Resend } from "resend";
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+
+export async function POST(req: NextRequest) {
+  // Step 1: ALWAYS verify the webhook signature - NEVER skip this
+  let evt;
+  try {
+    evt = await verifyWebhook(req); // uses CLERK_WEBHOOK_SECRET env var
+  } catch (err) {
+    console.error("Webhook verification failed:", err);
+    return new Response("Verification failed", { status: 400 });
+  }
+
+  // Step 2: Listen for user.created event
+  if (evt.type === "user.created") {
+    // Step 3: Extract user email and name from webhook payload
+    const { id, email_addresses, first_name, last_name } = evt.data;
+    const email = email_addresses[0]?.email_address;
+    const name = `${first_name ?? ""} ${last_name ?? ""}`.trim();
+
+    // Step 4: Call Resend API to send welcome email
+    await resend.emails.send({
+      from: "noreply@yourdomain.com",
+      to: email,
+      subject: "Welcome!",
+      html: `<p>Hi ${name}, welcome to our app!</p>`,
+    });
+
+    // Step 5: Post notification to Slack channel
+    await fetch(process.env.SLACK_WEBHOOK_URL!, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        text: `New user signed up: ${name} (${email})`,
+      }),
+    });
+  }
+
+  // Always return 200 to acknowledge receipt
+  return new Response("OK", { status: 200 });
+}
+```
+
+**Also include proxy.ts (Next.js <=15: middleware.ts) to make the route public:**
+
+```typescript
+// proxy.ts (Next.js <=15: middleware.ts)
+import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
+const isPublicRoute = createRouteMatcher(["/api/webhooks(.*)"]);
+export default clerkMiddleware((auth, req) => {
+  if (!isPublicRoute(req)) auth().protect();
+});
+```
+
+## Full Example: Organization Membership Sync to Database
+
+```typescript
+// app/api/webhooks/route.ts
+import { verifyWebhook } from "@clerk/nextjs/webhooks";
+import { NextRequest } from "next/server";
+import { db } from "@/lib/db"; // your database client
+
+export async function POST(req: NextRequest) {
+  // ALWAYS verify signature - never skip, even for simple handlers
+  let evt;
+  try {
+    evt = await verifyWebhook(req); // uses CLERK_WEBHOOK_SECRET env var
+  } catch (err) {
+    console.error("Webhook verification failed:", err);
+    return new Response("Verification failed", { status: 400 });
+  }
+
+  if (evt.type === "organization.created") {
+    const { id, name } = evt.data;
+    await db.workspaces.create({
+      data: { orgId: id, name, createdAt: new Date() },
+    });
+  }
+
+  if (evt.type === "organizationMembership.created") {
+    // Extract organization ID, user ID, and role from payload
+    const { organization, public_user_data, role } = evt.data;
+    const orgId = organization.id;
+    const userId = public_user_data.user_id;
+
+    // Add to team_members table
+    await db.team_members.create({
+      data: { orgId, userId, role },
+    });
+
+    // Create workspace record for new member
+    await db.workspaces.create({
+      data: { orgId, userId, createdAt: new Date() },
+    });
+  }
+
+  if (evt.type === "organizationMembership.deleted") {
+    // Extract organization ID and user ID from payload
+    const { organization, public_user_data } = evt.data;
+    const orgId = organization.id;
+    const userId = public_user_data.user_id;
+
+    // Remove from team_members table
+    await db.team_members.delete({
+      where: { orgId, userId },
+    });
+
+    // Remove workspace record
+    await db.workspaces.deleteMany({
+      where: { orgId, userId },
+    });
+  }
+
+  // Return 200 status on success
+  return new Response("OK", { status: 200 });
+}
+```
+
+## Express.js Webhook Handler
+
+> **CRITICAL**: Use `express.raw()` NOT `express.json()` for webhook routes. Signature verification requires the raw body bytes. `express.json()` parses the body and breaks verification.
+
+```typescript
+import express from "express";
+import { Webhook } from "svix";
+
+const app = express();
+
+// WRONG - breaks verification because it parses the body:
+// app.use(express.json())
+
+// CORRECT - use raw body for webhook route only:
+app.post("/webhooks/clerk", express.raw({ type: "application/json" }), async (req, res) => {
+  const webhookSecret = process.env.CLERK_WEBHOOK_SECRET!;
+
+  const wh = new Webhook(webhookSecret);
+  let evt: any;
+  try {
+    // Svix verifies using raw body bytes + svix headers
+    evt = wh.verify(req.body, {
+      "svix-id": req.headers["svix-id"] as string,
+      "svix-timestamp": req.headers["svix-timestamp"] as string,
+      "svix-signature": req.headers["svix-signature"] as string,
+    });
+  } catch (err) {
+    console.error("Webhook verification failed:", err);
+    return res.status(400).json({ error: "Verification failed" });
+  }
+
+  if (evt.type === "user.created") {
+    const { id, email_addresses, first_name, last_name } = evt.data;
+    const email = email_addresses[0]?.email_address;
+    const name = `${first_name ?? ""} ${last_name ?? ""}`.trim();
+    console.log(`New user: ${name} (${email})`);
+  }
+
+  if (evt.type === "user.updated") {
+    const { id, email_addresses } = evt.data;
+    const email = email_addresses[0]?.email_address;
+    console.log(`User updated: ${id}, email: ${email}`);
+  }
+
+  if (evt.type === "user.deleted") {
+    const { id } = evt.data;
+    console.log(`User deleted: ${id}`);
+  }
+
+  // Return 200 status on success
+  return res.status(200).json({ received: true });
+});
+```
+
+## Payload Field Reference
+
+### User events (`user.created`, `user.updated`, `user.deleted`)
+
+```typescript
+const {
+  id, // Clerk user ID
+  email_addresses, // array; [0].email_address is primary email
+  first_name,
+  last_name,
+  image_url,
+  public_metadata,
+} = evt.data;
+```
+
+### Organization events (`organization.created`, `organization.updated`, `organization.deleted`)
+
+```typescript
+const {
+  id, // org ID
+  name, // org name
+  slug,
+} = evt.data;
+```
+
+### Organization Membership events (`organizationMembership.created`, `organizationMembership.updated`, `organizationMembership.deleted`)
+
+```typescript
+const {
+  organization, // { id, name, ... }
+  public_user_data, // { user_id, first_name, last_name, ... }
+  role, // e.g. 'org:admin', 'org:member'
+} = evt.data;
+// Access: organization.id, public_user_data.user_id, role
+```
+
+## Supported Events (Full Catalog)
+
+**User**: `user.created` `user.updated` `user.deleted`
+
+**Session**: `session.created` `session.ended` `session.pending` `session.removed` `session.revoked`
+
+**Organization**: `organization.created` `organization.updated` `organization.deleted`
+
+**Organization Membership**: `organizationMembership.created` `organizationMembership.updated` `organizationMembership.deleted`
+
+**Organization Domain**: `organizationDomain.created` `organizationDomain.updated` `organizationDomain.deleted`
+
+**Organization Invitation**: `organizationInvitation.accepted` `organizationInvitation.created` `organizationInvitation.revoked`
+
+**Communication**: `email.created` `sms.created`
+
+**Invitation**: `invitation.accepted` `invitation.created` `invitation.revoked`
+
+**Waitlist**: `waitlistEntry.created` `waitlistEntry.updated`
+
+**Permission**: `permission.created` `permission.updated` `permission.deleted`
+
+**Role**: `role.created` `role.updated` `role.deleted`
+
+**Subscription**: `subscription.created` `subscription.updated` `subscription.active` `subscription.pastDue`
+
+**Subscription Item**: `subscriptionItem.created` `subscriptionItem.active` `subscriptionItem.updated` `subscriptionItem.canceled` `subscriptionItem.upcoming` `subscriptionItem.ended` `subscriptionItem.abandoned` `subscriptionItem.incomplete` `subscriptionItem.pastDue` `subscriptionItem.freeTrialEnding`
+
+**Payment**: `paymentAttempt.created` `paymentAttempt.updated`
+
+## Webhook Reliability
+
+**Retries**: Svix retries failed webhooks on a set schedule (see [Svix Retry Schedule](https://docs.svix.com/retries)). Return 2xx to succeed, 4xx/5xx to retry. Use the `svix-id` header as an idempotency key to deduplicate retried events.
+
+**Replay**: Failed webhooks can be replayed from Dashboard.
+
+## Common Pitfalls
+
+| Symptom                      | Cause                            | Fix                                                               |
+| ---------------------------- | -------------------------------- | ----------------------------------------------------------------- |
+| Verification fails (Next.js) | Wrong import or usage            | Use `@clerk/nextjs/webhooks`, pass `req` directly                 |
+| Verification fails (Express) | Using `express.json()`           | Use `express.raw({ type: 'application/json' })` for webhook route |
+| Route not found (404)        | Wrong path                       | Use `/api/webhooks` or preserve existing path                     |
+| Not authorized (401)         | Route is protected by middleware | Make route public in `clerkMiddleware()`                          |
+| No data in DB                | Async job pending                | Wait/check logs                                                   |
+| Duplicate entries            | Only handling `user.created`     | Also handle `user.updated`                                        |
+| Timeouts                     | Handler too slow                 | Queue async work, return 200 first                                |
+
+## Testing & Deployment
+
+**Local**: Use ngrok to tunnel `localhost:3000` to internet. Add ngrok URL to Dashboard endpoint.
+
+**Production**: Update webhook endpoint URL to production domain. Copy `CLERK_WEBHOOK_SECRET` to production env vars.
+
+## See Also
+
+- `clerk-setup` - Initial Clerk install
+- `clerk-orgs` - Org membership events
+- `clerk-backend-api` - Sync via direct API calls

--- a/.agents/skills/clerk-webhooks/evals/evals.json
+++ b/.agents/skills/clerk-webhooks/evals/evals.json
@@ -1,0 +1,61 @@
+{
+  "skill_name": "clerk-webhooks",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "every time a user signs up on our app i need to create a row in our users table in postgres (we use prisma). the table has id, email, name, clerkId, createdAt columns. can you set up the webhook handler? we're on next.js app router",
+      "expected_output": "Creates webhook route handler at app/api/webhooks/route.ts, verifies webhook signature, handles user.created event, inserts into Prisma users table",
+      "files": [],
+      "expectations": [
+        "Creates route handler at app/api/webhooks/route.ts or similar path",
+        "Uses POST method handler (not GET)",
+        "Includes webhook signature verification (verifyWebhook or svix verify)",
+        "Handles user.created event type and extracts email, name, id from payload",
+        "Inserts into database using Prisma with the correct column mapping (clerkId = evt.data.id)",
+        "Mentions that webhook route must be excluded from Clerk middleware (public route)"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "i want to send a welcome email via resend when someone creates an account. also want to notify our #new-users slack channel. we already have resend and slack sdks installed",
+      "expected_output": "Webhook handler for user.created that sends welcome email via Resend and posts to Slack",
+      "files": [],
+      "expectations": [
+        "Listens for user.created webhook event",
+        "Extracts user email and name from webhook payload",
+        "Calls Resend API to send welcome email",
+        "Posts notification to Slack channel",
+        "Includes webhook signature verification",
+        "Does NOT skip verification even though it's a notification-only handler"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "we're getting 401 errors on our webhook endpoint. the clerk dashboard shows the webhooks are being sent but our app keeps rejecting them. we're using express not next.js. heres our current code:\n\napp.post('/webhooks/clerk', express.json(), (req, res) => {\n  const evt = req.body;\n  console.log(evt);\n  res.json({ received: true });\n});",
+      "expected_output": "Identifies missing webhook verification, fixes express body parsing (needs raw body), adds proper Svix verification",
+      "files": [],
+      "expectations": [
+        "Identifies that express.json() is wrong - needs raw body for signature verification",
+        "Shows express.raw() or express.text() instead of express.json() for the webhook route",
+        "Adds webhook signature verification using Svix or @clerk/express webhook utilities",
+        "Preserves the existing route path /webhooks/clerk",
+        "Mentions CLERK_WEBHOOK_SECRET environment variable",
+        "Returns 200 status on success (not just res.json)"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "our app has clerk organizations and we need to sync org membership changes to our database. when someone joins or leaves an org we need to update our team_members table. also when an org is created we need to create a workspace record",
+      "expected_output": "Webhook handler for organizationMembership and organization events with database sync",
+      "files": [],
+      "expectations": [
+        "Handles organizationMembership.created event (user joins org)",
+        "Handles organizationMembership.deleted event (user leaves org)",
+        "Handles organization.created event (new org created)",
+        "Extracts organization ID, user ID, and role from webhook payloads",
+        "Includes webhook signature verification",
+        "Shows database operations for both team_members and workspace tables"
+      ]
+    }
+  ]
+}

--- a/.agents/skills/clerk/SKILL.md
+++ b/.agents/skills/clerk/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: clerk
+description: Clerk authentication router. Use when user asks about adding authentication,
+  setting up Clerk, custom sign-in flows, Swift or native iOS auth, native Android
+  auth, Next.js patterns, React patterns, Vue patterns, Nuxt patterns, Astro patterns,
+  TanStack Start patterns, Expo patterns, React Router patterns, Chrome Extension patterns,
+  organizations, syncing users, or testing. Automatically routes to the specific skill
+  based on their task.
+license: MIT
+metadata:
+  version: 2.0.0
+---
+
+# Clerk Skills Router
+
+## Version Detection
+
+Check `package.json` to determine the Clerk SDK version. This determines which patterns to use:
+
+| Package                                | Core 2 (LTS until Jan 2027) | Current  |
+| -------------------------------------- | --------------------------- | -------- |
+| `@clerk/nextjs`                        | v5–v6                       | v7+      |
+| `@clerk/react` or `@clerk/clerk-react` | v5–v6                       | v7+      |
+| `@clerk/expo` or `@clerk/clerk-expo`   | v1–v2                       | v3+      |
+| `@clerk/react-router`                  | v1–v2                       | v3+      |
+| `@clerk/tanstack-react-start`          | < v0.26.0                   | v0.26.0+ |
+
+**Default to current** if the version is unclear or the project is new. Core 2 packages use `@clerk/clerk-react` and `@clerk/clerk-expo` (with `clerk-` prefix); current packages use `@clerk/react` and `@clerk/expo`.
+
+All skills are written for the current SDK. When something differs in Core 2, it's noted inline with `> **Core 2 ONLY (skip if current SDK):**` callouts. The exception is `clerk-custom-ui`, which has separate `core-2/` and `core-3/` directories for custom flow hooks since those APIs are entirely different between versions.
+
+---
+
+## By Task
+
+**Adding Clerk to your project** → Use `clerk-setup`
+
+- Framework detection and quickstart
+- Environment setup, API keys, Keyless flow
+- Migration from other auth providers
+
+**Custom sign-in/sign-up UI** → Use `clerk-custom-ui`
+
+- Custom authentication flows with `useSignIn` / `useSignUp` hooks
+- Appearance and styling (themes, colors, layout)
+- `<Show>` component for conditional rendering
+
+**Advanced Next.js patterns** → Use `clerk-nextjs-patterns`
+
+- Server vs Client auth APIs
+- Middleware strategies
+- Server Actions, caching
+- API route protection
+
+**React patterns** → Use `clerk-react-patterns`
+
+- Hooks (`useAuth`, `useUser`, `useClerk`)
+- Protected routes, auth guards
+- Router integration
+
+**React Router patterns** → Use `clerk-react-router-patterns`
+
+- Loaders & actions with auth
+- Route protection
+- SSR auth
+
+**Vue patterns** → Use `clerk-vue-patterns`
+
+- Composables (`useAuth`, `useUser`, `useClerk`)
+- Vue Router guards
+- Pinia auth store integration
+
+**Nuxt patterns** → Use `clerk-nuxt-patterns`
+
+- Server middleware auth
+- SSR auth with composables
+- Server API routes
+
+**Astro patterns** → Use `clerk-astro-patterns`
+
+- SSR auth pages
+- Island components with React
+- Middleware & API routes
+
+**TanStack Start patterns** → Use `clerk-tanstack-patterns`
+
+- Server functions with auth
+- Route protection via loaders
+- Vinxi server integration
+
+**Expo patterns** → Use `clerk-expo-patterns`
+
+- Secure token storage
+- OAuth deep linking
+- Push notifications with auth
+
+**Chrome Extension patterns** → Use `clerk-chrome-extension-patterns`
+
+- Background scripts auth
+- Popup auth flows
+- Content scripts with sync host
+
+**B2B / Organizations** → Use `clerk-orgs`
+
+- Multi-tenant apps
+- Organization slugs in URLs
+- Roles, permissions, RBAC
+- Member management
+
+**Webhooks** → Use `clerk-webhooks`
+
+- Real-time events
+- Data syncing
+- Notifications & integrations
+
+**E2E Testing** → Use `clerk-testing`
+
+- Playwright/Cypress setup
+- Auth flow testing
+- Test utilities
+
+**Swift / native iOS auth** → Use `clerk-swift`
+
+- Native iOS Swift and SwiftUI projects
+- ClerkKit and ClerkKitUI implementation guidance
+- Source-driven patterns from `clerk-ios`
+
+**Android / native mobile auth** → Use `clerk-android`
+
+- Native Android Kotlin and Jetpack Compose projects
+- `clerk-android-api` and `clerk-android-ui` implementation guidance
+- Source-driven patterns from `clerk-android`
+- Do not use for Expo or React Native projects
+
+**Backend REST API** → Use `clerk-backend-api`
+
+- Browse API tags and endpoints
+- Inspect endpoint schemas
+- Execute API requests with scope enforcement
+
+## Quick Navigation
+
+If you know your task, you can directly access:
+
+- `/clerk-setup` - Framework setup
+- `/clerk-custom-ui` - Custom flows & appearance
+- `/clerk-nextjs-patterns` - Next.js patterns
+- `/clerk-react-patterns` - React patterns
+- `/clerk-react-router-patterns` - React Router patterns
+- `/clerk-vue-patterns` - Vue patterns
+- `/clerk-nuxt-patterns` - Nuxt patterns
+- `/clerk-astro-patterns` - Astro patterns
+- `/clerk-tanstack-patterns` - TanStack Start patterns
+- `/clerk-expo-patterns` - Expo patterns
+- `/clerk-chrome-extension-patterns` - Chrome Extension patterns
+- `/clerk-orgs` - Organizations
+- `/clerk-webhooks` - Webhooks
+- `/clerk-testing` - Testing
+- `/clerk-swift` - Swift/native iOS
+- `/clerk-android` - Native Android
+- `/clerk-backend-api` - Backend REST API
+
+Or describe what you need and I'll recommend the right one.

--- a/.claude/skills/clerk
+++ b/.claude/skills/clerk
@@ -1,0 +1,1 @@
+../../.agents/skills/clerk

--- a/.claude/skills/clerk-backend-api
+++ b/.claude/skills/clerk-backend-api
@@ -1,0 +1,1 @@
+../../.agents/skills/clerk-backend-api

--- a/.claude/skills/clerk-custom-ui
+++ b/.claude/skills/clerk-custom-ui
@@ -1,0 +1,1 @@
+../../.agents/skills/clerk-custom-ui

--- a/.claude/skills/clerk-expo-patterns
+++ b/.claude/skills/clerk-expo-patterns
@@ -1,0 +1,1 @@
+../../.agents/skills/clerk-expo-patterns

--- a/.claude/skills/clerk-webhooks
+++ b/.claude/skills/clerk-webhooks
@@ -1,0 +1,1 @@
+../../.agents/skills/clerk-webhooks

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,6 +1,11 @@
 {
   "version": 1,
   "skills": {
+    "clerk": {
+      "source": "clerk/skills",
+      "sourceType": "github",
+      "computedHash": "6108ab89edb9357a3e5991cca0cdfc5b370a1afc6ab49ce8d3ed2f31239a9e5a"
+    },
     "convex-create-component": {
       "source": "get-convex/agent-skills",
       "sourceType": "github",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -6,6 +6,26 @@
       "sourceType": "github",
       "computedHash": "6108ab89edb9357a3e5991cca0cdfc5b370a1afc6ab49ce8d3ed2f31239a9e5a"
     },
+    "clerk-backend-api": {
+      "source": "clerk/skills",
+      "sourceType": "github",
+      "computedHash": "b550d2d1c5d41d4820268c4faa4a23fa966fe98221c068327b19760bf4937961"
+    },
+    "clerk-custom-ui": {
+      "source": "clerk/skills",
+      "sourceType": "github",
+      "computedHash": "72dcda42d3755a468049e828180b66c25fb2ac66fd99bd1514699404445924c6"
+    },
+    "clerk-expo-patterns": {
+      "source": "clerk/skills",
+      "sourceType": "github",
+      "computedHash": "ef550f902d44c3292db0578409aed0729075ea559ed77bb98b294c8c7114599a"
+    },
+    "clerk-webhooks": {
+      "source": "clerk/skills",
+      "sourceType": "github",
+      "computedHash": "1e64996a3993027a25dcf1032a4ed13f0aa8607801fb2d1d27d653666aa9b929"
+    },
     "convex-create-component": {
       "source": "get-convex/agent-skills",
       "sourceType": "github",

--- a/src/app/(auth)/forgot-password.tsx
+++ b/src/app/(auth)/forgot-password.tsx
@@ -10,7 +10,6 @@ import { SafeAreaView } from "react-native-safe-area-context";
 
 import { BackButton } from "@/components/ui/BackButton";
 import { VerifyCodeScreen } from "@/components/ui/VerifyCodeScreen";
-import { useCountdown } from "@/hooks/useCountdown";
 
 type Step = "email" | "code" | "new-password";
 
@@ -19,7 +18,6 @@ export default function Page() {
   const router = useRouter();
 
   const [step, setStep] = useState<Step>("email");
-  const [resendCountdown, setResendCountdown] = useCountdown();
 
   const emailForm = useForm({
     defaultValues: {
@@ -45,7 +43,6 @@ export default function Page() {
       }
 
       setStep("code");
-      setResendCountdown(30);
     },
   });
 
@@ -123,11 +120,7 @@ export default function Page() {
                 isLoading={!!isSubmitting}
                 isDisabled={!canSubmit || !!isSubmitting || fetchStatus === "fetching"}
                 error={clerkErrors.fields.code?.message}
-                onResend={async () => {
-                  await signIn.resetPasswordEmailCode.sendCode();
-                  setResendCountdown(30);
-                }}
-                resendCountdown={resendCountdown}
+                onResend={() => signIn.resetPasswordEmailCode.sendCode()}
               />
             )}
           </codeForm.Subscribe>

--- a/src/app/(auth)/forgot-password.tsx
+++ b/src/app/(auth)/forgot-password.tsx
@@ -1,9 +1,327 @@
+import { useSignIn } from "@clerk/expo";
+import { useForm } from "@tanstack/react-form";
+import { Image } from "expo-image";
+import { type Href, Link, useRouter } from "expo-router";
+import { Button, Card, FieldError, Input, Label, LinkButton, TextField } from "heroui-native";
+import { useEffect, useState } from "react";
 import { Text, View } from "react-native";
+import { ScrollView } from "react-native-gesture-handler";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+import { VerifyCodeScreen } from "@/components/ui/VerifyCodeScreen";
+
+type Step = "email" | "code" | "new-password";
 
 export default function Page() {
+  const { signIn, errors: clerkErrors, fetchStatus } = useSignIn();
+  const router = useRouter();
+
+  const [step, setStep] = useState<Step>("email");
+  const [resendCountdown, setResendCountdown] = useState(0);
+
+  useEffect(() => {
+    if (resendCountdown === 0) return;
+    const timer = setTimeout(() => setResendCountdown((c) => c - 1), 1000);
+
+    return () => clearTimeout(timer);
+  }, [resendCountdown]);
+
+  const emailForm = useForm({
+    defaultValues: {
+      emailAddress: "",
+    },
+    onSubmit: async ({ value }) => {
+      const { error: createError } = await signIn.create({
+        identifier: value.emailAddress,
+      });
+
+      if (createError) {
+        console.error(JSON.stringify(createError, null, 2));
+
+        return;
+      }
+
+      const { error: sendError } = await signIn.resetPasswordEmailCode.sendCode();
+
+      if (sendError) {
+        console.error(JSON.stringify(sendError, null, 2));
+
+        return;
+      }
+
+      setStep("code");
+      setResendCountdown(30);
+    },
+  });
+
+  const codeForm = useForm({
+    defaultValues: {
+      code: "",
+    },
+    onSubmit: async ({ value }) => {
+      const { error } = await signIn.resetPasswordEmailCode.verifyCode({
+        code: value.code,
+      });
+
+      if (error) {
+        console.error(JSON.stringify(error, null, 2));
+
+        return;
+      }
+
+      setStep("new-password");
+    },
+  });
+
+  const passwordForm = useForm({
+    defaultValues: {
+      password: "",
+      confirmPassword: "",
+    },
+    onSubmit: async ({ value }) => {
+      const { error } = await signIn.resetPasswordEmailCode.submitPassword({
+        password: value.password,
+      });
+
+      if (error) {
+        console.error(JSON.stringify(error, null, 2));
+
+        return;
+      }
+
+      if (signIn.status === "complete") {
+        await signIn.finalize({
+          navigate: ({ session, decorateUrl }) => {
+            if (session?.currentTask) {
+              console.log(session?.currentTask);
+
+              return;
+            }
+
+            const url = decorateUrl("/");
+
+            if (url.startsWith("http")) {
+              window.location.href = url;
+            } else {
+              router.push(url as Href);
+            }
+          },
+        });
+      }
+    },
+  });
+
+  if (step === "code") {
+    return (
+      <codeForm.Field name="code">
+        {(field) => (
+          <codeForm.Subscribe selector={(state) => [state.canSubmit, state.isSubmitting]}>
+            {([canSubmit, isSubmitting]) => (
+              <VerifyCodeScreen
+                title="Check your email"
+                subtitle="Enter the 6-digit code sent to your email"
+                value={field.state.value}
+                onChange={field.handleChange}
+                onBlur={field.handleBlur}
+                onSubmit={() => codeForm.handleSubmit()}
+                onBack={() => setStep("email")}
+                isLoading={!!isSubmitting}
+                isDisabled={!canSubmit || !!isSubmitting || fetchStatus === "fetching"}
+                error={clerkErrors.fields.code?.message}
+                onResend={async () => {
+                  await signIn.resetPasswordEmailCode.sendCode();
+                  setResendCountdown(30);
+                }}
+                resendCountdown={resendCountdown}
+              />
+            )}
+          </codeForm.Subscribe>
+        )}
+      </codeForm.Field>
+    );
+  }
+
+  if (step === "new-password") {
+    return (
+      <View style={{ flex: 1 }}>
+        <SafeAreaView className="flex-1">
+          <View className="self-start">
+            <Button variant="ghost" onPress={() => setStep("code")} className="-ml-2">
+              ← Back
+            </Button>
+          </View>
+          <ScrollView contentContainerStyle={{ flexGrow: 1 }}>
+            <View className="flex-1 gap-6">
+              <View className="items-center gap-4 mx-4 my-8">
+                <Image
+                  source={require("@/assets/icons/splash-icon-dark.png")}
+                  style={{ width: 96, height: 96 }}
+                />
+                <Text className="text-3xl font-bold">Set new password</Text>
+                <Text className="text-muted">Choose a strong password for your account</Text>
+              </View>
+
+              <Card className="gap-4 mx-4">
+                <Card.Body className="gap-4">
+                  <passwordForm.Field name="password">
+                    {(field) => (
+                      <TextField isRequired isInvalid={!!clerkErrors.fields.password}>
+                        <Label>New password</Label>
+                        <Input
+                          autoCapitalize="none"
+                          autoCorrect={false}
+                          autoComplete="new-password"
+                          secureTextEntry
+                          value={field.state.value}
+                          onChangeText={field.handleChange}
+                          onBlur={field.handleBlur}
+                          returnKeyType="next"
+                        />
+                        {clerkErrors.fields.password && (
+                          <FieldError>{clerkErrors.fields.password.message}</FieldError>
+                        )}
+                      </TextField>
+                    )}
+                  </passwordForm.Field>
+
+                  <passwordForm.Field name="confirmPassword">
+                    {(field) => (
+                      <passwordForm.Subscribe selector={(state) => state.values.password}>
+                        {(password) => {
+                          const mismatch = !!field.state.value && field.state.value !== password;
+                          return (
+                            <TextField isRequired isInvalid={mismatch}>
+                              <Label>Confirm password</Label>
+                              <Input
+                                autoCapitalize="none"
+                                autoCorrect={false}
+                                autoComplete="new-password"
+                                secureTextEntry
+                                value={field.state.value}
+                                onChangeText={field.handleChange}
+                                onBlur={field.handleBlur}
+                                returnKeyType="send"
+                              />
+                              {mismatch && <FieldError>Passwords do not match</FieldError>}
+                            </TextField>
+                          );
+                        }}
+                      </passwordForm.Subscribe>
+                    )}
+                  </passwordForm.Field>
+                </Card.Body>
+
+                <Card.Footer>
+                  <passwordForm.Subscribe selector={(state) => [state.isSubmitting, state.values]}>
+                    {([isSubmitting, values]) => {
+                      const { password, confirmPassword } = values as {
+                        password: string;
+                        confirmPassword: string;
+                      };
+                      return (
+                        <Button
+                          variant="primary"
+                          onPress={() => passwordForm.handleSubmit()}
+                          isDisabled={
+                            !password ||
+                            !confirmPassword ||
+                            password !== confirmPassword ||
+                            !!isSubmitting ||
+                            fetchStatus === "fetching"
+                          }
+                          className="w-full"
+                        >
+                          {isSubmitting ? "Saving..." : "Reset password"}
+                        </Button>
+                      );
+                    }}
+                  </passwordForm.Subscribe>
+                </Card.Footer>
+              </Card>
+            </View>
+          </ScrollView>
+        </SafeAreaView>
+      </View>
+    );
+  }
+
   return (
-    <View>
-      <Text>Forgot Password</Text>
+    <View style={{ flex: 1 }}>
+      <SafeAreaView className="flex-1">
+        <View className="self-start">
+          <Link href="/sign-in" asChild>
+            <Button variant="ghost" className="-ml-2">
+              ← Back
+            </Button>
+          </Link>
+        </View>
+        <ScrollView contentContainerStyle={{ flexGrow: 1 }}>
+          <View className="flex-1 gap-6">
+            <View className="items-center gap-4 mx-4 my-8">
+              <Image
+                source={require("@/assets/icons/splash-icon-dark.png")}
+                style={{ width: 96, height: 96 }}
+              />
+              <Text className="text-3xl font-bold">Forgot password?</Text>
+              <Text className="text-muted text-center">
+                Enter your email and we'll send you a reset code
+              </Text>
+            </View>
+
+            <Card className="gap-4 mx-4">
+              <Card.Body>
+                <emailForm.Field name="emailAddress">
+                  {(field) => (
+                    <TextField isRequired isInvalid={!!clerkErrors.fields.identifier}>
+                      <Label>Email address</Label>
+                      <Input
+                        autoCapitalize="none"
+                        autoComplete="email"
+                        autoCorrect={false}
+                        value={field.state.value}
+                        onChangeText={field.handleChange}
+                        onBlur={field.handleBlur}
+                        keyboardType="email-address"
+                        returnKeyType="send"
+                      />
+                      {clerkErrors.fields.identifier && (
+                        <FieldError>{clerkErrors.fields.identifier.message}</FieldError>
+                      )}
+                    </TextField>
+                  )}
+                </emailForm.Field>
+              </Card.Body>
+
+              <Card.Footer>
+                <emailForm.Subscribe selector={(state) => [state.isSubmitting, state.values]}>
+                  {([isSubmitting, values]) => {
+                    const { emailAddress } = values as { emailAddress: string };
+                    return (
+                      <Button
+                        variant="primary"
+                        onPress={() => emailForm.handleSubmit()}
+                        isDisabled={!emailAddress || !!isSubmitting || fetchStatus === "fetching"}
+                        className="w-full"
+                      >
+                        {isSubmitting ? "Sending..." : "Send reset code"}
+                      </Button>
+                    );
+                  }}
+                </emailForm.Subscribe>
+              </Card.Footer>
+            </Card>
+
+            <View className="flex-row gap-1 justify-center">
+              <Text className="text-sm text-muted">Remember your password?</Text>
+              <Link href="../" asChild>
+                <LinkButton size="sm">
+                  <LinkButton.Label className="text-accent">Sign in</LinkButton.Label>
+                </LinkButton>
+              </Link>
+            </View>
+          </View>
+        </ScrollView>
+      </SafeAreaView>
     </View>
   );
 }

--- a/src/app/(auth)/forgot-password.tsx
+++ b/src/app/(auth)/forgot-password.tsx
@@ -102,15 +102,16 @@ export default function Page() {
 
         if (totpFactor) {
           setMfaStrategy("totp");
+          setStep("mfa");
         } else if (phoneFactor) {
           await signIn.mfa.sendPhoneCode();
           setMfaStrategy("phone_code");
+          setStep("mfa");
         } else if (emailFactor) {
           await signIn.mfa.sendEmailCode();
           setMfaStrategy("email_code");
+          setStep("mfa");
         }
-
-        setStep("mfa");
       } else {
         console.error(
           `[forgot-password] Unexpected sign-in status after password reset: "${signIn.status}".`,
@@ -124,12 +125,22 @@ export default function Page() {
       code: "",
     },
     onSubmit: async ({ value }) => {
+      let verifyError;
+
       if (mfaStrategy === "totp") {
-        await signIn.mfa.verifyTOTP({ code: value.code });
+        const { error } = await signIn.mfa.verifyTOTP({ code: value.code });
+        verifyError = error;
       } else if (mfaStrategy === "phone_code") {
-        await signIn.mfa.verifyPhoneCode({ code: value.code });
+        const { error } = await signIn.mfa.verifyPhoneCode({ code: value.code });
+        verifyError = error;
       } else {
-        await signIn.mfa.verifyEmailCode({ code: value.code });
+        const { error } = await signIn.mfa.verifyEmailCode({ code: value.code });
+        verifyError = error;
+      }
+
+      if (verifyError) {
+        console.error(JSON.stringify(verifyError, null, 2));
+        return;
       }
 
       if (signIn.status === "complete") {

--- a/src/app/(auth)/forgot-password.tsx
+++ b/src/app/(auth)/forgot-password.tsx
@@ -11,13 +11,14 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { BackButton } from "@/components/ui/BackButton";
 import { VerifyCodeScreen } from "@/components/ui/VerifyCodeScreen";
 
-type Step = "email" | "code" | "new-password";
+type Step = "email" | "code" | "new-password" | "mfa";
 
 export default function Page() {
   const { signIn, errors: clerkErrors, fetchStatus } = useSignIn();
   const router = useRouter();
 
   const [step, setStep] = useState<Step>("email");
+  const [mfaStrategy, setMfaStrategy] = useState<"totp" | "phone_code" | "email_code" | null>(null);
 
   const emailForm = useForm({
     defaultValues: {
@@ -90,18 +91,107 @@ export default function Page() {
               return;
             }
 
-            const url = decorateUrl("/");
-
-            if (url.startsWith("http")) {
-              window.location.href = url;
-            } else {
-              router.push(url as Href);
-            }
+            router.replace(decorateUrl("/") as Href);
           },
         });
+      } else if (signIn.status === "needs_second_factor") {
+        // MFA required after password reset (user has MFA enabled)
+        const totpFactor = signIn.supportedSecondFactors?.find((f) => f.strategy === "totp");
+        const phoneFactor = signIn.supportedSecondFactors?.find((f) => f.strategy === "phone_code");
+        const emailFactor = signIn.supportedSecondFactors?.find((f) => f.strategy === "email_code");
+
+        if (totpFactor) {
+          setMfaStrategy("totp");
+        } else if (phoneFactor) {
+          await signIn.mfa.sendPhoneCode();
+          setMfaStrategy("phone_code");
+        } else if (emailFactor) {
+          await signIn.mfa.sendEmailCode();
+          setMfaStrategy("email_code");
+        }
+
+        setStep("mfa");
+      } else {
+        console.error(
+          `[forgot-password] Unexpected sign-in status after password reset: "${signIn.status}".`,
+        );
       }
     },
   });
+
+  const mfaForm = useForm({
+    defaultValues: {
+      code: "",
+    },
+    onSubmit: async ({ value }) => {
+      if (mfaStrategy === "totp") {
+        await signIn.mfa.verifyTOTP({ code: value.code });
+      } else if (mfaStrategy === "phone_code") {
+        await signIn.mfa.verifyPhoneCode({ code: value.code });
+      } else {
+        await signIn.mfa.verifyEmailCode({ code: value.code });
+      }
+
+      if (signIn.status === "complete") {
+        await signIn.finalize({
+          navigate: ({ session, decorateUrl }) => {
+            if (session?.currentTask) {
+              console.log(session?.currentTask);
+
+              return;
+            }
+
+            router.replace(decorateUrl("/") as Href);
+          },
+        });
+      } else {
+        console.error("Sign-in attempt not complete after MFA:", signIn);
+      }
+    },
+  });
+
+  if (step === "mfa" && mfaStrategy) {
+    const subtitleByStrategy = {
+      totp: "Enter the 6-digit code from your authenticator app",
+      phone_code: "Enter the 6-digit code sent to your phone",
+      email_code: "Enter the 6-digit code sent to your email",
+    };
+
+    const handleResend =
+      mfaStrategy !== "totp"
+        ? async () => {
+            if (mfaStrategy === "phone_code") {
+              await signIn.mfa.sendPhoneCode();
+            } else {
+              await signIn.mfa.sendEmailCode();
+            }
+          }
+        : undefined;
+
+    return (
+      <mfaForm.Field name="code">
+        {(field) => (
+          <mfaForm.Subscribe selector={(state) => [state.canSubmit, state.isSubmitting]}>
+            {([canSubmit, isSubmitting]) => (
+              <VerifyCodeScreen
+                title="Two-factor authentication"
+                subtitle={subtitleByStrategy[mfaStrategy]}
+                value={field.state.value}
+                onChange={field.handleChange}
+                onBlur={field.handleBlur}
+                onSubmit={() => mfaForm.handleSubmit()}
+                onBack={() => setStep("new-password")}
+                isLoading={!!isSubmitting}
+                isDisabled={!canSubmit || !!isSubmitting || fetchStatus === "fetching"}
+                error={clerkErrors.fields.code?.message ?? clerkErrors.global?.[0]?.message}
+                onResend={handleResend}
+              />
+            )}
+          </mfaForm.Subscribe>
+        )}
+      </mfaForm.Field>
+    );
+  }
 
   if (step === "code") {
     return (
@@ -119,7 +209,7 @@ export default function Page() {
                 onBack={() => setStep("email")}
                 isLoading={!!isSubmitting}
                 isDisabled={!canSubmit || !!isSubmitting || fetchStatus === "fetching"}
-                error={clerkErrors.fields.code?.message}
+                error={clerkErrors.fields.code?.message ?? clerkErrors.global?.[0]?.message}
                 onResend={() => signIn.resetPasswordEmailCode.sendCode()}
               />
             )}
@@ -222,6 +312,12 @@ export default function Page() {
                   </passwordForm.Subscribe>
                 </Card.Footer>
               </Card>
+
+              {clerkErrors.global?.[0] && (
+                <Text className="text-danger text-sm text-center mx-4">
+                  {clerkErrors.global[0].message}
+                </Text>
+              )}
             </View>
           </ScrollView>
         </SafeAreaView>
@@ -288,6 +384,12 @@ export default function Page() {
                 </emailForm.Subscribe>
               </Card.Footer>
             </Card>
+
+            {clerkErrors.global?.[0] && (
+              <Text className="text-danger text-sm text-center mx-4">
+                {clerkErrors.global[0].message}
+              </Text>
+            )}
 
             <View className="flex-row gap-1 justify-center">
               <Text className="text-sm text-muted">Remember your password?</Text>

--- a/src/app/(auth)/forgot-password.tsx
+++ b/src/app/(auth)/forgot-password.tsx
@@ -3,12 +3,14 @@ import { useForm } from "@tanstack/react-form";
 import { Image } from "expo-image";
 import { type Href, Link, useRouter } from "expo-router";
 import { Button, Card, FieldError, Input, Label, LinkButton, TextField } from "heroui-native";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Text, View } from "react-native";
 import { ScrollView } from "react-native-gesture-handler";
 import { SafeAreaView } from "react-native-safe-area-context";
 
+import { BackButton } from "@/components/ui/BackButton";
 import { VerifyCodeScreen } from "@/components/ui/VerifyCodeScreen";
+import { useCountdown } from "@/hooks/useCountdown";
 
 type Step = "email" | "code" | "new-password";
 
@@ -17,14 +19,7 @@ export default function Page() {
   const router = useRouter();
 
   const [step, setStep] = useState<Step>("email");
-  const [resendCountdown, setResendCountdown] = useState(0);
-
-  useEffect(() => {
-    if (resendCountdown === 0) return;
-    const timer = setTimeout(() => setResendCountdown((c) => c - 1), 1000);
-
-    return () => clearTimeout(timer);
-  }, [resendCountdown]);
+  const [resendCountdown, setResendCountdown] = useCountdown();
 
   const emailForm = useForm({
     defaultValues: {
@@ -145,11 +140,7 @@ export default function Page() {
     return (
       <View style={{ flex: 1 }}>
         <SafeAreaView className="flex-1">
-          <View className="self-start">
-            <Button variant="ghost" onPress={() => setStep("code")} className="-ml-2">
-              ← Back
-            </Button>
-          </View>
+          <BackButton onPress={() => setStep("code")} />
           <ScrollView contentContainerStyle={{ flexGrow: 1 }}>
             <View className="flex-1 gap-6">
               <View className="items-center gap-4 mx-4 my-8">
@@ -248,13 +239,7 @@ export default function Page() {
   return (
     <View style={{ flex: 1 }}>
       <SafeAreaView className="flex-1">
-        <View className="self-start">
-          <Link href="/sign-in" asChild>
-            <Button variant="ghost" className="-ml-2">
-              ← Back
-            </Button>
-          </Link>
-        </View>
+        <BackButton href="/sign-in" />
         <ScrollView contentContainerStyle={{ flexGrow: 1 }}>
           <View className="flex-1 gap-6">
             <View className="items-center gap-4 mx-4 my-8">

--- a/src/app/(auth)/sign-in.tsx
+++ b/src/app/(auth)/sign-in.tsx
@@ -9,13 +9,11 @@ import { ScrollView } from "react-native-gesture-handler";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import { VerifyCodeScreen } from "@/components/ui/VerifyCodeScreen";
-import { useCountdown } from "@/hooks/useCountdown";
 
 export default function Page() {
   const { signIn, errors: clerkErrors, fetchStatus } = useSignIn();
   const router = useRouter();
 
-  const [resendCountdown, setResendCountdown] = useCountdown(30);
   const [secondFactorStrategy, setSecondFactorStrategy] = useState<
     "totp" | "email_code" | "phone_code" | null
   >(null);
@@ -63,11 +61,9 @@ export default function Page() {
         } else if (phoneCodeFactor) {
           await signIn.mfa.sendPhoneCode();
           setSecondFactorStrategy("phone_code");
-          setResendCountdown(30);
         } else if (emailCodeFactor) {
           await signIn.mfa.sendEmailCode();
           setSecondFactorStrategy("email_code");
-          setResendCountdown(30);
         }
       } else if (signIn.status === "needs_client_trust") {
         // For other second factor strategies,
@@ -78,7 +74,6 @@ export default function Page() {
 
         if (emailCodeFactor) {
           await signIn.mfa.sendEmailCode();
-          setResendCountdown(30);
         }
       } else {
         console.error("Sign-in attempt not complete:", signIn);
@@ -153,7 +148,6 @@ export default function Page() {
             } else {
               await signIn.mfa.sendEmailCode();
             }
-            setResendCountdown(30);
           }
         : undefined;
 
@@ -174,7 +168,6 @@ export default function Page() {
                 isDisabled={!canSubmit || !!isSubmitting || fetchStatus === "fetching"}
                 error={clerkErrors.fields.code?.message}
                 onResend={handleResendSecondFactor}
-                resendCountdown={resendCountdown}
               />
             )}
           </verifyForm.Subscribe>
@@ -200,11 +193,7 @@ export default function Page() {
                 isLoading={!!isSubmitting}
                 isDisabled={!canSubmit || !!isSubmitting || fetchStatus === "fetching"}
                 error={clerkErrors.fields.code?.message}
-                onResend={async () => {
-                  await signIn.mfa.sendEmailCode();
-                  setResendCountdown(30);
-                }}
-                resendCountdown={resendCountdown}
+                onResend={() => signIn.mfa.sendEmailCode()}
               />
             )}
           </verifyForm.Subscribe>

--- a/src/app/(auth)/sign-in.tsx
+++ b/src/app/(auth)/sign-in.tsx
@@ -26,7 +26,7 @@ export default function Page() {
     },
     onSubmit: async ({ value }) => {
       const { error } = await signIn.password({
-        emailAddress: value.emailAddress,
+        identifier: value.emailAddress,
         password: value.password,
       });
 
@@ -68,7 +68,7 @@ export default function Page() {
       } else if (signIn.status === "needs_client_trust") {
         // For other second factor strategies,
         // see https://clerk.com/docs/guides/development/custom-flows/authentication/client-trust
-        const emailCodeFactor = signIn.supportedSecondFactors.find(
+        const emailCodeFactor = signIn.supportedSecondFactors?.find(
           (factor) => factor.strategy === "email_code",
         );
 
@@ -120,13 +120,7 @@ export default function Page() {
           return;
         }
 
-        const url = decorateUrl("/");
-
-        if (url.startsWith("http")) {
-          window.location.href = url;
-        } else {
-          router.push(url as Href);
-        }
+        router.replace(decorateUrl("/") as Href);
       },
     });
   }
@@ -166,7 +160,7 @@ export default function Page() {
                 onBack={() => signIn.reset()}
                 isLoading={!!isSubmitting}
                 isDisabled={!canSubmit || !!isSubmitting || fetchStatus === "fetching"}
-                error={clerkErrors.fields.code?.message}
+                error={clerkErrors.fields.code?.message ?? clerkErrors.global?.[0]?.message}
                 onResend={handleResendSecondFactor}
               />
             )}
@@ -192,7 +186,7 @@ export default function Page() {
                 onBack={() => signIn.reset()}
                 isLoading={!!isSubmitting}
                 isDisabled={!canSubmit || !!isSubmitting || fetchStatus === "fetching"}
-                error={clerkErrors.fields.code?.message}
+                error={clerkErrors.fields.code?.message ?? clerkErrors.global?.[0]?.message}
                 onResend={() => signIn.mfa.sendEmailCode()}
               />
             )}
@@ -294,6 +288,12 @@ export default function Page() {
                 </signInForm.Subscribe>
               </Card.Footer>
             </Card>
+
+            {clerkErrors.global?.[0] && (
+              <Text className="text-danger text-sm text-center mx-4">
+                {clerkErrors.global[0].message}
+              </Text>
+            )}
 
             <View className="flex-row gap-1 justify-center">
               <Text className="text-sm text-muted">Don't have an account?</Text>

--- a/src/app/(auth)/sign-in.tsx
+++ b/src/app/(auth)/sign-in.tsx
@@ -3,28 +3,23 @@ import { useForm } from "@tanstack/react-form";
 import { Image } from "expo-image";
 import { type Href, Link, useRouter } from "expo-router";
 import { Button, Card, FieldError, Input, Label, LinkButton, TextField } from "heroui-native";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Text, View } from "react-native";
 import { ScrollView } from "react-native-gesture-handler";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import { VerifyCodeScreen } from "@/components/ui/VerifyCodeScreen";
+import { useCountdown } from "@/hooks/useCountdown";
 
 export default function Page() {
   const { signIn, errors: clerkErrors, fetchStatus } = useSignIn();
   const router = useRouter();
 
-  const [resendCountdown, setResendCountdown] = useState(30);
+  const [resendCountdown, setResendCountdown] = useCountdown(30);
   const [secondFactorStrategy, setSecondFactorStrategy] = useState<
     "totp" | "email_code" | "phone_code" | null
   >(null);
   const [isNavigating, setIsNavigating] = useState(false);
-
-  useEffect(() => {
-    if (resendCountdown === 0) return;
-    const timer = setTimeout(() => setResendCountdown((c) => c - 1), 1000);
-    return () => clearTimeout(timer);
-  }, [resendCountdown]);
 
   const signInForm = useForm({
     defaultValues: {

--- a/src/app/(auth)/sign-up.tsx
+++ b/src/app/(auth)/sign-up.tsx
@@ -9,7 +9,6 @@ import { ScrollView } from "react-native-gesture-handler";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import { VerifyCodeScreen } from "@/components/ui/VerifyCodeScreen";
-import { useCountdown } from "@/hooks/useCountdown";
 
 export default function Page() {
   const { signUp, errors: clerkErrors, fetchStatus } = useSignUp();
@@ -17,7 +16,6 @@ export default function Page() {
   const router = useRouter();
 
   const [pendingVerification, setPendingVerification] = useState(false);
-  const [resendCountdown, setResendCountdown] = useCountdown();
 
   useEffect(() => {
     return () => {
@@ -48,7 +46,6 @@ export default function Page() {
 
       await signUp.verifications.sendEmailCode();
       setPendingVerification(true);
-      setResendCountdown(30);
     },
   });
 
@@ -104,11 +101,7 @@ export default function Page() {
                 isLoading={!!isSubmitting}
                 isDisabled={!canSubmit || !!isSubmitting || fetchStatus === "fetching"}
                 error={clerkErrors.fields.code?.message}
-                onResend={async () => {
-                  await signUp.verifications.sendEmailCode();
-                  setResendCountdown(30);
-                }}
-                resendCountdown={resendCountdown}
+                onResend={() => signUp.verifications.sendEmailCode()}
               />
             )}
           </verifyForm.Subscribe>

--- a/src/app/(auth)/sign-up.tsx
+++ b/src/app/(auth)/sign-up.tsx
@@ -9,6 +9,7 @@ import { ScrollView } from "react-native-gesture-handler";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import { VerifyCodeScreen } from "@/components/ui/VerifyCodeScreen";
+import { useCountdown } from "@/hooks/useCountdown";
 
 export default function Page() {
   const { signUp, errors: clerkErrors, fetchStatus } = useSignUp();
@@ -16,21 +17,13 @@ export default function Page() {
   const router = useRouter();
 
   const [pendingVerification, setPendingVerification] = useState(false);
-  const [resendCountdown, setResendCountdown] = useState(0);
+  const [resendCountdown, setResendCountdown] = useCountdown();
 
   useEffect(() => {
     return () => {
       signUp.reset();
     };
   }, []);
-
-  useEffect(() => {
-    if (resendCountdown === 0) return;
-
-    const timer = setTimeout(() => setResendCountdown((c) => c - 1), 1000);
-
-    return () => clearTimeout(timer);
-  }, [resendCountdown]);
 
   const signUpForm = useForm({
     defaultValues: {

--- a/src/app/(auth)/sign-up.tsx
+++ b/src/app/(auth)/sign-up.tsx
@@ -44,7 +44,13 @@ export default function Page() {
         return;
       }
 
-      await signUp.verifications.sendEmailCode();
+      const { error: sendError } = await signUp.verifications.sendEmailCode();
+
+      if (sendError) {
+        console.error(JSON.stringify(sendError, null, 2));
+        return;
+      }
+
       setPendingVerification(true);
     },
   });
@@ -65,13 +71,7 @@ export default function Page() {
               return;
             }
 
-            const url = decorateUrl("/");
-
-            if (url.startsWith("http")) {
-              window.location.href = url;
-            } else {
-              router.push(url as Href);
-            }
+            router.replace(decorateUrl("/") as Href);
           },
         });
       } else {
@@ -100,7 +100,7 @@ export default function Page() {
                 onBack={() => setPendingVerification(false)}
                 isLoading={!!isSubmitting}
                 isDisabled={!canSubmit || !!isSubmitting || fetchStatus === "fetching"}
-                error={clerkErrors.fields.code?.message}
+                error={clerkErrors.fields.code?.message ?? clerkErrors.global?.[0]?.message}
                 onResend={() => signUp.verifications.sendEmailCode()}
               />
             )}
@@ -245,6 +245,12 @@ export default function Page() {
                 </signUpForm.Subscribe>
               </Card.Footer>
             </Card>
+
+            {clerkErrors.global?.[0] && (
+              <Text className="text-danger text-sm text-center mx-4">
+                {clerkErrors.global[0].message}
+              </Text>
+            )}
 
             <View className="flex-row gap-1 justify-center">
               <Text className="text-sm text-muted">Already have an account?</Text>

--- a/src/components/ui/BackButton.tsx
+++ b/src/components/ui/BackButton.tsx
@@ -1,0 +1,25 @@
+import { type Href, Link } from "expo-router";
+import { Button } from "heroui-native";
+import { View } from "react-native";
+
+type Props = { onPress: () => void; href?: never } | { href: Href; onPress?: never };
+
+export function BackButton({ onPress, href }: Props) {
+  const button = (
+    <Button variant="ghost" onPress={onPress} className="-ml-2">
+      ← Back
+    </Button>
+  );
+
+  return (
+    <View className="self-start">
+      {href ? (
+        <Link href={href} asChild>
+          {button}
+        </Link>
+      ) : (
+        button
+      )}
+    </View>
+  );
+}

--- a/src/components/ui/VerifyCodeScreen.stories.tsx
+++ b/src/components/ui/VerifyCodeScreen.stories.tsx
@@ -25,16 +25,6 @@ export const ClientTrust: Story = {
     title: "Verify your account",
     subtitle: "Enter the 6-digit code sent to your email",
     onResend: () => {},
-    resendCountdown: 0,
-  },
-};
-
-export const ClientTrustResendCountdown: Story = {
-  args: {
-    title: "Verify your account",
-    subtitle: "Enter the 6-digit code sent to your email",
-    onResend: () => {},
-    resendCountdown: 24,
   },
 };
 
@@ -51,7 +41,6 @@ export const MfaEmailCode: Story = {
     title: "Two-factor authentication",
     subtitle: "Enter the 6-digit code sent to your email",
     onResend: () => {},
-    resendCountdown: 0,
   },
 };
 
@@ -60,7 +49,6 @@ export const MfaPhoneCode: Story = {
     title: "Two-factor authentication",
     subtitle: "Enter the 6-digit code sent to your phone",
     onResend: () => {},
-    resendCountdown: 0,
   },
 };
 

--- a/src/components/ui/VerifyCodeScreen.tsx
+++ b/src/components/ui/VerifyCodeScreen.tsx
@@ -35,7 +35,7 @@ export function VerifyCodeScreen({
   error,
   onResend,
 }: Props) {
-  const [countdown, setCountdown] = useCountdown(onResend ? 30 : 0);
+  const [countdown, startCountdown] = useCountdown(onResend ? 30 : 0);
   return (
     <View style={{ flex: 1 }}>
       <SafeAreaView className="flex-1">
@@ -95,7 +95,7 @@ export function VerifyCodeScreen({
                   onPress={async () => {
                     try {
                       await onResend();
-                      setCountdown(30);
+                      startCountdown(30);
                     } catch (error) {
                       console.error("[VerifyCodeScreen] Resend failed:", error);
                     }

--- a/src/components/ui/VerifyCodeScreen.tsx
+++ b/src/components/ui/VerifyCodeScreen.tsx
@@ -3,6 +3,8 @@ import { Text, View } from "react-native";
 import { ScrollView } from "react-native-gesture-handler";
 import { SafeAreaView } from "react-native-safe-area-context";
 
+import { BackButton } from "./BackButton";
+
 type Props = {
   title: string;
   subtitle: string;
@@ -36,11 +38,7 @@ export function VerifyCodeScreen({
   return (
     <View style={{ flex: 1 }}>
       <SafeAreaView className="flex-1">
-        <View className="self-start">
-          <Button variant="ghost" onPress={onBack} className="-ml-2">
-            ← Back
-          </Button>
-        </View>
+        <BackButton onPress={onBack} />
         <ScrollView contentContainerStyle={{ flexGrow: 1 }}>
           <View className="flex-1 gap-6 p-5">
             <View className="items-center gap-4 mx-4 mb-2">

--- a/src/components/ui/VerifyCodeScreen.tsx
+++ b/src/components/ui/VerifyCodeScreen.tsx
@@ -3,6 +3,8 @@ import { Text, View } from "react-native";
 import { ScrollView } from "react-native-gesture-handler";
 import { SafeAreaView } from "react-native-safe-area-context";
 
+import { useCountdown } from "@/hooks/useCountdown";
+
 import { BackButton } from "./BackButton";
 
 type Props = {
@@ -17,8 +19,7 @@ type Props = {
   isDisabled: boolean;
   error?: string | null;
   /** Omit for strategies that don't send a code (e.g. TOTP) */
-  onResend?: () => void;
-  resendCountdown?: number;
+  onResend?: () => unknown;
 };
 
 export function VerifyCodeScreen({
@@ -33,8 +34,8 @@ export function VerifyCodeScreen({
   isDisabled,
   error,
   onResend,
-  resendCountdown = 0,
 }: Props) {
+  const [countdown, setCountdown] = useCountdown(onResend ? 30 : 0);
   return (
     <View style={{ flex: 1 }}>
       <SafeAreaView className="flex-1">
@@ -90,10 +91,13 @@ export function VerifyCodeScreen({
                 <Button
                   variant="ghost"
                   size="sm"
-                  isDisabled={isDisabled || isLoading || resendCountdown > 0}
-                  onPress={onResend}
+                  isDisabled={isDisabled || isLoading || countdown > 0}
+                  onPress={async () => {
+                    await onResend();
+                    setCountdown(30);
+                  }}
                 >
-                  {resendCountdown > 0 ? `Resend code in ${resendCountdown}s` : "Resend code"}
+                  {countdown > 0 ? `Resend code in ${countdown}s` : "Resend code"}
                 </Button>
               </View>
             )}

--- a/src/components/ui/VerifyCodeScreen.tsx
+++ b/src/components/ui/VerifyCodeScreen.tsx
@@ -93,8 +93,12 @@ export function VerifyCodeScreen({
                   size="sm"
                   isDisabled={isDisabled || isLoading || countdown > 0}
                   onPress={async () => {
-                    await onResend();
-                    setCountdown(30);
+                    try {
+                      await onResend();
+                      setCountdown(30);
+                    } catch (error) {
+                      console.error("[VerifyCodeScreen] Resend failed:", error);
+                    }
                   }}
                 >
                   {countdown > 0 ? `Resend code in ${countdown}s` : "Resend code"}

--- a/src/hooks/useCountdown.ts
+++ b/src/hooks/useCountdown.ts
@@ -5,13 +5,15 @@ import { useEffect, useState } from "react";
  * from a given number (counting down to 0, one tick per second).
  */
 export function useCountdown(initialValue = 0): [number, (n: number) => void] {
-  const [countdown, setCountdown] = useState(initialValue);
+  const [countdown, setCountdown] = useState(Math.max(0, initialValue));
+  const startCountdown = (n: number) => setCountdown(Math.max(0, n));
 
   useEffect(() => {
-    if (countdown === 0) return;
-    const timer = setTimeout(() => setCountdown((c) => c - 1), 1000);
+    if (countdown <= 0) return;
+    const timer = setTimeout(() => setCountdown((c) => Math.max(0, c - 1)), 1000);
+
     return () => clearTimeout(timer);
   }, [countdown]);
 
-  return [countdown, setCountdown];
+  return [countdown, startCountdown];
 }

--- a/src/hooks/useCountdown.ts
+++ b/src/hooks/useCountdown.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Returns the current countdown value and a function to start the countdown
+ * from a given number (counting down to 0, one tick per second).
+ */
+export function useCountdown(initialValue = 0): [number, (n: number) => void] {
+  const [countdown, setCountdown] = useState(initialValue);
+
+  useEffect(() => {
+    if (countdown === 0) return;
+    const timer = setTimeout(() => setCountdown((c) => c - 1), 1000);
+    return () => clearTimeout(timer);
+  }, [countdown]);
+
+  return [countdown, setCountdown];
+}


### PR DESCRIPTION
## Summary

- Implements the forgot password page with a 3-step Clerk reset flow: email entry → code verification → new password
- Extracts a `useCountdown` hook and `BackButton` component to eliminate duplication across the auth screens
- Moves countdown state into `VerifyCodeScreen` so parents only need to provide an `onResend` callback

## Test plan

- [ ] Enter email on forgot password screen → reset code email is sent, code screen appears
- [ ] Enter incorrect code → error is shown
- [ ] Enter correct code → new password screen appears
- [ ] Enter mismatched passwords → submit button stays disabled and mismatch error shows
- [ ] Enter matching passwords → password is reset and user is navigated home
- [ ] Resend button is disabled for 30s after code is sent, then re-enables
- [ ] Back button on each step navigates to the previous step
- [ ] Sign in and sign up flows still work correctly (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Built the forgot password page using the `@clerk/expo` reset flow (email → code → new password), with an MFA step when required. Extracted `useCountdown` and `BackButton`, and moved the resend countdown into `VerifyCodeScreen` to simplify sign-in and sign-up.

- **New Features**
  - Forgot password flow with code verification and new password.
  - MFA step (TOTP, email, or phone) after password submission when required.

- **Bug Fixes**
  - Sign-in uses `identifier` (not `emailAddress`) for `signIn.password()`.
  - Replaced `window.location.href` with `router.replace()` to avoid native crashes and clear auth screens from history.
  - Prevented a null crash by guarding `supportedSecondFactors` in the client trust path.
  - Surfaced `clerkErrors.global` across screens and fall back to it in code verification.
  - Sign-up now aborts if `sendEmailCode()` fails instead of proceeding to verification.
  - Wrapped `VerifyCodeScreen` resend handler in try/catch to prevent unhandled rejections.

<sup>Written for commit ee3cfe2f9601f03fb614b457d5127ad855ddfcd7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-step password reset (email → code → new password → optional 2FA) and a reusable Back button component.

* **Bug Fixes**
  * Simplified resend code behaviour and more reliable resend handling.
  * Consistent post-auth navigation to the home route.

* **Improvements**
  * Clearer sign-in/sign-up error messaging and refined second-factor flows.
  * New lightweight countdown hook powering resend timers.

* **Documentation**
  * Extensive new Clerk guides (APIs, webhooks, Expo patterns, custom UI and SDK flows).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->