### PR TITLE
feat(calendars): #91 CalendarProvider types, adapter stubs, and orchestrator shell

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,23 @@ Convex agent skills for common tasks can be installed by running `npx convex ai-
 
 <!-- convex-ai-end -->
 
+## Code Boundaries
+
+The codebase has three distinct runtime zones. Never mix imports across these boundaries:
+
+| Zone         | Directory | May import from                                               |
+| ------------ | --------- | ------------------------------------------------------------- |
+| Shared types | `types/`  | Nothing — pure TypeScript types only, no runtime dependencies |
+| Server       | `convex/` | `@shared/*`, `@convex/_generated/*`, npm packages             |
+| Client       | `src/`    | `@shared/*`, `@/*`, `@convex/_generated/*`, npm packages      |
+
+**Rules:**
+
+- `types/` files must contain only type definitions — no `import` of anything with a runtime (no React Native, no Convex functions, no Node built-ins). Use `import type` for any cross-references within `types/`.
+- `convex/` must never import from `src/` — server code must not depend on client/device APIs.
+- `src/` must never import from `convex/` directly — only via the generated client at `@convex/_generated/`.
+- All new shared types (types used by both `convex/` and `src/`) go in `types/` and are imported via `@shared/*`.
+
 ## Agent skills
 
 ### Issue tracker

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -166,6 +166,12 @@ _Avoid_: Date range, fetch window, sync range
 
 ---
 
+## Shared types
+
+Types that must be used by both `convex/` (server) and `src/` (client) live in `types/` at the repo root and are imported via the `@shared/*` alias (e.g. `import type { IncomingEvent } from "@shared/calendars"`).
+
+`types/` files must contain **only pure TypeScript type definitions** — no runtime imports. This boundary is what prevents server and client code from mixing. See `CLAUDE.md` → Code Boundaries for the full rules.
+
 ## Industry Context
 
 **Diary Service**:

--- a/convex/calendars/actions.ts
+++ b/convex/calendars/actions.ts
@@ -5,6 +5,7 @@ import { Doc, Id } from "../_generated/dataModel";
 import { ActionCtx, action, internalAction } from "../_generated/server";
 import { assertSafeIcalUrl, safeHostname } from "./domain/icalUrl";
 import { parseIcs } from "./domain/parseIcs";
+import { currentSyncWindow } from "./orchestrator";
 
 const EventInputValidator = v.object({
   externalId: v.string(),
@@ -26,11 +27,6 @@ async function requireUser(ctx: ActionCtx): Promise<Doc<"users">> {
 }
 
 const MAX_ICAL_REDIRECTS = 5;
-
-// Match the Apple/Google sync windows so iCal recurrence expansion materialises
-// the same horizon (30 days back, 180 days forward) into calendarEvents.
-const ICAL_WINDOW_PAST_MS = 30 * 24 * 60 * 60 * 1000;
-const ICAL_WINDOW_FUTURE_MS = 180 * 24 * 60 * 60 * 1000;
 
 // Walk redirects manually so we can re-run the SSRF hostname check on every
 // Location header. With `redirect: "follow"` the browser would happily send us
@@ -60,11 +56,7 @@ async function fetchAndStoreIcal(
   const res = await fetchIcalWithSafeRedirects(args.url);
   if (!res.ok) throw new Error(`Failed to fetch iCal feed (status ${res.status})`);
   const body = await res.text();
-  const now = Date.now();
-  const events = parseIcs(body, {
-    windowStartMs: now - ICAL_WINDOW_PAST_MS,
-    windowEndMs: now + ICAL_WINDOW_FUTURE_MS,
-  });
+  const events = parseIcs(body, currentSyncWindow());
   await ctx.runMutation(internal.calendars.mutations.replaceEvents, {
     connectionId: args.connectionId,
     userId: args.userId,

--- a/convex/calendars/adapters/google.ts
+++ b/convex/calendars/adapters/google.ts
@@ -1,0 +1,29 @@
+import type {
+  CalendarProvider,
+  CalendarProviderCapabilities,
+  IncomingEvent,
+  SyncWindow,
+  WriteError,
+} from "../orchestrator/types";
+
+export const googleCapabilities: CalendarProviderCapabilities = {
+  serverSidePullable: true,
+  writable: true,
+  hasSubCalendars: true,
+};
+
+export const GoogleCalendarAdapter: CalendarProvider = {
+  capabilities: googleCapabilities,
+
+  fetchEvents(_window: SyncWindow): Promise<IncomingEvent[]> {
+    throw new Error("Not implemented: GoogleCalendarAdapter");
+  },
+
+  writeEvent(_event: IncomingEvent): Promise<WriteError | null> {
+    throw new Error("Not implemented: GoogleCalendarAdapter");
+  },
+
+  listSubCalendars(): Promise<Array<{ id: string; label: string }>> {
+    throw new Error("Not implemented: GoogleCalendarAdapter");
+  },
+};

--- a/convex/calendars/adapters/google.ts
+++ b/convex/calendars/adapters/google.ts
@@ -4,7 +4,7 @@ import type {
   IncomingEvent,
   SyncWindow,
   WriteError,
-} from "../orchestrator/types";
+} from "@shared/calendars";
 
 export const googleCapabilities: CalendarProviderCapabilities = {
   serverSidePullable: true,
@@ -15,15 +15,15 @@ export const googleCapabilities: CalendarProviderCapabilities = {
 export const GoogleCalendarAdapter: CalendarProvider = {
   capabilities: googleCapabilities,
 
-  fetchEvents(_window: SyncWindow): Promise<IncomingEvent[]> {
+  async fetchEvents(_window: SyncWindow): Promise<IncomingEvent[]> {
     throw new Error("Not implemented: GoogleCalendarAdapter");
   },
 
-  writeEvent(_event: IncomingEvent): Promise<WriteError | null> {
+  async writeEvent(_event: IncomingEvent): Promise<WriteError | null> {
     throw new Error("Not implemented: GoogleCalendarAdapter");
   },
 
-  listSubCalendars(): Promise<Array<{ id: string; label: string }>> {
+  async listSubCalendars(): Promise<Array<{ id: string; label: string }>> {
     throw new Error("Not implemented: GoogleCalendarAdapter");
   },
 };

--- a/convex/calendars/adapters/ical.ts
+++ b/convex/calendars/adapters/ical.ts
@@ -3,7 +3,7 @@ import type {
   CalendarProviderCapabilities,
   IncomingEvent,
   SyncWindow,
-} from "../orchestrator/types";
+} from "@shared/calendars";
 
 export const icalCapabilities: CalendarProviderCapabilities = {
   serverSidePullable: true,
@@ -14,7 +14,7 @@ export const icalCapabilities: CalendarProviderCapabilities = {
 export const ICalAdapter: CalendarProvider = {
   capabilities: icalCapabilities,
 
-  fetchEvents(_window: SyncWindow): Promise<IncomingEvent[]> {
+  async fetchEvents(_window: SyncWindow): Promise<IncomingEvent[]> {
     throw new Error("Not implemented: ICalAdapter");
   },
 };

--- a/convex/calendars/adapters/ical.ts
+++ b/convex/calendars/adapters/ical.ts
@@ -1,0 +1,20 @@
+import type {
+  CalendarProvider,
+  CalendarProviderCapabilities,
+  IncomingEvent,
+  SyncWindow,
+} from "../orchestrator/types";
+
+export const icalCapabilities: CalendarProviderCapabilities = {
+  serverSidePullable: true,
+  writable: false,
+  hasSubCalendars: false,
+};
+
+export const ICalAdapter: CalendarProvider = {
+  capabilities: icalCapabilities,
+
+  fetchEvents(_window: SyncWindow): Promise<IncomingEvent[]> {
+    throw new Error("Not implemented: ICalAdapter");
+  },
+};

--- a/convex/calendars/adapters/microsoft.ts
+++ b/convex/calendars/adapters/microsoft.ts
@@ -1,0 +1,29 @@
+import type {
+  CalendarProvider,
+  CalendarProviderCapabilities,
+  IncomingEvent,
+  SyncWindow,
+  WriteError,
+} from "../orchestrator/types";
+
+export const microsoftCapabilities: CalendarProviderCapabilities = {
+  serverSidePullable: true,
+  writable: true,
+  hasSubCalendars: true,
+};
+
+export const MicrosoftCalendarAdapter: CalendarProvider = {
+  capabilities: microsoftCapabilities,
+
+  fetchEvents(_window: SyncWindow): Promise<IncomingEvent[]> {
+    throw new Error("Not implemented: Microsoft Calendar is not yet supported");
+  },
+
+  writeEvent(_event: IncomingEvent): Promise<WriteError | null> {
+    throw new Error("Not implemented: Microsoft Calendar is not yet supported");
+  },
+
+  listSubCalendars(): Promise<Array<{ id: string; label: string }>> {
+    throw new Error("Not implemented: Microsoft Calendar is not yet supported");
+  },
+};

--- a/convex/calendars/adapters/microsoft.ts
+++ b/convex/calendars/adapters/microsoft.ts
@@ -4,7 +4,7 @@ import type {
   IncomingEvent,
   SyncWindow,
   WriteError,
-} from "../orchestrator/types";
+} from "@shared/calendars";
 
 export const microsoftCapabilities: CalendarProviderCapabilities = {
   serverSidePullable: true,
@@ -15,15 +15,15 @@ export const microsoftCapabilities: CalendarProviderCapabilities = {
 export const MicrosoftCalendarAdapter: CalendarProvider = {
   capabilities: microsoftCapabilities,
 
-  fetchEvents(_window: SyncWindow): Promise<IncomingEvent[]> {
+  async fetchEvents(_window: SyncWindow): Promise<IncomingEvent[]> {
     throw new Error("Not implemented: Microsoft Calendar is not yet supported");
   },
 
-  writeEvent(_event: IncomingEvent): Promise<WriteError | null> {
+  async writeEvent(_event: IncomingEvent): Promise<WriteError | null> {
     throw new Error("Not implemented: Microsoft Calendar is not yet supported");
   },
 
-  listSubCalendars(): Promise<Array<{ id: string; label: string }>> {
+  async listSubCalendars(): Promise<Array<{ id: string; label: string }>> {
     throw new Error("Not implemented: Microsoft Calendar is not yet supported");
   },
 };

--- a/convex/calendars/db/writeEvents.ts
+++ b/convex/calendars/db/writeEvents.ts
@@ -1,18 +1,8 @@
 import { Doc, Id } from "@convex/_generated/dataModel";
 import { MutationCtx } from "@convex/_generated/server";
+import type { IncomingEvent } from "@shared/calendars";
 
-export type IncomingEvent = {
-  externalId: string;
-  subCalendarId?: string;
-  uid?: string;
-  recurrenceId?: number;
-  title: string;
-  description?: string;
-  location?: string;
-  startsAt: number;
-  endsAt: number;
-  isAllDay: boolean;
-};
+export type { IncomingEvent };
 
 export async function replaceConnectionEvents(
   ctx: MutationCtx,

--- a/convex/calendars/google.ts
+++ b/convex/calendars/google.ts
@@ -14,13 +14,12 @@ import {
   googleEventToIncoming,
   shouldSkipGoogleEvent,
 } from "./domain/googleEvents";
+import { currentSyncWindow } from "./orchestrator";
 
 const TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
 const USERINFO_ENDPOINT = "https://openidconnect.googleapis.com/v1/userinfo";
 const CALENDAR_BASE = "https://www.googleapis.com/calendar/v3";
 const DEFAULT_SCOPE = "https://www.googleapis.com/auth/calendar.readonly openid email";
-const SYNC_WINDOW_PAST_MS = 30 * 24 * 60 * 60 * 1000;
-const SYNC_WINDOW_FUTURE_MS = 180 * 24 * 60 * 60 * 1000;
 
 type TokenResponse = {
   access_token: string;
@@ -144,8 +143,9 @@ async function fetchEventsForCalendar(
   accessToken: string,
   calendarId: string,
 ): Promise<IncomingEvent[]> {
-  const timeMin = new Date(Date.now() - SYNC_WINDOW_PAST_MS).toISOString();
-  const timeMax = new Date(Date.now() + SYNC_WINDOW_FUTURE_MS).toISOString();
+  const { windowStartMs, windowEndMs } = currentSyncWindow();
+  const timeMin = new Date(windowStartMs).toISOString();
+  const timeMax = new Date(windowEndMs).toISOString();
   const events: IncomingEvent[] = [];
   let pageToken: string | undefined;
   do {

--- a/convex/calendars/orchestrator/index.ts
+++ b/convex/calendars/orchestrator/index.ts
@@ -1,4 +1,4 @@
-import type { AdapterRegistry, SyncWindow } from "./types";
+import type { AdapterRegistry, SyncWindow } from "@shared/calendars";
 
 export function currentSyncWindow(): SyncWindow {
   return {

--- a/convex/calendars/orchestrator/index.ts
+++ b/convex/calendars/orchestrator/index.ts
@@ -1,0 +1,22 @@
+import type { AdapterRegistry, SyncWindow } from "./types";
+
+export function currentSyncWindow(): SyncWindow {
+  return {
+    windowStartMs: Date.now() - 30 * 24 * 60 * 60 * 1000,
+    windowEndMs: Date.now() + 180 * 24 * 60 * 60 * 1000,
+  };
+}
+
+export function createCalendarOrchestrator(_adapters: AdapterRegistry) {
+  return {
+    syncConnection(_connectionId: string): Promise<void> {
+      throw new Error("Not implemented: orchestrator");
+    },
+    syncNewConnection(_connectionId: string): Promise<void> {
+      throw new Error("Not implemented: orchestrator");
+    },
+    addToCalendar(_event: unknown): Promise<void> {
+      throw new Error("Not implemented: orchestrator");
+    },
+  };
+}

--- a/convex/calendars/orchestrator/types.ts
+++ b/convex/calendars/orchestrator/types.ts
@@ -1,0 +1,39 @@
+import type { IncomingEvent } from "../db/writeEvents";
+
+export type { IncomingEvent };
+
+export type CalendarProviderCapabilities = {
+  serverSidePullable: boolean;
+  writable: boolean;
+  hasSubCalendars: boolean;
+};
+
+export type SyncWindow = {
+  windowStartMs: number;
+  windowEndMs: number;
+};
+
+export type SyncError =
+  | { kind: "network"; message: string }
+  | { kind: "auth"; message: string }
+  | { kind: "parse"; message: string }
+  | { kind: "unknown"; message: string };
+
+export type WriteError =
+  | { kind: "not_supported"; message: string }
+  | { kind: "conflict"; message: string }
+  | { kind: "unknown"; message: string };
+
+export interface CalendarProvider {
+  capabilities: CalendarProviderCapabilities;
+  fetchEvents?(window: SyncWindow): Promise<IncomingEvent[]>;
+  writeEvent?(event: IncomingEvent): Promise<WriteError | null>;
+  listSubCalendars?(): Promise<Array<{ id: string; label: string }>>;
+}
+
+export type AdapterRegistry = {
+  google: CalendarProvider;
+  ical: CalendarProvider;
+  native: CalendarProvider;
+  microsoft?: CalendarProvider;
+};

--- a/src/calendars/adapters/native.ts
+++ b/src/calendars/adapters/native.ts
@@ -3,7 +3,7 @@ import type {
   CalendarProviderCapabilities,
   IncomingEvent,
   WriteError,
-} from "@convex/calendars/orchestrator/types";
+} from "@shared/calendars";
 
 export const nativeCapabilities: CalendarProviderCapabilities = {
   serverSidePullable: false,
@@ -14,11 +14,11 @@ export const nativeCapabilities: CalendarProviderCapabilities = {
 export const NativeCalendarAdapter: CalendarProvider = {
   capabilities: nativeCapabilities,
 
-  writeEvent(_event: IncomingEvent): Promise<WriteError | null> {
+  async writeEvent(_event: IncomingEvent): Promise<WriteError | null> {
     throw new Error("Not implemented: NativeCalendarAdapter");
   },
 
-  listSubCalendars(): Promise<Array<{ id: string; label: string }>> {
+  async listSubCalendars(): Promise<Array<{ id: string; label: string }>> {
     throw new Error("Not implemented: NativeCalendarAdapter");
   },
 };

--- a/src/calendars/adapters/native.ts
+++ b/src/calendars/adapters/native.ts
@@ -1,0 +1,24 @@
+import type {
+  CalendarProvider,
+  CalendarProviderCapabilities,
+  IncomingEvent,
+  WriteError,
+} from "@convex/calendars/orchestrator/types";
+
+export const nativeCapabilities: CalendarProviderCapabilities = {
+  serverSidePullable: false,
+  writable: true,
+  hasSubCalendars: true,
+};
+
+export const NativeCalendarAdapter: CalendarProvider = {
+  capabilities: nativeCapabilities,
+
+  writeEvent(_event: IncomingEvent): Promise<WriteError | null> {
+    throw new Error("Not implemented: NativeCalendarAdapter");
+  },
+
+  listSubCalendars(): Promise<Array<{ id: string; label: string }>> {
+    throw new Error("Not implemented: NativeCalendarAdapter");
+  },
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "jsxImportSource": "react",
     "paths": {
       "@/*": ["./src/*"],
-      "@convex/*": ["./convex/*"]
+      "@convex/*": ["./convex/*"],
+      "@shared/*": ["./types/*"]
     }
   },
   "include": ["**/*.ts", "**/*.tsx", ".expo/types/**/*.ts", "expo-env.d.ts"]

