### PR TITLE
fix(calendars): #52 add pagination guard to deleteConnectionEvents

### DIFF
--- a/convex/calendars/db/writeEvents.test.ts
+++ b/convex/calendars/db/writeEvents.test.ts
@@ -170,7 +170,7 @@ describe("deleteConnectionEvents", () => {
         events: Array.from({ length: 5 }, (_, i) => event(`e${i}`)),
       }),
     );
-    await t.run((ctx) => deleteConnectionEvents(ctx, connectionId));
+    await t.run((ctx) => deleteConnectionEvents(ctx, connectionId, null));
     const rows = await t.run((ctx) =>
       ctx.db
         .query("calendarEvents")
@@ -182,7 +182,8 @@ describe("deleteConnectionEvents", () => {
 
   test("is a no-op when the connection has no events", async () => {
     const { t, connectionId } = await makeHarness();
-    await t.run((ctx) => deleteConnectionEvents(ctx, connectionId));
+    const { done } = await t.run((ctx) => deleteConnectionEvents(ctx, connectionId, null));
+    expect(done).toBe(true);
     const rows = await t.run((ctx) =>
       ctx.db
         .query("calendarEvents")
@@ -190,5 +191,39 @@ describe("deleteConnectionEvents", () => {
         .collect(),
     );
     expect(rows).toEqual([]);
+  });
+
+  test("returns done:false and a cursor when more than 200 events remain", async () => {
+    const { t, userId, connectionId } = await makeHarness();
+    await t.run(async (ctx) => {
+      for (let i = 0; i < 201; i++) {
+        await ctx.db.insert("calendarEvents", {
+          userId,
+          connectionId,
+          externalId: `e${i}`,
+          title: `event-${i}`,
+          startsAt: Date.now(),
+          endsAt: Date.now() + 60_000,
+          isAllDay: false,
+          updatedAt: Date.now(),
+        });
+      }
+    });
+
+    const first = await t.run((ctx) => deleteConnectionEvents(ctx, connectionId, null));
+    expect(first.done).toBe(false);
+
+    const second = await t.run((ctx) =>
+      deleteConnectionEvents(ctx, connectionId, first.continueCursor),
+    );
+    expect(second.done).toBe(true);
+
+    const remaining = await t.run((ctx) =>
+      ctx.db
+        .query("calendarEvents")
+        .withIndex("byConnection", (q) => q.eq("connectionId", connectionId))
+        .collect(),
+    );
+    expect(remaining).toEqual([]);
   });
 });

--- a/convex/calendars/db/writeEvents.ts
+++ b/convex/calendars/db/writeEvents.ts
@@ -75,14 +75,12 @@ export async function replaceConnectionEvents(
 export async function deleteConnectionEvents(
   ctx: MutationCtx,
   connectionId: Id<"calendarConnections">,
-) {
-  while (true) {
-    const batch = await ctx.db
-      .query("calendarEvents")
-      .withIndex("byConnection", (q) => q.eq("connectionId", connectionId))
-      .take(200);
-    if (batch.length === 0) break;
-    for (const row of batch) await ctx.db.delete(row._id);
-    if (batch.length < 200) break;
-  }
+  cursor: string | null,
+): Promise<{ done: boolean; continueCursor: string }> {
+  const result = await ctx.db
+    .query("calendarEvents")
+    .withIndex("byConnection", (q) => q.eq("connectionId", connectionId))
+    .paginate({ cursor, numItems: 200 });
+  for (const row of result.page) await ctx.db.delete(row._id);
+  return { done: result.isDone, continueCursor: result.continueCursor };
 }

--- a/convex/calendars/mutations.ts
+++ b/convex/calendars/mutations.ts
@@ -166,10 +166,39 @@ export const replaceEvents = internalMutation({
   },
 });
 
+export const deleteConnectionBatch = internalMutation({
+  args: {
+    connectionId: v.id("calendarConnections"),
+    cursor: v.union(v.string(), v.null()),
+  },
+  handler: async (ctx, args) => {
+    const { done, continueCursor } = await deleteConnectionEvents(
+      ctx,
+      args.connectionId,
+      args.cursor,
+    );
+    if (!done) {
+      await ctx.scheduler.runAfter(0, internal.calendars.mutations.deleteConnectionBatch, {
+        connectionId: args.connectionId,
+        cursor: continueCursor,
+      });
+    } else {
+      await ctx.db.delete(args.connectionId);
+    }
+  },
+});
+
 export const deleteConnection = internalMutation({
   args: { connectionId: v.id("calendarConnections") },
   handler: async (ctx, args) => {
-    await deleteConnectionEvents(ctx, args.connectionId);
-    await ctx.db.delete(args.connectionId);
+    const { done, continueCursor } = await deleteConnectionEvents(ctx, args.connectionId, null);
+    if (!done) {
+      await ctx.scheduler.runAfter(0, internal.calendars.mutations.deleteConnectionBatch, {
+        connectionId: args.connectionId,
+        cursor: continueCursor,
+      });
+    } else {
+      await ctx.db.delete(args.connectionId);
+    }
   },
 });


### PR DESCRIPTION
## Summary

- Replaced the unbounded `while (true)` loop in `deleteConnectionEvents` with Convex's `paginate()` API so each mutation call processes exactly one page of 200 events and returns `{ done, continueCursor }`
- `deleteConnection` now handles the first page synchronously (preserving existing behaviour for small calendars) and schedules the new `deleteConnectionBatch` internal mutation for any remaining pages
- `deleteConnectionBatch` self-schedules via `ctx.scheduler.runAfter(0, ...)` until all events are deleted, then removes the connection document — the same pattern used by `pruneDisabledSubCalendarEvents`

## Test Plan

- Added a new test (`returns done:false and a cursor when more than 200 events remain`) that inserts 201 events, calls `deleteConnectionEvents` twice with the continuation cursor, and asserts all events are gone
- Updated two existing `deleteConnectionEvents` test calls to pass the new required `cursor` parameter (`null` for first call)
- All 241 existing tests continue to pass

## Checklist

- [x] TypeScript compiles with zero errors
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass (241/241)

Closes #52

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #52 by adding a pagination guard to deleteConnectionEvents. Each call deletes one page (200) and schedules follow-ups, preventing long-running mutations and ensuring the connection is removed after all events are cleared.

- **Bug Fixes**
  - Replaced the unbounded loop with Convex `paginate()`; returns `{ done, continueCursor }`.
  - `deleteConnection` deletes the first page synchronously; new internal `deleteConnectionBatch` self-schedules until done, then deletes the connection.
  - Updated tests to pass the `cursor` param and added a case for >200 events.

<sup>Written for commit 086381ab955e1e319e8d0daab3fad0eb39329123. Summary will update on new commits. <a href="https://cubic.dev/pr/ChazUK/crewcircle-app/pull/104?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

