### PR TITLE
fix(calendars): #59 validate Google Calendar list API response before mapping

### DIFF
--- a/src/components/ui/CalendarConnectionsSheet.tsx
+++ b/src/components/ui/CalendarConnectionsSheet.tsx
@@ -20,6 +20,7 @@ import {
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Alert, Platform, Text, View } from "react-native";
 
+import { GoogleCalendarListSchema } from "./googleCalendarSchemas";
 import {
   AppleCalendarIcon,
   GoogleCalendarIcon,
@@ -187,8 +188,12 @@ export function CalendarConnectionsSheet({ isOpen, onOpenChange }: Props) {
       try {
         let options: SubCalendarOption[] = [];
         if (args.provider === "google") {
-          const items = await listGoogleCalendars({ connectionId: args.connectionId });
-          options = items.map((item) => ({
+          const raw = await listGoogleCalendars({ connectionId: args.connectionId });
+          const parsed = GoogleCalendarListSchema.safeParse(raw);
+          if (!parsed.success) {
+            throw new Error("Unexpected response from Google Calendar API");
+          }
+          options = parsed.data.map((item) => ({
             id: item.id,
             label: item.label,
             hint: item.primary ? "Primary" : item.accessRole,

--- a/src/components/ui/googleCalendarSchemas.test.ts
+++ b/src/components/ui/googleCalendarSchemas.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "vitest";
+
+import { GoogleCalendarItemSchema, GoogleCalendarListSchema } from "./googleCalendarSchemas";
+
+describe("GoogleCalendarItemSchema", () => {
+  test("accepts a valid item with all fields", () => {
+    const result = GoogleCalendarItemSchema.safeParse({
+      id: "user@gmail.com",
+      label: "My Calendar",
+      primary: true,
+      accessRole: "owner",
+      backgroundColor: "#4285F4",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.id).toBe("user@gmail.com");
+      expect(result.data.primary).toBe(true);
+    }
+  });
+
+  test("accepts a valid item with only required fields", () => {
+    const result = GoogleCalendarItemSchema.safeParse({
+      id: "cal123",
+      label: "Work",
+      primary: false,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects an item missing id", () => {
+    const result = GoogleCalendarItemSchema.safeParse({
+      label: "Work",
+      primary: false,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects an item missing label", () => {
+    const result = GoogleCalendarItemSchema.safeParse({
+      id: "cal123",
+      primary: false,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects an item with wrong type for primary", () => {
+    const result = GoogleCalendarItemSchema.safeParse({
+      id: "cal123",
+      label: "Work",
+      primary: "yes",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("GoogleCalendarListSchema", () => {
+  test("accepts an array of valid items", () => {
+    const result = GoogleCalendarListSchema.safeParse([
+      { id: "primary@gmail.com", label: "Primary", primary: true, accessRole: "owner" },
+      { id: "other@group.calendar.google.com", label: "Shared", primary: false },
+    ]);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toHaveLength(2);
+    }
+  });
+
+  test("accepts an empty array", () => {
+    const result = GoogleCalendarListSchema.safeParse([]);
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects a non-array value", () => {
+    const result = GoogleCalendarListSchema.safeParse({ id: "x", label: "X", primary: false });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects an array containing an invalid item", () => {
+    const result = GoogleCalendarListSchema.safeParse([
+      { id: "good", label: "Good", primary: false },
+      { label: "Missing id", primary: true },
+    ]);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects a null response", () => {
+    const result = GoogleCalendarListSchema.safeParse(null);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects an error-shaped API response object", () => {
+    const result = GoogleCalendarListSchema.safeParse({
+      error: { code: 401, message: "Unauthorized" },
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/components/ui/googleCalendarSchemas.ts
+++ b/src/components/ui/googleCalendarSchemas.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const GoogleCalendarItemSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  primary: z.boolean(),
+  accessRole: z.string().optional(),
+  backgroundColor: z.string().optional(),
+});
+
+export const GoogleCalendarListSchema = z.array(GoogleCalendarItemSchema);
+
+export type GoogleCalendarItem = z.infer<typeof GoogleCalendarItemSchema>;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,14 @@ export default defineConfig({
           environment: "edge-runtime",
         },
       },
+      {
+        extends: true,
+        test: {
+          name: "src",
+          include: ["src/**/*.test.ts"],
+          environment: "node",
+        },
+      },
     ],
     coverage: {
       provider: "v8",


### PR DESCRIPTION
## Summary

- Add `GoogleCalendarItemSchema` and `GoogleCalendarListSchema` (Zod) in a new exported file `src/components/ui/googleCalendarSchemas.ts`
- Guard `listGoogleCalendars` result with `safeParse` before calling `.map()` in `openManagePicker` — invalid shapes now surface a clear error message via the existing catch block instead of throwing an unhandled exception that crashed the sheet
- Add a `src` vitest project so the exported schemas can be unit-tested independently (10 new tests)

## Test Plan

- [ ] Run `npm run test` — all 240 tests pass including 10 new schema tests
- [ ] Run `npx tsc --noEmit` — zero errors
- [ ] Run `npm run lint` — zero warnings/errors
- [ ] Run `npm run fmt:check` — all files correctly formatted
- [ ] Manual: open the Calendar Connections sheet and tap "Manage" on a Google connection — calendars load and the picker opens as expected
- [ ] Manual: to verify error path, temporarily break the schema (e.g. rename a field) and confirm the error banner is shown rather than a crash

## Checklist
- [x] TypeScript compiles with zero errors
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass

Closes #59

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate Google Calendar list API responses before mapping to stop the Manage picker from crashing and show a clear error when the shape is wrong. Adds reusable Zod schemas and applies them in the Google connection flow. Fixes #59.

- **Bug Fixes**
  - Guard `listGoogleCalendars` with `GoogleCalendarListSchema.safeParse`; on failure, the existing catch path shows the error banner instead of crashing.
  - Add `GoogleCalendarItemSchema` and `GoogleCalendarListSchema` in `src/components/ui/googleCalendarSchemas.ts`, plus 10 `vitest` tests and a `src` test project config.

<sup>Written for commit 32bd41639e07a660a29f3ab43ca7e8b9deb53fa1. Summary will update on new commits. <a href="https://cubic.dev/pr/ChazUK/crewcircle-app/pull/87?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