--- a/types/calendars.ts
+++ b/types/calendars.ts
@@ -1,6 +1,15 @@
-import type { IncomingEvent } from "../db/writeEvents";
-
-export type { IncomingEvent };
+export type IncomingEvent = {
+  externalId: string;
+  subCalendarId?: string;
+  uid?: string;
+  recurrenceId?: number;
+  title: string;
+  description?: string;
+  location?: string;
+  startsAt: number;
+  endsAt: number;
+  isAllDay: boolean;
+};
 
 export type CalendarProviderCapabilities = {
   serverSidePullable: boolean;


### PR DESCRIPTION
## Summary

- Adds canonical types file (`convex/calendars/orchestrator/types.ts`) exporting `CalendarProviderCapabilities`, `CalendarProvider` interface, `AdapterRegistry`, `SyncWindow`, `IncomingEvent` re-export, and `SyncError`/`WriteError` discriminated unions
- Creates stub adapters for all four providers: `google`, `ical`, `microsoft` (server-side in `convex/`) and `native` (client-side in `src/`) — all methods throw a clear "Not implemented" error; capabilities set correctly per provider
- Adds orchestrator shell (`convex/calendars/orchestrator/index.ts`) with `createCalendarOrchestrator` factory and `currentSyncWindow()` as the single source of truth for the 30-day past / 180-day future horizon
- Replaces duplicate `SYNC_WINDOW_PAST_MS`/`SYNC_WINDOW_FUTURE_MS` constants in `google.ts` and `actions.ts` with imports of `currentSyncWindow()`

## Test Plan

- [x] TypeScript compiles with zero errors (`npx tsc --noEmit`)
- [x] Lint passes (`npm run lint`)
- [x] Formatting passes (`npm run fmt:check`)
- [x] All 267 existing tests pass (`npm run test`) — no behaviour changed, stubs are not yet called by production code

## Checklist
- [x] TypeScript compiles with zero errors
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)