### PR TITLE
fix(calendars): #54 prevent duplicate Google auth flows on rapid taps

### DIFF
--- a/src/components/ui/CalendarConnectionsSheet.tsx
+++ b/src/components/ui/CalendarConnectionsSheet.tsx
@@ -134,6 +134,7 @@ export function CalendarConnectionsSheet({ isOpen, onOpenChange }: Props) {
   const [icalUrl, setIcalUrl] = useState("");
   const [icalLabel, setIcalLabel] = useState("");
   const [busy, setBusy] = useState<string | null>(null);
+  const [isConnecting, setIsConnecting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [appleDeviceCalendars, setAppleDeviceCalendars] = useState<Calendar.Calendar[]>([]);
   const [applePickerOpen, setApplePickerOpen] = useState(false);
@@ -273,6 +274,7 @@ export function CalendarConnectionsSheet({ isOpen, onOpenChange }: Props) {
   }, [googleResponse, connectGoogleAction, openManagePicker]);
 
   const handleConnectGoogle = useCallback(async () => {
+    if (isConnecting) return;
     setError(null);
     const resolvedClientId =
       Platform.OS === "ios"
@@ -295,12 +297,15 @@ export function CalendarConnectionsSheet({ isOpen, onOpenChange }: Props) {
       redirectUri: googleRequest.redirectUri,
       clientId: resolvedClientId,
     };
+    setIsConnecting(true);
     try {
       await promptGoogle();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to launch Google sign-in");
+    } finally {
+      setIsConnecting(false);
     }
-  }, [googleRequest, promptGoogle]);
+  }, [isConnecting, googleRequest, promptGoogle]);
 
   const handleConnectIcal = useCallback(async () => {
     const trimmed = icalUrl.trim();
@@ -582,7 +587,7 @@ export function CalendarConnectionsSheet({ isOpen, onOpenChange }: Props) {
               </Text>
               <ListGroup>
                 {addTiles.map((tile, index) => {
-                  const isBusyTile = busy === tile.key;
+                  const isBusyTile = busy === tile.key || (tile.key === "google" && isConnecting);
                   return (
                     <Fragment key={tile.key}>
                       {index > 0 && <Separator className="mx-4" />}


### PR DESCRIPTION
## Summary

- Added `isConnecting` state to `CalendarConnectionsSheet` to track when a Google OAuth browser session is open
- `handleConnectGoogle` now returns early if `isConnecting` is already `true`, preventing duplicate auth flows from rapid taps
- The Google Calendar tile is disabled and shows a spinner for the full duration of the connect flow (from tap until the browser closes)
- `isConnecting` is cleared in a `finally` block so the button re-enables whether auth succeeds, fails, or is cancelled by the user

## Test Plan

- [ ] Tap "Google Calendar" — browser opens; the tile is disabled and shows a spinner
- [ ] Tap the tile rapidly multiple times before the browser opens — only one auth session is initiated
- [ ] Cancel the browser mid-flow — the tile re-enables and can be tapped again
- [ ] Complete the flow — the picker opens; after dismissal the tile is re-enabled

## Checklist

- [x] TypeScript compiles with zero errors
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass (228 passing)

Closes #54

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate Google Calendar OAuth sessions on rapid taps by tracking an in-flight state and disabling the Google tile with a spinner until the browser closes. Closes #54.

<sup>Written for commit 6412272ae6cc51a592da24e6535d43cd2dd46a24. Summary will update on new commits. <a href="https://cubic.dev/pr/ChazUK/crewcircle-app/pull/84?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

