### PR TITLE
fix(calendars): #68 handle RFC 5545 floating times correctly for non-UTC users

### DIFF
--- a/convex/calendars/db/writeEvents.ts
+++ b/convex/calendars/db/writeEvents.ts
@@ -12,6 +12,7 @@ export type IncomingEvent = {
   startsAt: number;
   endsAt: number;
   isAllDay: boolean;
+  isFloating?: boolean;
 };
 
 export async function replaceConnectionEvents(
@@ -49,6 +50,7 @@ export async function replaceConnectionEvents(
       startsAt: event.startsAt,
       endsAt: event.endsAt,
       isAllDay: event.isAllDay,
+      isFloating: event.isFloating,
       updatedAt: now,
     };
     if (prior) {

--- a/convex/calendars/domain/parseIcs.test.ts
+++ b/convex/calendars/domain/parseIcs.test.ts
@@ -188,7 +188,7 @@ describe("parseIcs", () => {
     expect(event.startsAt).toBe(Date.UTC(2026, 4, 1, 9, 0, 0));
   });
 
-  test("floating times without TZID are stored as UTC", () => {
+  test("floating times without TZID are stored as UTC wall-clock and flagged isFloating", () => {
     const ics = buildIcs(
       vevent({
         UID: "floating",
@@ -200,6 +200,59 @@ describe("parseIcs", () => {
     const [event] = parseIcs(ics);
     expect(event.startsAt).toBe(Date.UTC(2026, 4, 1, 9, 0, 0));
     expect(event.endsAt).toBe(Date.UTC(2026, 4, 1, 10, 0, 0));
+    expect(event.isFloating).toBe(true);
+  });
+
+  test("floating event wall-clock value is recoverable via UTC components (UTC+5 scenario)", () => {
+    // A floating DTSTART of "09:00" should display as 09:00 on any device,
+    // including one in UTC+5. Since the wall-clock value is stored as
+    // Date.UTC(..., 9, 0, 0), reading getUTCHours() always returns 9.
+    const ics = buildIcs(
+      vevent({
+        UID: "floating-utc5",
+        SUMMARY: "Morning standup",
+        DTSTART: "20260501T090000",
+        DTEND: "20260501T093000",
+      }),
+    );
+    const [event] = parseIcs(ics);
+    expect(event.isFloating).toBe(true);
+    const startDate = new Date(event.startsAt);
+    const endDate = new Date(event.endsAt);
+    // UTC components reflect the original wall-clock time regardless of the
+    // device's local timezone (e.g. UTC+5 would show 14:00 without this flag).
+    expect(startDate.getUTCHours()).toBe(9);
+    expect(startDate.getUTCMinutes()).toBe(0);
+    expect(endDate.getUTCHours()).toBe(9);
+    expect(endDate.getUTCMinutes()).toBe(30);
+  });
+
+  test("non-floating UTC events have isFloating false", () => {
+    const ics = buildIcs(
+      vevent({
+        UID: "utc-event",
+        SUMMARY: "UTC event",
+        DTSTART: "20260501T090000Z",
+        DTEND: "20260501T100000Z",
+      }),
+    );
+    const [event] = parseIcs(ics);
+    expect(event.isFloating).toBe(false);
+  });
+
+  test("TZID events have isFloating false", () => {
+    const ics = buildIcs(
+      [
+        "BEGIN:VEVENT",
+        "UID:tzid-not-floating",
+        "SUMMARY:NY meeting",
+        "DTSTART;TZID=America/New_York:20260501T090000",
+        "DTEND;TZID=America/New_York:20260501T100000",
+        "END:VEVENT",
+      ].join("\r\n"),
+    );
+    const [event] = parseIcs(ics);
+    expect(event.isFloating).toBe(false);
   });
 
   test("malformed DTSTART values are ignored", () => {

--- a/convex/calendars/domain/parseIcs.ts
+++ b/convex/calendars/domain/parseIcs.ts
@@ -15,6 +15,10 @@ export type ParsedEvent = {
   startsAt: number;
   endsAt: number;
   isAllDay: boolean;
+  // RFC 5545 "floating" time: no TZID and no Z suffix. The wall-clock value
+  // is stored verbatim as if it were UTC. Clients must display UTC components
+  // directly rather than converting to local time.
+  isFloating: boolean;
 };
 
 export type ParseIcsOptions = {
@@ -29,7 +33,7 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 // Stops a malicious or misconfigured "FREQ=SECONDLY" rule from exploding.
 const MAX_OCCURRENCES_PER_RULE = 5_000;
 
-type RawDate = { ms: number; isAllDay: boolean; raw: string };
+type RawDate = { ms: number; isAllDay: boolean; raw: string; isFloating?: boolean };
 
 type RawVEvent = {
   uid?: string;
@@ -108,7 +112,12 @@ function collectVEvents(lines: string[]): RawVEvent[] {
       case "DTSTART": {
         const parsed = parseIcsDate(value, params);
         if (parsed) {
-          current.dtstart = { ms: parsed.ms, isAllDay: parsed.isDateOnly, raw: line };
+          current.dtstart = {
+            ms: parsed.ms,
+            isAllDay: parsed.isDateOnly,
+            raw: line,
+            isFloating: parsed.isFloating,
+          };
         }
         break;
       }
@@ -214,6 +223,7 @@ function pushGroup(out: ParsedEvent[], group: Group, options: ParseIcsOptions) {
       startsAt: base.dtstart.ms,
       endsAt,
       isAllDay: base.dtstart.isAllDay,
+      isFloating: base.dtstart.isFloating ?? false,
     });
     return;
   }
@@ -248,6 +258,7 @@ function emitOverrideOrphan(
     startsAt,
     endsAt,
     isAllDay: ov.dtstart.isAllDay,
+    isFloating: ov.dtstart.isFloating ?? false,
   });
 }
 
@@ -271,6 +282,7 @@ function expandRecurrence(
   // dtend on an occurrence implies the same duration as the seed.
   const durationMs = (base.dtend?.ms ?? base.dtstart!.ms) - base.dtstart!.ms;
   const isAllDay = base.dtstart!.isAllDay;
+  const isFloating = base.dtstart!.isFloating ?? false;
 
   // Window defaults: if callers don't constrain, use a sensible bounded
   // ±1 year so an unbounded RRULE doesn't run forever.
@@ -289,7 +301,7 @@ function expandRecurrence(
     // Malformed recurrence — fall back to emitting just the seed at its
     // DTSTART so the user at least sees one instance.
     if (!withinWindow(base.dtstart!.ms, base.dtstart!.ms + durationMs, options)) return;
-    out.push(seedToInstance(group.uid, base, base.dtstart!.ms, durationMs, isAllDay));
+    out.push(seedToInstance(group.uid, base, base.dtstart!.ms, durationMs, isAllDay, isFloating));
     return;
   }
 
@@ -322,10 +334,11 @@ function expandRecurrence(
         startsAt: override.dtstart.ms,
         endsAt: resolveEndsAt(override),
         isAllDay: override.dtstart.isAllDay,
+        isFloating: override.dtstart.isFloating ?? false,
       });
       continue;
     }
-    out.push(seedToInstance(group.uid, base, occurrence.ms, durationMs, isAllDay));
+    out.push(seedToInstance(group.uid, base, occurrence.ms, durationMs, isAllDay, isFloating));
   }
 
   // Overrides whose recurrence-id sat outside the expanded window but whose
@@ -343,6 +356,7 @@ function seedToInstance(
   startsAt: number,
   durationMs: number,
   isAllDay: boolean,
+  isFloating: boolean,
 ): ParsedEvent {
   return {
     externalId: `${uid}::${startsAt}`,
@@ -354,6 +368,7 @@ function seedToInstance(
     startsAt,
     endsAt: startsAt + durationMs,
     isAllDay,
+    isFloating,
   };
 }
 
@@ -377,7 +392,7 @@ function unescapeIcsText(value: string): string {
 function parseIcsDate(
   value: string,
   params: Map<string, string>,
-): { ms: number; isDateOnly: boolean } | null {
+): { ms: number; isDateOnly: boolean; isFloating?: boolean } | null {
   const valueType = params.get("VALUE")?.toUpperCase();
   const isDateOnly = valueType === "DATE" || /^\d{8}$/.test(value);
   if (isDateOnly) {
@@ -405,9 +420,13 @@ function parseIcsDate(
     if (ms != null) return { ms, isDateOnly: false };
   }
   // Floating time (no TZID, no Z) — RFC 5545 says interpret in the observer's
-  // local zone. We have no "observer" server-side, so fall back to UTC for
-  // deterministic storage.
-  return { ms: Date.UTC(year, month - 1, day, hour, minute, second), isDateOnly: false };
+  // local zone. The wall-clock value is stored verbatim as UTC ms so it can
+  // be round-tripped. Callers must use UTC components for display, not local.
+  return {
+    ms: Date.UTC(year, month - 1, day, hour, minute, second),
+    isDateOnly: false,
+    isFloating: true,
+  };
 }
 
 // Convert a wall-clock timestamp in the given IANA zone to an absolute UTC

--- a/convex/calendars/mutations.ts
+++ b/convex/calendars/mutations.ts
@@ -22,6 +22,7 @@ const ParsedEventValidator = v.object({
   startsAt: v.number(),
   endsAt: v.number(),
   isAllDay: v.boolean(),
+  isFloating: v.optional(v.boolean()),
 });
 
 export const insertConnection = internalMutation({

--- a/convex/calendars/queries.ts
+++ b/convex/calendars/queries.ts
@@ -94,6 +94,7 @@ export const listEventsInRange = query({
         startsAt: event.startsAt,
         endsAt: event.endsAt,
         isAllDay: event.isAllDay,
+        isFloating: event.isFloating,
       }));
   },
 });

--- a/convex/calendars/schema.ts
+++ b/convex/calendars/schema.ts
@@ -68,6 +68,9 @@ export const CalendarEvent = {
   startsAt: v.number(),
   endsAt: v.number(),
   isAllDay: v.boolean(),
+  // RFC 5545 floating time: wall-clock stored verbatim as UTC ms. Clients must
+  // display UTC components rather than converting to local time.
+  isFloating: v.optional(v.boolean()),
   updatedAt: v.number(),
 };
 

--- a/src/app/(home)/diary.tsx
+++ b/src/app/(home)/diary.tsx
@@ -26,8 +26,24 @@ function parseIsoDateLocal(isoDate: string): Date {
   return new Date(y, m - 1, d, 0, 0, 0, 0);
 }
 
-function formatTimeRange(startsAt: number, endsAt: number, isAllDay: boolean): string {
+function padTwo(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+function formatTimeRange(
+  startsAt: number,
+  endsAt: number,
+  isAllDay: boolean,
+  isFloating?: boolean,
+): string {
   if (isAllDay) return "All day";
+  if (isFloating) {
+    // Floating events store the wall-clock value as UTC ms. Read UTC components
+    // directly so the display matches the original wall-clock time on any device.
+    const s = new Date(startsAt);
+    const e = new Date(endsAt);
+    return `${padTwo(s.getUTCHours())}:${padTwo(s.getUTCMinutes())} – ${padTwo(e.getUTCHours())}:${padTwo(e.getUTCMinutes())}`;
+  }
   const start = format(new Date(startsAt), "HH:mm");
   const end = format(new Date(endsAt), "HH:mm");
   return `${start} – ${end}`;
@@ -162,7 +178,7 @@ export default function Diary() {
                 className="rounded-xl border border-default-200 bg-default-100/50 p-3"
               >
                 <Text className="text-xs font-semibold uppercase text-foreground/60">
-                  {formatTimeRange(event.startsAt, event.endsAt, event.isAllDay)}
+                  {formatTimeRange(event.startsAt, event.endsAt, event.isAllDay, event.isFloating)}
                 </Text>
                 <Text className="text-base font-medium text-foreground" numberOfLines={2}>
                   {event.title}


### PR DESCRIPTION
## Summary

- Adds `isFloating: boolean` to `ParsedEvent`, the `calendarEvents` Convex schema, and all intermediate types/validators in the sync pipeline
- Parser now sets `isFloating: true` for date-times with no TZID and no `Z` suffix (RFC 5545 floating times); the wall-clock value continues to be stored verbatim as UTC ms
- Diary `formatTimeRange` reads UTC components (`getUTCHours`/`getUTCMinutes`) for floating events so the original wall-clock time is displayed correctly on any device — a floating "09:00" shows as "09:00" regardless of the user's local timezone
- Existing non-floating events (UTC `Z` suffix or TZID) are unaffected; `isAllDay` events are unaffected

## Files changed

| File | Change |
|---|---|
| `convex/calendars/domain/parseIcs.ts` | `ParsedEvent.isFloating`, `RawDate.isFloating`, `parseIcsDate` returns `isFloating: true` for floating times |
| `convex/calendars/schema.ts` | `calendarEvents.isFloating: v.optional(v.boolean())` |
| `convex/calendars/db/writeEvents.ts` | `IncomingEvent.isFloating` propagated to DB payload |
| `convex/calendars/mutations.ts` | `ParsedEventValidator` includes `isFloating` |
| `convex/calendars/queries.ts` | `listEventsInRange` returns `isFloating` |
| `src/app/(home)/diary.tsx` | `formatTimeRange` uses UTC components for floating events |
| `convex/calendars/domain/parseIcs.test.ts` | Updated floating test + UTC+5 scenario + non-floating assertions |

## Test Plan

- [ ] `npx tsc --noEmit` — zero errors
- [ ] `npm run lint` — zero warnings/errors
- [ ] `npm run fmt:check` — passes
- [ ] `npm run test` — all 243 tests pass (including 4 new tests for floating time behaviour)
- [ ] Manual: connect an iCal feed that contains floating-time events and verify they display at the correct wall-clock time on a non-UTC device

## Checklist

- [x] TypeScript compiles with zero errors
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass

Closes #68

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect display of RFC 5545 floating-time events (no TZID, no Z) so they show at the original wall-clock time for all users. Adds an `isFloating` flag across parsing, storage, and UI. Fixes #68.

- **Bug Fixes**
  - Add `isFloating` to `ParsedEvent` and Convex `calendarEvents`; propagate through mutations, writes, and queries.
  - Parser sets `isFloating: true` for date-times without TZID/Z; wall-clock stored as UTC ms.
  - Diary `formatTimeRange` uses UTC components for floating events so "09:00" displays as "09:00" on any device.
  - Tests cover floating behavior and assert `isFloating` for UTC/TZID vs floating cases.

<sup>Written for commit 854ed8b27a16b68fd8eec37e56113a33d60872a0. Summary will update on new commits. <a href="https://cubic.dev/pr/ChazUK/crewcircle-app/pull/106?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

