### PR TITLE
feat(calendars): #89 rename provider literals apple→native and outlook→microsoft

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -18,6 +18,7 @@ import type * as calendars_domain_googleEvents from "../calendars/domain/googleE
 import type * as calendars_domain_icalUrl from "../calendars/domain/icalUrl.js";
 import type * as calendars_domain_parseIcs from "../calendars/domain/parseIcs.js";
 import type * as calendars_google from "../calendars/google.js";
+import type * as calendars_migrations from "../calendars/migrations.js";
 import type * as calendars_mutations from "../calendars/mutations.js";
 import type * as calendars_queries from "../calendars/queries.js";
 import type * as calendars_scheduler from "../calendars/scheduler.js";
@@ -51,6 +52,7 @@ declare const fullApi: ApiFromModules<{
   "calendars/domain/icalUrl": typeof calendars_domain_icalUrl;
   "calendars/domain/parseIcs": typeof calendars_domain_parseIcs;
   "calendars/google": typeof calendars_google;
+  "calendars/migrations": typeof calendars_migrations;
   "calendars/mutations": typeof calendars_mutations;
   "calendars/queries": typeof calendars_queries;
   "calendars/scheduler": typeof calendars_scheduler;

--- a/convex/calendars/actions.test.ts
+++ b/convex/calendars/actions.test.ts
@@ -267,7 +267,7 @@ describe("uploadAppleEvents", () => {
     const connectionId = await t.run((ctx) =>
       ctx.db.insert("calendarConnections", {
         userId: owner,
-        provider: "apple",
+        provider: "native",
         label: "Not mine",
         enabledSubCalendarIds: [],
         createdAt: Date.now(),
@@ -305,7 +305,7 @@ describe("uploadAppleEvents", () => {
     const connectionId = await t.run((ctx) =>
       ctx.db.insert("calendarConnections", {
         userId,
-        provider: "apple",
+        provider: "native",
         label: "Apple",
         enabledSubCalendarIds: ["cal"],
         createdAt: Date.now(),
@@ -362,7 +362,7 @@ describe("syncConnection", () => {
     const connectionId = await t.run((ctx) =>
       ctx.db.insert("calendarConnections", {
         userId,
-        provider: "apple",
+        provider: "native",
         label: "Apple",
         createdAt: Date.now(),
       }),
@@ -418,7 +418,7 @@ describe("syncIcalConnectionInternal", () => {
     const connectionId = await t.run((ctx) =>
       ctx.db.insert("calendarConnections", {
         userId,
-        provider: "apple",
+        provider: "native",
         label: "Apple",
         createdAt: Date.now(),
       }),
@@ -439,7 +439,7 @@ describe("setEnabledSubCalendars", () => {
     const connectionId = await t.run((ctx) =>
       ctx.db.insert("calendarConnections", {
         userId,
-        provider: "apple",
+        provider: "native",
         label: "Apple",
         enabledSubCalendarIds: ["cal-1"],
         createdAt: Date.now(),

--- a/convex/calendars/actions.ts
+++ b/convex/calendars/actions.ts
@@ -119,7 +119,7 @@ export const connectApple = action({
       internal.calendars.mutations.insertConnection,
       {
         userId: user._id,
-        provider: "apple",
+        provider: "native",
         label: args.label,
         enabledSubCalendarIds: args.enabledSubCalendarIds,
       },
@@ -149,7 +149,7 @@ export const uploadAppleEvents = action({
       { connectionId: args.connectionId, userId: user._id },
     );
     if (!connection) throw new Error("Calendar connection not found");
-    if (connection.provider !== "apple") {
+    if (connection.provider !== "native") {
       throw new Error("uploadAppleEvents only supports Apple calendars");
     }
     await ctx.runMutation(internal.calendars.mutations.replaceEvents, {
@@ -202,8 +202,8 @@ export const syncConnection = action({
       return null;
     }
 
-    if (connection.provider === "apple") {
-      // Apple events originate on-device; the client must call uploadAppleEvents.
+    if (connection.provider === "native") {
+      // Native (Apple) events originate on-device; the client must call uploadAppleEvents.
       throw new Error("Apple calendars must be re-synced from the device");
     }
 

--- a/convex/calendars/migrations.ts
+++ b/convex/calendars/migrations.ts
@@ -1,0 +1,55 @@
+import { v } from "convex/values";
+
+import { internal } from "../_generated/api";
+import { internalAction, internalMutation } from "../_generated/server";
+
+const PAGE_SIZE = 100;
+
+/**
+ * Rename provider literals: "apple" → "native", "outlook" → "microsoft".
+ * Run once after deploying the updated schema.
+ */
+export const migrateProviderNames = internalAction({
+  args: {},
+  handler: async (ctx): Promise<{ patched: number }> => {
+    let cursor: string | null = null;
+    let totalPatched = 0;
+    while (true) {
+      const result: { patched: number; done: boolean; nextCursor: string | null } =
+        await ctx.runMutation(internal.calendars.migrations.migrateProviderNamesPage, { cursor });
+      totalPatched += result.patched;
+      if (result.done) break;
+      cursor = result.nextCursor;
+    }
+    return { patched: totalPatched };
+  },
+});
+
+export const migrateProviderNamesPage = internalMutation({
+  args: { cursor: v.union(v.string(), v.null()) },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{ patched: number; done: boolean; nextCursor: string | null }> => {
+    const page = await ctx.db
+      .query("calendarConnections")
+      .paginate({ numItems: PAGE_SIZE, cursor: args.cursor });
+
+    let patched = 0;
+    for (const row of page.page) {
+      const provider = row.provider as string;
+      if (provider === "apple") {
+        await ctx.db.patch(row._id, { provider: "native" });
+        patched++;
+      } else if (provider === "outlook") {
+        await ctx.db.patch(row._id, { provider: "microsoft" });
+        patched++;
+      }
+    }
+    return {
+      patched,
+      done: page.isDone,
+      nextCursor: page.isDone ? null : page.continueCursor,
+    };
+  },
+});

--- a/convex/calendars/scheduler.test.ts
+++ b/convex/calendars/scheduler.test.ts
@@ -98,7 +98,7 @@ describe("listConnectionsPage", () => {
 describe("syncAllConnections", () => {
   const TEST_KEY = Buffer.alloc(32, 0).toString("base64");
 
-  test("kicks off per-provider syncs for Google and iCal and skips Apple/Outlook", async () => {
+  test("kicks off per-provider syncs for Google and iCal and skips native/microsoft", async () => {
     vi.stubEnv("CALENDAR_ENCRYPTION_KEY", TEST_KEY);
 
     // Route responses by URL so Google API calls get JSON and iCal fetches
@@ -152,13 +152,13 @@ describe("syncAllConnections", () => {
       });
       await ctx.db.insert("calendarConnections", {
         userId,
-        provider: "apple",
+        provider: "native",
         label: "Apple",
         createdAt: Date.now(),
       });
       await ctx.db.insert("calendarConnections", {
         userId,
-        provider: "outlook",
+        provider: "microsoft",
         label: "Outlook",
         createdAt: Date.now(),
       });
@@ -172,8 +172,8 @@ describe("syncAllConnections", () => {
     const byProvider = Object.fromEntries(connections.map((c) => [c.provider, c]));
     expect(byProvider.ical.lastSyncedAt).toBeTruthy();
     expect(byProvider.google.lastSyncedAt).toBeTruthy();
-    expect(byProvider.apple.lastSyncedAt).toBeUndefined();
-    expect(byProvider.outlook.lastSyncedAt).toBeUndefined();
+    expect(byProvider.native.lastSyncedAt).toBeUndefined();
+    expect(byProvider.microsoft.lastSyncedAt).toBeUndefined();
 
     // The Google sync actually pulled the stubbed event into the cache.
     const googleEvents = await t.run((ctx) =>

--- a/convex/calendars/scheduler.ts
+++ b/convex/calendars/scheduler.ts
@@ -24,9 +24,9 @@ export const syncAllConnections = internalAction({
       );
 
       for (const connection of page.page) {
-        // Apple events live on the device; the client must push them via
-        // uploadAppleEvents. Outlook isn't implemented yet.
-        if (connection.provider === "apple" || connection.provider === "outlook") continue;
+        // Native (Apple) events live on the device; the client must push them via
+        // uploadAppleEvents. Microsoft (Outlook) isn't implemented yet.
+        if (connection.provider === "native" || connection.provider === "microsoft") continue;
 
         if (connection.provider === "google") {
           await ctx.scheduler.runAfter(0, internal.calendars.google.syncGoogleConnectionInternal, {

--- a/convex/calendars/schema.ts
+++ b/convex/calendars/schema.ts
@@ -3,8 +3,8 @@ import { v } from "convex/values";
 
 export const CalendarProvider = v.union(
   v.literal("google"),
-  v.literal("apple"),
-  v.literal("outlook"),
+  v.literal("native"),
+  v.literal("microsoft"),
   v.literal("ical"),
 );
 
@@ -17,11 +17,11 @@ export const CalendarConnection = {
   externalAccountId: v.optional(v.string()),
   // For provider="ical" — the subscription URL
   icalUrl: v.optional(v.string()),
-  // For provider="apple" — the on-device calendar id from expo-calendar
+  // For provider="native" — the on-device calendar id from expo-calendar
   localCalendarId: v.optional(v.string()),
-  // For provider="google" / "outlook" — OAuth scope granted
+  // For provider="google" / "microsoft" — OAuth scope granted
   scope: v.optional(v.string()),
-  // For provider="google" / "outlook" — the OAuth client_id that issued the tokens.
+  // For provider="google" / "microsoft" — the OAuth client_id that issued the tokens.
   // Refresh-token exchange must be made against the same client, so it's persisted here.
   oauthClientId: v.optional(v.string()),
   // Encrypted JSON blob: { accessToken, refreshToken, tokenType }

--- a/src/components/ui/CalendarConnectionsSheet.tsx
+++ b/src/components/ui/CalendarConnectionsSheet.tsx
@@ -77,8 +77,8 @@ const PROVIDER_META: Record<
   { title: string; Icon: React.ComponentType<{ size?: number }> }
 > = {
   google: { title: "Google Calendar", Icon: GoogleCalendarIcon },
-  apple: { title: "Apple Calendar", Icon: AppleCalendarIcon },
-  outlook: { title: "Outlook", Icon: OutlookCalendarIcon },
+  native: { title: "Apple Calendar", Icon: AppleCalendarIcon },
+  microsoft: { title: "Outlook", Icon: OutlookCalendarIcon },
   ical: { title: "iCal URL", Icon: LinkCalendarIcon },
 };
 
@@ -186,7 +186,7 @@ export function CalendarConnectionsSheet({ isOpen, onOpenChange, _initialSyncWar
       provider: Provider;
       currentIds: string[];
     }) => {
-      if (args.provider === "ical" || args.provider === "outlook") return;
+      if (args.provider === "ical" || args.provider === "microsoft") return;
       setError(null);
       setBusy(args.connectionId);
       try {
@@ -202,7 +202,7 @@ export function CalendarConnectionsSheet({ isOpen, onOpenChange, _initialSyncWar
             label: item.label,
             hint: item.primary ? "Primary" : item.accessRole,
           }));
-        } else if (args.provider === "apple") {
+        } else if (args.provider === "native") {
           const permission = await Calendar.requestCalendarPermissionsAsync();
           if (permission.status !== "granted") {
             throw new Error("Calendar permission is required");
@@ -235,8 +235,8 @@ export function CalendarConnectionsSheet({ isOpen, onOpenChange, _initialSyncWar
         connectionId: target.connectionId,
         enabledSubCalendarIds: pickedIds,
       });
-      if (target.provider === "apple") {
-        // For Apple the server can't sync on its own; push events from the device.
+      if (target.provider === "native") {
+        // For native (Apple) calendars the server can't sync on its own; push events from the device.
         const events = await readAppleEvents(pickedIds);
         await uploadAppleEvents({ connectionId: target.connectionId, events });
       }
@@ -403,7 +403,7 @@ export function CalendarConnectionsSheet({ isOpen, onOpenChange, _initialSyncWar
       setBusy(connection._id);
       setError(null);
       try {
-        if (connection.provider === "apple") {
+        if (connection.provider === "native") {
           const ids = connection.enabledSubCalendarIds ?? [];
           if (ids.length === 0) {
             throw new Error("No calendars selected for this Apple connection");
@@ -448,13 +448,13 @@ export function CalendarConnectionsSheet({ isOpen, onOpenChange, _initialSyncWar
         onPress: handleConnectGoogle,
       },
       {
-        key: "apple" as const,
+        key: "native" as const,
         title: "Apple Calendar",
         Icon: AppleCalendarIcon,
         onPress: handleStartApple,
       },
       {
-        key: "outlook" as const,
+        key: "microsoft" as const,
         title: "Outlook",
         Icon: OutlookCalendarIcon,
         onPress: handleOutlook,
@@ -510,7 +510,7 @@ export function CalendarConnectionsSheet({ isOpen, onOpenChange, _initialSyncWar
                     const isBusyRow = busy === connection._id;
                     const isExpanded = expandedId === connection._id;
                     const hasSubCalendars =
-                      connection.provider === "google" || connection.provider === "apple";
+                      connection.provider === "google" || connection.provider === "native";
 
                     return (
                       <Fragment key={connection._id}>
@@ -544,7 +544,7 @@ export function CalendarConnectionsSheet({ isOpen, onOpenChange, _initialSyncWar
                               <Text className="text-sm text-muted-foreground">
                                 iCal feeds are a single subscription — no sub-calendars to pick.
                               </Text>
-                            ) : connection.provider === "outlook" ? (
+                            ) : connection.provider === "microsoft" ? (
                               <Text className="text-sm text-muted-foreground">
                                 Outlook support isn't wired up yet.
                               </Text>


### PR DESCRIPTION
## Summary

- Renames the `CalendarProvider` union in `convex/calendars/schema.ts`: `"apple"` → `"native"`, `"outlook"` → `"microsoft"`
- Adds `convex/calendars/migrations.ts` — a paginated `internalAction` + `internalMutation` pair that rewrites any existing `calendarConnections` rows with the old provider literals (run once after deploying)
- Updates all references across the Convex backend (`actions.ts`, `scheduler.ts`) and the React Native client (`CalendarConnectionsSheet.tsx`)
- Updates all test fixtures to use the new literals

This is a pure rename with no behaviour change. All other issues in the Calendar Sync Orchestrator feature depend on this migration landing first.

## Test Plan

- [x] `npx tsc --noEmit` — zero errors
- [x] `npm run lint` — zero warnings/errors
- [x] `npm run fmt:check` — all files correctly formatted
- [x] `npm run test` — 243 tests pass (21 test files)

## Checklist
- [x] TypeScript compiles with zero errors
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass

Closes #89

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed calendar provider literals across the app: `apple` → `native` and `outlook` → `microsoft`, and added a Convex data migration to update existing `calendarConnections`. No behavior changes. Addresses Linear #89 and unblocks follow-ups in the Calendar Sync Orchestrator.

- **Migration**
  - After deploy, run `internal.calendars.migrations.migrateProviderNames` once to rewrite existing rows (paginated, idempotent).
  - Update any external references to use `native` and `microsoft` if they exist outside this repo.

<sup>Written for commit b171164c981d495566a09e98b291ea7c1af6513d. Summary will update on new commits. <a href="https://cubic.dev/pr/ChazUK/crewcircle-app/pull/108?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

