### PR TITLE
feat(diary): #65 replace hardcoded calendar colors with HeroUI theme tokens

### DIFF
--- a/src/app/(home)/diary.tsx
+++ b/src/app/(home)/diary.tsx
@@ -1,6 +1,7 @@
 import { api } from "@convex/_generated/api";
 import { useQuery } from "convex/react";
 import { format } from "date-fns";
+import { useThemeColor } from "heroui-native";
 import { useMemo, useState } from "react";
 import { Pressable, Text, View } from "react-native";
 import { Calendar, DateData } from "react-native-calendars";
@@ -10,7 +11,6 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { CalendarConnectionsSheet } from "@/components/ui/CalendarConnectionsSheet";
 import { GearIcon } from "@/components/ui/icons/GearIcon";
 
-const ACCENT = "#6366f1";
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 function toIsoDate(ts: number): string {
@@ -45,6 +45,13 @@ export default function Diary() {
   const [isConnectionsOpen, setIsConnectionsOpen] = useState(false);
   const insets = useSafeAreaInsets();
 
+  const [accent, accentForeground, foreground, muted] = useThemeColor([
+    "accent",
+    "accent-foreground",
+    "foreground",
+    "muted",
+  ]);
+
   // Query a buffer around the visible month so dots show up on the adjacent-
   // month days that react-native-calendars includes on the grid edges.
   const { startsAtMs, endsAtMs } = useMemo(() => {
@@ -75,15 +82,15 @@ export default function Diary() {
       { marked?: boolean; dotColor?: string; selected?: boolean; selectedColor?: string }
     > = {};
     for (const key of Object.keys(eventsByDate)) {
-      m[key] = { marked: true, dotColor: ACCENT };
+      m[key] = { marked: true, dotColor: accent };
     }
     m[selectedDate] = {
       ...(m[selectedDate] ?? {}),
       selected: true,
-      selectedColor: ACCENT,
+      selectedColor: accent,
     };
     return m;
-  }, [eventsByDate, selectedDate]);
+  }, [eventsByDate, selectedDate, accent]);
 
   const sortedSelectedDayEvents = useMemo(() => {
     const dayStart = parseIsoDateLocal(selectedDate).getTime();
@@ -118,18 +125,18 @@ export default function Diary() {
           theme={{
             backgroundColor: "transparent",
             calendarBackground: "transparent",
-            selectedDayBackgroundColor: ACCENT,
-            selectedDayTextColor: "#ffffff",
-            todayTextColor: ACCENT,
-            dayTextColor: "#1f2937",
-            textDisabledColor: "#d1d5db",
-            monthTextColor: "#1f2937",
-            arrowColor: ACCENT,
+            selectedDayBackgroundColor: accent,
+            selectedDayTextColor: accentForeground,
+            todayTextColor: accent,
+            dayTextColor: foreground,
+            textDisabledColor: muted,
+            monthTextColor: foreground,
+            arrowColor: accent,
             textDayFontWeight: "400",
             textMonthFontWeight: "600",
             textDayHeaderFontWeight: "500",
-            dotColor: ACCENT,
-            selectedDotColor: "#ffffff",
+            dotColor: accent,
+            selectedDotColor: accentForeground,
           }}
           style={{ marginHorizontal: 8 }}
         />


### PR DESCRIPTION
## Summary

- Replaced the hardcoded `ACCENT = "#6366f1"` constant and all static hex values in the `react-native-calendars` theme object with `useThemeColor` calls
- Token mapping: `accent` for primary action colors, `accent-foreground` for text on accent backgrounds, `foreground` for day/month text, `muted` for disabled day text
- Calendar now adapts correctly to light/dark mode and custom HeroUI themes
- `markedDates` memo updated to depend on `accent` so dots/selected ring re-resolve when the theme changes

## Test Plan

- [ ] Open the Diary screen in light mode — calendar renders with correct indigo accent color
- [ ] Toggle dark mode — calendar text/arrow/dot colors adapt (foreground goes white, muted shifts lighter)
- [ ] Tap a day — selected day background uses `accent`, text uses `accent-foreground` (white)
- [ ] Navigate months — arrow color uses `accent`
- [ ] Days with events show dots in `accent` color

## Checklist

- [x] TypeScript compiles with zero errors
- [x] Lint passes (oxlint — 0 warnings, 0 errors)
- [x] Formatting passes (oxfmt)
- [x] Tests pass (240/240)

Closes #65

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced hardcoded Diary calendar colors with `useThemeColor` tokens so the UI adapts to light/dark mode and custom HeroUI themes. Implements #65.

- **Refactors**
  - Swapped `ACCENT` and hex values for `useThemeColor` tokens from `heroui-native`.
  - Token mapping: `accent` (selected bg, today, arrows, dots), `accent-foreground` (selected text/dot), `foreground` (day/month text), `muted` (disabled text) in `react-native-calendars`.
  - Made `markedDates` memo depend on `accent` so dots/selection update when the theme changes.

<sup>Written for commit 1acef2f12cc5081231fad32cd44f46b046df0c83. Summary will update on new commits. <a href="https://cubic.dev/pr/ChazUK/crewcircle-app/pull/103?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

