### PR TITLE
chore(auth): #58 remove debug console.log from forgot-password unmount

### DIFF
--- a/src/app/(auth)/forgot-password.tsx
+++ b/src/app/(auth)/forgot-password.tsx
@@ -22,7 +22,6 @@ export default function Page() {
 
   useEffect(() => {
     return () => {
-      console.log("reset, forgot password");
       signIn.reset();
     };
   }, []);


### PR DESCRIPTION
## Summary

- Removes the debug `console.log("reset, forgot password")` that was firing on every unmount of the forgot-password screen in production
- The cleanup function still calls `signIn.reset()` to clear form state on unmount

## Test Plan

- Navigate to the forgot-password screen and press back (or navigate away) — no console output should appear
- Verify password reset flow still works end-to-end

## Checklist
- [x] TypeScript compiles with zero errors
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass (229/229)

Closes #58

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the debug `console.log` that ran on forgot-password unmount to keep production logs clean (addresses #58). The cleanup still calls `signIn.reset()` so the form state clears when leaving the screen.

<sup>Written for commit 99cf2ad625d1789553c52e4a1242ffbb1cd5c6a3. Summary will update on new commits. <a href="https://cubic.dev/pr/ChazUK/crewcircle-app/pull/85?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

