### PR TITLE
feat(ui): #66 replace hardcoded colors in ProgressIndicator with HeroUI theme tokens

### DIFF
--- a/src/components/ui/ProgressIndicator.tsx
+++ b/src/components/ui/ProgressIndicator.tsx
@@ -1,3 +1,4 @@
+import { useThemeColor } from "heroui-native";
 import React from "react";
 import { StyleSheet, View } from "react-native";
 
@@ -10,6 +11,9 @@ type Props = {
 export function ProgressIndicator({ currentStep, totalSteps, className }: Props) {
   const safeTotalSteps = Math.min(5, Math.max(1, Math.trunc(totalSteps)));
   const safeCurrentStep = Math.min(safeTotalSteps, Math.max(1, Math.trunc(currentStep)));
+
+  const accentColor = useThemeColor("accent");
+  const defaultColor = useThemeColor("default");
 
   return (
     <View
@@ -30,9 +34,9 @@ export function ProgressIndicator({ currentStep, totalSteps, className }: Props)
             key={step}
             style={[
               styles.line,
-              isCompleted && styles.lineCompleted,
-              isActive && styles.lineActive,
-              !isCompleted && !isActive && styles.lineUpcoming,
+              isCompleted || isActive
+                ? { backgroundColor: accentColor }
+                : { backgroundColor: defaultColor },
             ]}
           />
         );
@@ -52,16 +56,5 @@ const styles = StyleSheet.create({
     flex: 1,
     height: 4,
     borderRadius: 2,
-  },
-  lineCompleted: {
-    backgroundColor: "#0a7ea4",
-  },
-  lineActive: {
-    height: 4,
-    borderRadius: 2,
-    backgroundColor: "#0a7ea4",
-  },
-  lineUpcoming: {
-    backgroundColor: "#ccc",
   },
 });


### PR DESCRIPTION
## Summary

- Replaced three hardcoded hex color values (`#0a7ea4`, `#ccc`) in `ProgressIndicator.tsx` with `useThemeColor('accent')` and `useThemeColor('default')` from `heroui-native`
- Removed duplicate `height`/`borderRadius` properties that were already set in the base `line` style
- Component now respects the HeroUI theme and will work correctly in dark mode

## Test Plan

- Open Storybook and verify `ProgressIndicator` stories (FirstStep, MiddleStep, LastStep, ThreeSteps) render correctly
- Toggle dark mode and confirm colors adapt (accent → dark accent, default muted grey → dark muted)
- No visual regression on existing onboarding flows

## Checklist
- [x] TypeScript compiles with zero errors
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass (240/240)

Closes #66

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements #66 by replacing hardcoded colors in `ProgressIndicator` with `useThemeColor('accent')` and `useThemeColor('default')` from `heroui-native`, so it respects HeroUI themes and dark mode. Also removes redundant style props and simplifies line state styles for a smaller, cleaner component.

<sup>Written for commit 4201b42223dc458851c108ae98d474996d45f646. Summary will update on new commits. <a href="https://cubic.dev/pr/ChazUK/crewcircle-app/pull/102?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

