### PR TITLE
test(calendars): #72 add empty-batch and mixed-batch tests for replaceConnectionEvents

### DIFF
--- a/convex/calendars/db/writeEvents.test.ts
+++ b/convex/calendars/db/writeEvents.test.ts
@@ -130,6 +130,54 @@ describe("replaceConnectionEvents", () => {
     expect(rows[0].title).toBe("second");
   });
 
+  test("empty batch removes all existing events for the connection", async () => {
+    const { t, userId, connectionId } = await makeHarness();
+    await t.run((ctx) =>
+      replaceConnectionEvents(ctx, {
+        connectionId,
+        userId,
+        events: [event("a"), event("b"), event("c")],
+      }),
+    );
+    await t.run((ctx) => replaceConnectionEvents(ctx, { connectionId, userId, events: [] }));
+    const rows = await t.run((ctx) =>
+      ctx.db
+        .query("calendarEvents")
+        .withIndex("byConnection", (q) => q.eq("connectionId", connectionId))
+        .collect(),
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  test("mixed batch inserts, updates, and deletes in one call", async () => {
+    const { t, userId, connectionId } = await makeHarness();
+    await t.run((ctx) =>
+      replaceConnectionEvents(ctx, {
+        connectionId,
+        userId,
+        events: [event("keep", "original"), event("update-me", "old"), event("delete-me")],
+      }),
+    );
+    await t.run((ctx) =>
+      replaceConnectionEvents(ctx, {
+        connectionId,
+        userId,
+        events: [event("keep", "original"), event("update-me", "new"), event("brand-new")],
+      }),
+    );
+    const rows = await t.run((ctx) =>
+      ctx.db
+        .query("calendarEvents")
+        .withIndex("byConnection", (q) => q.eq("connectionId", connectionId))
+        .collect(),
+    );
+    const byId = Object.fromEntries(rows.map((r) => [r.externalId, r]));
+    expect(Object.keys(byId).sort()).toEqual(["brand-new", "keep", "update-me"]);
+    expect(byId["delete-me"]).toBeUndefined();
+    expect(byId["update-me"].title).toBe("new");
+    expect(byId["brand-new"].title).toBe("brand-new");
+  });
+
   test("does not touch events on other connections", async () => {
     const { t, userId, connectionId } = await makeHarness();
     const otherConnectionId = await t.run((ctx) =>


### PR DESCRIPTION
## Summary

- Adds two missing test cases from issue #72 to `convex/calendars/db/writeEvents.test.ts`
- **Empty batch** — passing `events: []` removes all existing Calendar Events for a Connection
- **Mixed batch** — a single call that inserts new events, patches existing ones, and deletes stale ones all at once

The other three required cases (insert, patch/no-duplicate, stale deletion) were already covered by existing tests in this file.

## Test Plan

- `npm run test` → 243 tests pass (2 new)
- `npx tsc --noEmit` → zero errors
- `npm run lint` → zero warnings/errors
- `npm run fmt:check` → all files formatted correctly

## Checklist
- [x] TypeScript compiles with zero errors
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass

Closes #72

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two missing tests for `replaceConnectionEvents` to cover empty and mixed batches, completing the cases required by #72. Confirms that `events: []` clears all events for a connection, and a mixed batch inserts, updates, and deletes in one call.

<sup>Written for commit 4700c64ac5400ad6c641547d6ba9c75f2e515911. Summary will update on new commits. <a href="https://cubic.dev/pr/ChazUK/crewcircle-app/pull/107?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

