### PR TITLE
fix(security): #47 strip IPv6 zone IDs before SSRF hostname check

### DIFF
--- a/convex/calendars/domain/icalUrl.test.ts
+++ b/convex/calendars/domain/icalUrl.test.ts
@@ -103,6 +103,15 @@ describe("assertSafeIcalUrl", () => {
     expect(() => assertSafeIcalUrl(url)).toThrow(/private or reserved/);
   });
 
+  test("rejects IPv6 link-local address with zone ID bypass attempt", () => {
+    // fe80::1%25eth0 — zone ID is stripped before range checks so the bare
+    // fe80:: address is identified as private/link-local. If the runtime URL
+    // parser already rejects zone ID literals, that also closes the SSRF door.
+    expect(() => assertSafeIcalUrl("http://[fe80::1%25eth0]/")).toThrow(
+      /private or reserved|Invalid iCal URL/,
+    );
+  });
+
   test("rejects a malformed IPv6 literal", () => {
     // WHATWG URL refuses to parse an illegal literal before our check sees it,
     // which is fine — either rejection closes the SSRF door.

--- a/convex/calendars/domain/icalUrl.ts
+++ b/convex/calendars/domain/icalUrl.ts
@@ -26,7 +26,10 @@ export function assertSafeIcalUrl(raw: string): string {
   if (url.username || url.password) {
     throw new Error("iCal URL must not contain credentials");
   }
-  const hostname = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  const hostname = url.hostname
+    .toLowerCase()
+    .replace(/^\[|\]$/g, "") // strip IPv6 brackets
+    .replace(/%.*$/, ""); // strip zone ID (e.g. %25eth0) before range checks
   if (!hostname) throw new Error("iCal URL is missing a hostname");
   if (hostname === "localhost" || hostname.endsWith(".localhost") || hostname === "broadcasthost") {
     throw new Error("iCal URL points at a local host");


### PR DESCRIPTION
## Summary

- Zone IDs (e.g. `%25eth0`) in IPv6 URL literals were not stripped before the private-range SSRF check in `icalUrl.ts`
- A crafted URL like `http://[fe80::1%25eth0]/` could evade the link-local block on runtimes that accept zone-ID syntax in IPv6 literals
- Fix: after stripping `[]` brackets, also strip everything from `%` onwards so the bare address is always validated against private ranges

## Test Plan

- New test case `rejects IPv6 link-local address with zone ID bypass attempt` verifies `http://[fe80::1%25eth0]/` is rejected (either as private/reserved or as an unparseable URL — both outcomes close the SSRF door)
- All 202 existing tests continue to pass

## Checklist

- [x] TypeScript compiles with zero errors (pre-existing unrelated error in `VerifyCodeScreen.stories.tsx` excluded)
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass (202/202)

Closes #47

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strip IPv6 zone IDs from hostnames before SSRF private-range checks so URLs like http://[fe80::1%25eth0]/ cannot bypass link-local blocking. Addresses #47.

- **Bug Fixes**
  - After removing IPv6 brackets, strip everything from '%' onward before validating the hostname against private/reserved ranges.
  - Added a test that ensures `http://[fe80::1%25eth0]/` is rejected.

<sup>Written for commit 41de39e007a89ad42e1d9620a3ab94e45405e629. Summary will update on new commits. <a href="https://cubic.dev/pr/ChazUK/crewcircle-app/pull/73?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

