### PR TITLE
fix(verify-code): #56 show error and halt countdown when OTP resend fails

### DIFF
--- a/src/components/ui/VerifyCodeScreen.stories.tsx
+++ b/src/components/ui/VerifyCodeScreen.stories.tsx
@@ -77,3 +77,11 @@ export const Loading: Story = {
     isDisabled: true,
   },
 };
+
+export const ResendError: Story = {
+  args: {
+    title: "Verify your account",
+    subtitle: "Enter the 6-digit code sent to your email",
+    onResend: () => Promise.reject(new Error("Network error")),
+  },
+};

--- a/src/components/ui/VerifyCodeScreen.tsx
+++ b/src/components/ui/VerifyCodeScreen.tsx
@@ -1,4 +1,5 @@
 import { Button, Card, FieldError, InputOTP } from "heroui-native";
+import { useState } from "react";
 import { Text, View } from "react-native";
 
 import { useCountdown } from "@/hooks/useCountdown";
@@ -30,6 +31,7 @@ export function VerifyCodeScreen({
   onResend,
 }: Props) {
   const [countdown, startCountdown] = useCountdown(onResend ? 30 : 0);
+  const [resendError, setResendError] = useState<string | null>(null);
 
   return (
     <View className="gap-6">
@@ -72,22 +74,24 @@ export function VerifyCodeScreen({
       </Card>
 
       {onResend && (
-        <View className="items-center">
+        <View className="items-center gap-2">
           <Button
             variant="ghost"
             size="sm"
             isDisabled={isDisabled || isLoading || countdown > 0}
             onPress={async () => {
+              setResendError(null);
               try {
                 await onResend();
                 startCountdown(30);
-              } catch (error) {
-                console.error("[VerifyCodeScreen] Resend failed:", error);
+              } catch {
+                setResendError("Failed to resend code. Please try again.");
               }
             }}
           >
             {countdown > 0 ? `Resend code in ${countdown}s` : "Resend code"}
           </Button>
+          {resendError && <FieldError isInvalid>{resendError}</FieldError>}
         </View>
       )}
     </View>


### PR DESCRIPTION
## Summary

- Added `resendError` local state to `VerifyCodeScreen` — renders a `FieldError` below the resend button when `onResend` throws
- Countdown no longer restarts on a failed resend (only restarts on success)
- Error is cleared (`setResendError(null)`) before each new attempt so stale messages don't persist
- Added `ResendError` Storybook story covering the new visual state

## Test Plan

- [ ] Trigger `onResend` with a function that throws — confirm error message appears below the button and countdown does not start
- [ ] Trigger `onResend` with a function that succeeds — confirm error is cleared and countdown restarts from 30s
- [ ] Check `ResendError` story in Storybook renders the error message correctly

## Checklist

- [x] TypeScript compiles with zero errors
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass (228/228)

Closes #56

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a clear error and stop the timer when OTP resend fails on `VerifyCodeScreen`. Fixes #56 by only restarting the countdown after a successful resend.

- **Bug Fixes**
  - Show `FieldError` under the Resend button when `onResend` fails; clear it before each new attempt.
  - Only restart the 30s countdown on successful resend.
  - Added `ResendError` Storybook story to cover the error state.

<sup>Written for commit 9d57f9c796ae629b0567ba80d66f9208bc8d3a3e. Summary will update on new commits. <a href="https://cubic.dev/pr/ChazUK/crewcircle-app/pull/82?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

