### PR TITLE
fix(calendars): #53 prevent concurrent Google token refresh race via optimistic nonce lock

### DIFF
--- a/convex/calendars/google.test.ts
+++ b/convex/calendars/google.test.ts
@@ -493,7 +493,7 @@ describe("syncGoogleConnectionInternal", () => {
     );
 
     let tokenRefreshCallCount = 0;
-    stubFetches([
+    const { calls } = stubFetches([
       // Token refresh call — simulate another concurrent action winning by writing a
       // new nonce into the DB before this action's CAS mutation runs.
       async (url: string) => {
@@ -521,6 +521,11 @@ describe("syncGoogleConnectionInternal", () => {
 
     // Only one HTTP refresh call was made (no retry loop)
     expect(tokenRefreshCallCount).toBe(1);
+    // Events request used the re-read token, not the locally-refreshed one
+    const eventsCall = calls[1];
+    expect((eventsCall.init?.headers as Record<string, string>)?.Authorization).toBe(
+      "Bearer token-from-winner",
+    );
     // DB nonce belongs to the winning action — this action's CAS write was skipped
     const conn = await t.run((ctx) => ctx.db.get(connectionId));
     expect(conn?.refreshNonce).toBe("nonce-from-winner");

--- a/convex/calendars/google.test.ts
+++ b/convex/calendars/google.test.ts
@@ -31,7 +31,9 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-function stubFetches(handlers: Array<(url: string, init?: RequestInit) => Response>) {
+function stubFetches(
+  handlers: Array<(url: string, init?: RequestInit) => Response | Promise<Response>>,
+) {
   const calls: Array<{ url: string; init?: RequestInit }> = [];
   let index = 0;
   const fn = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -470,5 +472,143 @@ describe("syncGoogleConnectionInternal", () => {
         userId,
       }),
     ).rejects.toThrow(/OAuth client id/);
+  });
+
+  test("concurrent refresh: nonce mismatch causes fallback to re-read token without a second HTTP refresh", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await seedUser(t);
+    const expiredTokens = encryptJson({ accessToken: "expired", refreshToken: "refresh-1" });
+    const connectionId = await t.run((ctx) =>
+      ctx.db.insert("calendarConnections", {
+        userId,
+        provider: "google",
+        label: "Google",
+        oauthClientId: "client-id",
+        encryptedTokens: expiredTokens,
+        tokenExpiresAt: Date.now() - 1000,
+        refreshNonce: "initial-nonce",
+        enabledSubCalendarIds: ["cal"],
+        createdAt: Date.now(),
+      }),
+    );
+
+    let tokenRefreshCallCount = 0;
+    stubFetches([
+      // Token refresh call — simulate another concurrent action winning by writing a
+      // new nonce into the DB before this action's CAS mutation runs.
+      async (url: string) => {
+        if (url.includes("oauth2.googleapis.com/token")) {
+          tokenRefreshCallCount++;
+          const otherTokens = encryptJson({ accessToken: "token-from-winner", refreshToken: "r" });
+          await t.run((ctx) =>
+            ctx.db.patch(connectionId, {
+              refreshNonce: "nonce-from-winner",
+              encryptedTokens: otherTokens,
+              tokenExpiresAt: Date.now() + 3600 * 1000,
+            }),
+          );
+        }
+        return json({ access_token: "token-from-this-action", expires_in: 3600 });
+      },
+      // Events list — called with the re-read token (token-from-winner)
+      () => json({ items: [] }),
+    ]);
+
+    await t.action(internal.calendars.google.syncGoogleConnectionInternal, {
+      connectionId,
+      userId,
+    });
+
+    // Only one HTTP refresh call was made (no retry loop)
+    expect(tokenRefreshCallCount).toBe(1);
+    // DB nonce belongs to the winning action — this action's CAS write was skipped
+    const conn = await t.run((ctx) => ctx.db.get(connectionId));
+    expect(conn?.refreshNonce).toBe("nonce-from-winner");
+  });
+});
+
+describe("updateTokensIfNonce", () => {
+  async function seedConnection(t: TestConvex<typeof schema>, nonce?: string) {
+    const userId = await seedUser(t);
+    const connectionId = await t.run((ctx) =>
+      ctx.db.insert("calendarConnections", {
+        userId,
+        provider: "google",
+        label: "Google",
+        encryptedTokens: encryptJson({ accessToken: "old-token" }),
+        refreshNonce: nonce,
+        createdAt: Date.now(),
+      }),
+    );
+    return { userId, connectionId };
+  }
+
+  test("updates tokens and returns true when nonce matches", async () => {
+    const t = convexTest(schema, modules);
+    const { connectionId } = await seedConnection(t, "nonce-1");
+
+    const newTokens = encryptJson({ accessToken: "new-token" });
+    const updated = await t.mutation(internal.calendars.mutations.updateTokensIfNonce, {
+      connectionId,
+      expectedNonce: "nonce-1",
+      encryptedTokens: newTokens,
+      tokenExpiresAt: Date.now() + 3_600_000,
+      newNonce: "nonce-2",
+    });
+
+    expect(updated).toBe(true);
+    const conn = await t.run((ctx) => ctx.db.get(connectionId));
+    expect(conn?.refreshNonce).toBe("nonce-2");
+  });
+
+  test("is a no-op and returns false when nonce does not match", async () => {
+    const t = convexTest(schema, modules);
+    const { connectionId } = await seedConnection(t, "nonce-current");
+
+    const newTokens = encryptJson({ accessToken: "new-token" });
+    const updated = await t.mutation(internal.calendars.mutations.updateTokensIfNonce, {
+      connectionId,
+      expectedNonce: "nonce-stale",
+      encryptedTokens: newTokens,
+      tokenExpiresAt: Date.now() + 3_600_000,
+      newNonce: "nonce-next",
+    });
+
+    expect(updated).toBe(false);
+    const conn = await t.run((ctx) => ctx.db.get(connectionId));
+    expect(conn?.refreshNonce).toBe("nonce-current");
+  });
+
+  test("succeeds when both expected and stored nonce are undefined (first-ever refresh)", async () => {
+    const t = convexTest(schema, modules);
+    const { connectionId } = await seedConnection(t, undefined);
+
+    const newTokens = encryptJson({ accessToken: "first-token" });
+    const updated = await t.mutation(internal.calendars.mutations.updateTokensIfNonce, {
+      connectionId,
+      expectedNonce: undefined,
+      encryptedTokens: newTokens,
+      tokenExpiresAt: Date.now() + 3_600_000,
+      newNonce: "nonce-first",
+    });
+
+    expect(updated).toBe(true);
+    const conn = await t.run((ctx) => ctx.db.get(connectionId));
+    expect(conn?.refreshNonce).toBe("nonce-first");
+  });
+
+  test("returns false when connection does not exist", async () => {
+    const t = convexTest(schema, modules);
+    const { connectionId } = await seedConnection(t);
+    await t.run((ctx) => ctx.db.delete(connectionId));
+
+    const updated = await t.mutation(internal.calendars.mutations.updateTokensIfNonce, {
+      connectionId,
+      expectedNonce: undefined,
+      encryptedTokens: encryptJson({ accessToken: "x" }),
+      newNonce: "nonce-1",
+    });
+
+    expect(updated).toBe(false);
   });
 });

--- a/convex/calendars/google.ts
+++ b/convex/calendars/google.ts
@@ -1,5 +1,7 @@
 "use node";
 
+import { randomUUID } from "node:crypto";
+
 import { v } from "convex/values";
 
 import { api, internal } from "../_generated/api";
@@ -200,6 +202,7 @@ async function ensureAccessToken(
   if (!tokens.refreshToken) {
     throw new Error("Access token expired and no refresh token available; reconnect required");
   }
+  const currentNonce = connection.refreshNonce;
   const refreshed = await refreshAccessToken({
     refreshToken: tokens.refreshToken,
     clientId,
@@ -210,12 +213,29 @@ async function ensureAccessToken(
     tokenType: refreshed.token_type ?? tokens.tokenType,
   };
   const encrypted = encryptJson(nextTokens);
-  await ctx.runMutation(internal.calendars.mutations.updateConnectionTokens, {
+  const updated: boolean = await ctx.runMutation(internal.calendars.mutations.updateTokensIfNonce, {
     connectionId: connection._id,
+    expectedNonce: currentNonce,
     encryptedTokens: encrypted,
     tokenExpiresAt: Date.now() + refreshed.expires_in * 1000,
+    newNonce: randomUUID(),
   });
-  return refreshed.access_token;
+  if (updated) {
+    return refreshed.access_token;
+  }
+  // Another concurrent action already refreshed. Re-read the freshly stored token.
+  const fresh: Doc<"calendarConnections"> | null = await ctx.runQuery(
+    internal.calendars.actionHelpers.getConnectionInternal,
+    { connectionId: connection._id },
+  );
+  if (!fresh?.encryptedTokens) {
+    throw new Error("Token refresh race: re-read connection is missing credentials");
+  }
+  const freshTokens = decryptJson<EncryptedOAuthTokens>(fresh.encryptedTokens);
+  if (!freshTokens.accessToken) {
+    throw new Error("Token refresh race: re-read connection is missing access token");
+  }
+  return freshTokens.accessToken;
 }
 
 export const connectGoogle = action({

--- a/convex/calendars/mutations.ts
+++ b/convex/calendars/mutations.ts
@@ -116,6 +116,27 @@ export const updateConnectionTokens = internalMutation({
   },
 });
 
+export const updateTokensIfNonce = internalMutation({
+  args: {
+    connectionId: v.id("calendarConnections"),
+    expectedNonce: v.optional(v.string()),
+    encryptedTokens: v.bytes(),
+    tokenExpiresAt: v.optional(v.number()),
+    newNonce: v.string(),
+  },
+  handler: async (ctx, args): Promise<boolean> => {
+    const connection = await ctx.db.get(args.connectionId);
+    if (!connection) return false;
+    if (connection.refreshNonce !== args.expectedNonce) return false;
+    await ctx.db.patch(args.connectionId, {
+      encryptedTokens: args.encryptedTokens,
+      tokenExpiresAt: args.tokenExpiresAt,
+      refreshNonce: args.newNonce,
+    });
+    return true;
+  },
+});
+
 export const markSynced = internalMutation({
   args: {
     connectionId: v.id("calendarConnections"),

--- a/convex/calendars/schema.ts
+++ b/convex/calendars/schema.ts
@@ -35,6 +35,9 @@ export const CalendarConnection = {
   // - Apple: device localCalendarIds from expo-calendar
   // - iCal: not applicable (the feed URL is opaque)
   enabledSubCalendarIds: v.optional(v.array(v.string())),
+  // Optimistic-lock nonce written atomically with each token refresh so that
+  // concurrent refreshes are serialised: only the first writer wins.
+  refreshNonce: v.optional(v.string()),
   // Sync metadata
   lastSyncedAt: v.optional(v.number()),
   lastSyncError: v.optional(v.string()),


### PR DESCRIPTION
## Summary

- Added `refreshNonce: v.optional(v.string())` to the `calendarConnections` schema as an optimistic-lock field
- Added `updateTokensIfNonce` internal mutation that performs an atomic compare-and-swap: writes the refreshed tokens only when the stored nonce matches the value read at the start of the action
- Updated `ensureAccessToken` to use the CAS mutation; if the write is skipped (nonce changed), the action re-reads the freshly stored token from the winning concurrent action instead of using a stale one

## Test Plan

- Unit tests for `updateTokensIfNonce`: verifies update-on-match, no-op-on-mismatch, no-op when connection is deleted, and success on first-ever refresh (both nonces undefined)
- Integration test using a fetch-stub side-effect: simulates a concurrent action winning the nonce race while this action's token refresh HTTP call is in flight, then asserts that (a) only one HTTP refresh call was made, and (b) the DB retains the winning action's nonce

## Checklist
- [x] TypeScript compiles with zero errors
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass (214/214)

Closes #53

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents concurrent Google token refresh races using an optimistic nonce lock so only one action writes tokens, and losers re-use the winning token without extra refresh calls. Fixes Linear #53 and stops stale tokens from overwriting fresh ones.

- **Bug Fixes**
  - Added optional `refreshNonce` to `calendarConnections` for optimistic locking.
  - Introduced `updateTokensIfNonce` (CAS) to update tokens only when the stored nonce matches.
  - Updated `ensureAccessToken` to use CAS; on mismatch, re-reads the winner’s token with no second refresh call.

<sup>Written for commit f783802727161e8468bb4ebc8a53f5de6376653e. Summary will update on new commits. <a href="https://cubic.dev/pr/ChazUK/crewcircle-app/pull/81?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

