### PR TITLE
perf(calendars): #51 cap listEventsInRange to 90 days and 2000 results

### DIFF
--- a/convex/calendars/queries.test.ts
+++ b/convex/calendars/queries.test.ts
@@ -170,6 +170,18 @@ describe("listEventsInRange", () => {
     expect(result).toEqual([]);
   });
 
+  test("throws ConvexError when the date range exceeds 90 days", async () => {
+    const t = convexTest(schema, modules);
+    const base = Date.UTC(2026, 0, 1);
+    const ninetyOneDays = 91 * ONE_DAY;
+    await expect(
+      t.query(api.calendars.queries.listEventsInRange, {
+        startsAtMs: base,
+        endsAtMs: base + ninetyOneDays,
+      }),
+    ).rejects.toThrow("Date range exceeds the maximum allowed window of 90 days");
+  });
+
   test("does not leak another user's events", async () => {
     const { t } = await setupUserWithConnection();
     const otherUser = await t.run((ctx) =>

--- a/convex/calendars/queries.ts
+++ b/convex/calendars/queries.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { ConvexError, v } from "convex/values";
 
 import { Doc } from "../_generated/dataModel";
 import { query } from "../_generated/server";
@@ -54,12 +54,19 @@ export const listConnections = query({
 // endsAt.
 const OVERLAP_LOOKBACK_MS = 365 * 24 * 60 * 60 * 1000;
 
+const MAX_RANGE_MS = 90 * 24 * 60 * 60 * 1000;
+const MAX_EVENTS = 2000;
+
 export const listEventsInRange = query({
   args: {
     startsAtMs: v.number(),
     endsAtMs: v.number(),
   },
   handler: async (ctx, args) => {
+    if (args.endsAtMs - args.startsAtMs > MAX_RANGE_MS) {
+      throw new ConvexError("Date range exceeds the maximum allowed window of 90 days");
+    }
+
     const identity = await ctx.auth.getUserIdentity();
     if (!identity) return [];
     const user = await getUserByExternalId(ctx, identity.subject);
@@ -73,7 +80,7 @@ export const listEventsInRange = query({
           .gte("startsAt", args.startsAtMs - OVERLAP_LOOKBACK_MS)
           .lt("startsAt", args.endsAtMs),
       )
-      .collect();
+      .take(MAX_EVENTS);
 
     return events
       .filter((event) => event.endsAt > args.startsAtMs)


### PR DESCRIPTION
## Summary

- Added a `MAX_RANGE_MS` guard (90 days) to `listEventsInRange`: requests with a date window larger than 90 days now throw a `ConvexError` with a clear message
- Replaced unbounded `.collect()` with `.take(2000)` as a defence-in-depth safety net
- Added a unit test covering the out-of-range error case

## Test Plan

- [ ] Run `npm run test` — all 210 tests pass including the new range-cap test
- [ ] Run `npx tsc --noEmit` — zero TypeScript errors
- [ ] Run `npm run lint` — zero lint warnings/errors
- [ ] Run `npm run fmt:check` — formatting clean

## Checklist

- [x] TypeScript compiles with zero errors
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass

Closes #51

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps `listEventsInRange` to a 90‑day window and limits results to 2000 to prevent expensive scans and reduce abuse risk. Oversized ranges now throw a clear `ConvexError`, and a unit test covers the error case; closes #51.

<sup>Written for commit 45c92c2b38cccf4d008f50e45db21a82d89f871c. Summary will update on new commits. <a href="https://cubic.dev/pr/ChazUK/crewcircle-app/pull/79?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

