### PR TITLE
fix(calendars): #55 surface initial Google sync failure to the UI

### DIFF
--- a/convex/calendars/google.test.ts
+++ b/convex/calendars/google.test.ts
@@ -129,6 +129,7 @@ describe("connectGoogle", () => {
     });
 
     expect(result.enabledSubCalendarIds).toEqual(["me@google.test"]);
+    expect(result.syncError).toBeNull();
     const connection = (await t.run((ctx) =>
       ctx.db.get(result.connectionId),
     )) as Doc<"calendarConnections">;
@@ -164,6 +165,7 @@ describe("connectGoogle", () => {
       clientId: "client-id",
       redirectUri: "https://example.com/callback",
     });
+    expect(result.syncError).toMatch(/Google events fetch failed/);
     const connection = (await t.run((ctx) =>
       ctx.db.get(result.connectionId),
     )) as Doc<"calendarConnections">;

--- a/convex/calendars/google.ts
+++ b/convex/calendars/google.ts
@@ -251,6 +251,7 @@ export const connectGoogle = action({
   ): Promise<{
     connectionId: Id<"calendarConnections">;
     enabledSubCalendarIds: string[];
+    syncError: string | null;
   }> => {
     const user = await ctx.runQuery(api.users.queries.getCurrentUser, {});
     if (!user) throw new Error("Not authenticated");
@@ -305,6 +306,7 @@ export const connectGoogle = action({
       },
     );
 
+    let syncError: string | null = null;
     try {
       const events = await fetchEventsForCalendars(token.access_token, [primaryId]);
       await ctx.runMutation(internal.calendars.mutations.replaceEvents, {
@@ -317,13 +319,13 @@ export const connectGoogle = action({
         error: undefined,
       });
     } catch (err) {
-      const message = err instanceof Error ? err.message : "Unknown sync error";
+      syncError = err instanceof Error ? err.message : "Unknown sync error";
       await ctx.runMutation(internal.calendars.mutations.markSynced, {
         connectionId,
-        error: message,
+        error: syncError,
       });
     }
-    return { connectionId, enabledSubCalendarIds: [primaryId] };
+    return { connectionId, enabledSubCalendarIds: [primaryId], syncError };
   },
 });
 

--- a/src/components/ui/CalendarConnectionsSheet.stories.tsx
+++ b/src/components/ui/CalendarConnectionsSheet.stories.tsx
@@ -9,14 +9,19 @@ import { CalendarConnectionsSheet } from "./CalendarConnectionsSheet";
 
 type StoryArgs = {
   startOpen: boolean;
+  initialSyncWarning?: string;
 };
 
-function Harness({ startOpen }: StoryArgs) {
+function Harness({ startOpen, initialSyncWarning }: StoryArgs) {
   const [isOpen, setIsOpen] = useState(startOpen);
   return (
     <View style={{ flex: 1, padding: 16, gap: 16 }}>
       <Button onPress={() => setIsOpen(true)}>Open calendar connections</Button>
-      <CalendarConnectionsSheet isOpen={isOpen} onOpenChange={setIsOpen} />
+      <CalendarConnectionsSheet
+        isOpen={isOpen}
+        onOpenChange={setIsOpen}
+        _initialSyncWarning={initialSyncWarning}
+      />
     </View>
   );
 }
@@ -47,4 +52,11 @@ export const Closed: Story = {};
 
 export const InitiallyOpen: Story = {
   args: { startOpen: true },
+};
+
+export const WithSyncWarning: Story = {
+  args: {
+    startOpen: true,
+    initialSyncWarning: "Calendar connected but initial sync failed. It will retry shortly.",
+  },
 };

--- a/src/components/ui/CalendarConnectionsSheet.tsx
+++ b/src/components/ui/CalendarConnectionsSheet.tsx
@@ -259,6 +259,8 @@ export function CalendarConnectionsSheet({ isOpen, onOpenChange, _initialSyncWar
         });
         if (syncError != null) {
           setSyncWarning("Calendar connected but initial sync failed. It will retry shortly.");
+        } else {
+          setSyncWarning(null);
         }
         // After Google returns tokens, surface its sub-calendars so the user
         // can pick which ones to actually sync. connectGoogle resolves the

--- a/src/components/ui/CalendarConnectionsSheet.tsx
+++ b/src/components/ui/CalendarConnectionsSheet.tsx
@@ -67,6 +67,8 @@ type AddProvider = "ical";
 type Props = {
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
+  /** Only used by Storybook to pre-seed the sync-warning banner. */
+  _initialSyncWarning?: string;
 };
 
 const PROVIDER_META: Record<
@@ -110,7 +112,7 @@ async function readAppleEvents(subCalendarIds: string[]): Promise<EventInput[]> 
   return events;
 }
 
-export function CalendarConnectionsSheet({ isOpen, onOpenChange }: Props) {
+export function CalendarConnectionsSheet({ isOpen, onOpenChange, _initialSyncWarning }: Props) {
   const connections = useQuery(api.calendars.queries.listConnections) ?? [];
   const connectIcal = useAction(api.calendars.actions.connectIcal);
   const connectApple = useAction(api.calendars.actions.connectApple);
@@ -135,6 +137,7 @@ export function CalendarConnectionsSheet({ isOpen, onOpenChange }: Props) {
   const [icalLabel, setIcalLabel] = useState("");
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [syncWarning, setSyncWarning] = useState<string | null>(_initialSyncWarning ?? null);
   const [appleDeviceCalendars, setAppleDeviceCalendars] = useState<Calendar.Calendar[]>([]);
   const [applePickerOpen, setApplePickerOpen] = useState(false);
   const [expandedId, setExpandedId] = useState<Id<"calendarConnections"> | null>(null);
@@ -168,6 +171,7 @@ export function CalendarConnectionsSheet({ isOpen, onOpenChange }: Props) {
       if (!value) {
         resetAddState();
         setError(null);
+        setSyncWarning(null);
         setExpandedId(null);
       }
     },
@@ -247,12 +251,15 @@ export function CalendarConnectionsSheet({ isOpen, onOpenChange }: Props) {
       setBusy("google");
       setError(null);
       try {
-        const { connectionId, enabledSubCalendarIds } = await connectGoogleAction({
+        const { connectionId, enabledSubCalendarIds, syncError } = await connectGoogleAction({
           code,
           codeVerifier: snapshot.codeVerifier,
           clientId: snapshot.clientId,
           redirectUri: snapshot.redirectUri,
         });
+        if (syncError != null) {
+          setSyncWarning("Calendar connected but initial sync failed. It will retry shortly.");
+        }
         // After Google returns tokens, surface its sub-calendars so the user
         // can pick which ones to actually sync. connectGoogle resolves the
         // "primary" alias to the real calendar id so initial selection is
@@ -467,6 +474,12 @@ export function CalendarConnectionsSheet({ isOpen, onOpenChange }: Props) {
             {error != null && (
               <View className="mb-3 rounded-xl bg-danger/10 p-3">
                 <Text className="text-sm text-danger">{error}</Text>
+              </View>
+            )}
+
+            {syncWarning != null && (
+              <View className="mb-3 rounded-xl bg-warning/10 p-3">
+                <Text className="text-sm text-warning">{syncWarning}</Text>
               </View>
             )}
 


### PR DESCRIPTION
## Summary

- `connectGoogle` now returns `syncError: string | null` alongside `connectionId` and `enabledSubCalendarIds`. When the initial event pull throws, `syncError` carries the message and is stored in `lastSyncError` as before — but the result is no longer silently discarded.
- `CalendarConnectionsSheet` checks `syncError` after a Google connect completes and shows a non-blocking amber warning banner: _"Calendar connected but initial sync failed. It will retry shortly."_ The connection flow (sub-calendar picker) continues normally.
- Tests updated: the existing _"records a sync error if event fetching fails"_ test now also asserts `result.syncError` is non-null; a new assertion confirms `result.syncError` is `null` on success.
- Storybook: added a `WithSyncWarning` story to `CalendarConnectionsSheet.stories.tsx` that pre-seeds the warning banner so all visual states are reviewable.

## Test Plan

- [ ] TypeScript compiles with zero errors (`npx tsc --noEmit`)
- [ ] Lint passes (`npm run lint`)
- [ ] Formatting passes (`npm run fmt:check`)
- [ ] All 228 tests pass (`npm run test`)
- [ ] Storybook `WithSyncWarning` story shows an amber banner beneath the sheet title
- [ ] On a real device: connect Google Calendar with a network condition that lets token exchange succeed but fails the events fetch — verify the sheet stays open with the warning banner rather than silently appearing connected

## Checklist
- [x] TypeScript compiles with zero errors
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass

Closes #55

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface initial Google Calendar sync failures by returning `syncError` from `connectGoogle` and showing a non‑blocking banner in the connections sheet. The banner clears on a successful reconnect or when the sheet closes. Closes #55.

- **Bug Fixes**
  - Return `syncError: string | null` from `connectGoogle` and persist it in `lastSyncError`.
  - `CalendarConnectionsSheet` shows an amber warning when `syncError` is present and clears stale warnings on success or close; sub‑calendar picker continues.
  - Copy fix for the banner (references a connected calendar, not a disconnect); tests assert `syncError` on success/failure, and Storybook adds `WithSyncWarning` via `_initialSyncWarning`.

<sup>Written for commit f4406be6902b581c0f02c533215403bf6914c62f. Summary will update on new commits. <a href="https://cubic.dev/pr/ChazUK/crewcircle-app/pull/83?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

