### PR TITLE
fix(auth): #44 replace as-any Clerk error casts with typed helper

### DIFF
--- a/src/app/(auth)/forgot-password.tsx
+++ b/src/app/(auth)/forgot-password.tsx
@@ -10,6 +10,7 @@ import { withUniwind } from "uniwind";
 
 import { BackButton } from "@/components/ui/BackButton";
 import { VerifyCodeScreen } from "@/components/ui/VerifyCodeScreen";
+import { getClerkErrorMessage } from "@/utils/clerkErrors";
 
 type Step = "email" | "code" | "new-password" | "mfa";
 
@@ -233,7 +234,7 @@ export default function Page() {
                       isDisabled={!canSubmit || !!isSubmitting || fetchStatus === "fetching"}
                       error={
                         clerkErrors.fields.code?.longMessage ??
-                        (clerkErrors.global?.[0] as any)?.errors?.[0]?.longMessage
+                        getClerkErrorMessage(clerkErrors.global?.[0])
                       }
                       onResend={() => {
                         codeForm.reset();

--- a/src/app/(auth)/sign-in.tsx
+++ b/src/app/(auth)/sign-in.tsx
@@ -21,6 +21,7 @@ import { SignInWithAppleButton } from "@/components/auth/SignInWithAppleButton";
 import { SignInWithGoogleButton } from "@/components/auth/SignInWithGoogleButton";
 import { BackButton } from "@/components/ui/BackButton";
 import { VerifyCodeScreen } from "@/components/ui/VerifyCodeScreen";
+import { getClerkErrorMessage } from "@/utils/clerkErrors";
 
 const StyledSafeAreaView = withUniwind(SafeAreaView);
 
@@ -195,7 +196,7 @@ export default function Page() {
                       isDisabled={!canSubmit || !!isSubmitting || fetchStatus === "fetching"}
                       error={
                         clerkErrors.fields.code?.longMessage ??
-                        (clerkErrors.global?.[0] as any)?.errors?.[0]?.longMessage
+                        getClerkErrorMessage(clerkErrors.global?.[0])
                       }
                       onResend={() => {
                         verifyForm.reset();
@@ -240,7 +241,7 @@ export default function Page() {
                       isDisabled={!canSubmit || !!isSubmitting || fetchStatus === "fetching"}
                       error={
                         clerkErrors.fields.code?.longMessage ??
-                        (clerkErrors.global?.[0] as any)?.errors?.[0]?.longMessage
+                        getClerkErrorMessage(clerkErrors.global?.[0])
                       }
                       onResend={() => {
                         verifyForm.reset();

--- a/src/components/ui/VerifyCodeScreen.stories.tsx
+++ b/src/components/ui/VerifyCodeScreen.stories.tsx
@@ -10,7 +10,6 @@ const meta = {
     onChange: () => {},
     onBlur: () => {},
     onSubmit: () => {},
-    onBack: () => {},
     isLoading: false,
     isDisabled: false,
   },

--- a/src/utils/clerkErrors.ts
+++ b/src/utils/clerkErrors.ts
@@ -1,0 +1,16 @@
+import { isClerkAPIResponseError } from "@clerk/expo";
+
+/**
+ * Extracts the long message from a Clerk global hook error.
+ *
+ * ClerkGlobalHookError wraps either a ClerkAPIResponseError (which carries
+ * an `errors[]` array of typed API errors) or a plain ClerkRuntimeError.
+ * We narrow the type with the official guard before accessing `errors[0]`.
+ */
+export function getClerkErrorMessage(err: unknown): string | undefined {
+  if (!err) return undefined;
+  if (isClerkAPIResponseError(err)) {
+    return err.errors[0]?.longMessage;
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary

- Creates `src/utils/clerkErrors.ts` with `getClerkErrorMessage(err: unknown): string | undefined` that uses the official `isClerkAPIResponseError` type guard from `@clerk/expo` to safely access `errors[0].longMessage`
- Replaces three `as any` casts in `sign-in.tsx` (lines 198, 242) and `forgot-password.tsx` (line 236) with calls to this helper
- Also fixes a pre-existing TypeScript error in `VerifyCodeScreen.stories.tsx` where `onBack` was in default args but not in `Props` (was blocking `tsc --noEmit`)

## Test Plan

- [ ] `npx tsc --noEmit` — zero errors
- [ ] `npm run lint` — 0 warnings, 0 errors
- [ ] `npm run test` — 201 tests pass
- [ ] Manual: sign-in MFA/client-trust screens still show Clerk error messages correctly
- [ ] Manual: forgot-password code entry step still shows Clerk error messages correctly

## Checklist
- [x] TypeScript compiles with zero errors
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass (201 passing)

Closes #44

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced unsafe Clerk error casts with a typed helper to safely extract messages and satisfy TypeScript. Also fixed a Storybook prop mismatch. Closes #44.

- **Bug Fixes**
  - Added `src/utils/clerkErrors.ts` with `getClerkErrorMessage` using `isClerkAPIResponseError` from `@clerk/expo`.
  - Replaced three `as any` casts in `sign-in.tsx` and `forgot-password.tsx` with the helper.
  - Removed invalid `onBack` default arg in `VerifyCodeScreen.stories.tsx` to fix a TS error.

<sup>Written for commit 6ee738e4fff57c7732525618e783140850602db9. Summary will update on new commits. <a href="https://cubic.dev/pr/ChazUK/crewcircle-app/pull/77?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

