### PR TITLE
chore(calendars): #113 schema migration — calendarSubCalendars table, updated calendarConnections and calendarEvents

### DIFF
--- a/convex/calendars/actionHelpers.test.ts
+++ b/convex/calendars/actionHelpers.test.ts
@@ -30,6 +30,8 @@ async function seed() {
       provider: "ical",
       label: "Mine",
       createdAt: Date.now(),
+      color: "#6366f1",
+      syncErrorCount: 0,
     }),
   );
   return { t, owner, other, connectionId };

--- a/convex/calendars/db/cascadeDelete.test.ts
+++ b/convex/calendars/db/cascadeDelete.test.ts
@@ -25,6 +25,22 @@ async function insertConnection(t: TestConvex<typeof schema>, userId: Id<"users"
       provider: "ical",
       label,
       createdAt: Date.now(),
+      color: "#6366f1",
+      syncErrorCount: 0,
+    }),
+  );
+}
+
+async function insertSubCalendar(
+  t: TestConvex<typeof schema>,
+  connectionId: Id<"calendarConnections">,
+) {
+  return t.run((ctx) =>
+    ctx.db.insert("calendarSubCalendars", {
+      connectionId,
+      externalId: "default",
+      label: "Default",
+      showAsBusy: true,
     }),
   );
 }
@@ -33,12 +49,14 @@ async function insertEvent(
   t: TestConvex<typeof schema>,
   userId: Id<"users">,
   connectionId: Id<"calendarConnections">,
+  subCalendarId: Id<"calendarSubCalendars">,
   externalId: string,
 ) {
   return t.run((ctx) =>
     ctx.db.insert("calendarEvents", {
       userId,
       connectionId,
+      subCalendarId,
       externalId,
       title: externalId,
       startsAt: Date.now(),
@@ -66,9 +84,11 @@ describe("scheduleDeleteUserCalendarData", () => {
     const userId = await insertUser(t, "target");
     const connectionA = await insertConnection(t, userId, "A");
     const connectionB = await insertConnection(t, userId, "B");
-    await insertEvent(t, userId, connectionA, "a1");
-    await insertEvent(t, userId, connectionA, "a2");
-    await insertEvent(t, userId, connectionB, "b1");
+    const subCalA = await insertSubCalendar(t, connectionA);
+    const subCalB = await insertSubCalendar(t, connectionB);
+    await insertEvent(t, userId, connectionA, subCalA, "a1");
+    await insertEvent(t, userId, connectionA, subCalA, "a2");
+    await insertEvent(t, userId, connectionB, subCalB, "b1");
 
     await t.run((ctx) => scheduleDeleteUserCalendarData(ctx, userId));
     await new Promise((r) => setTimeout(r, 0));
@@ -86,7 +106,8 @@ describe("scheduleDeleteUserCalendarData", () => {
     const bystander = await insertUser(t, "bystander");
     await insertConnection(t, target, "mine");
     const keepConnection = await insertConnection(t, bystander, "keep");
-    await insertEvent(t, bystander, keepConnection, "keep-evt");
+    const keepSubCal = await insertSubCalendar(t, keepConnection);
+    await insertEvent(t, bystander, keepConnection, keepSubCal, "keep-evt");
 
     await t.run((ctx) => scheduleDeleteUserCalendarData(ctx, target));
     await new Promise((r) => setTimeout(r, 0));

--- a/convex/calendars/schema.ts
+++ b/convex/calendars/schema.ts
@@ -15,7 +15,7 @@ export const CalendarConnection = {
   label: v.string(),
   // Provider-side identifier (Google email/sub, Outlook UPN, Apple localCalendarId, etc.)
   externalAccountId: v.optional(v.string()),
-  // For provider="ical" — the subscription URL
+  // For provider="ical" — the subscription URL (stored encrypted at the application layer)
   icalUrl: v.optional(v.string()),
   // For provider="native" — the on-device calendar id from expo-calendar
   localCalendarId: v.optional(v.string()),
@@ -30,11 +30,6 @@ export const CalendarConnection = {
   encryptedTokens: v.optional(v.bytes()),
   // Unix ms — when the access token expires
   tokenExpiresAt: v.optional(v.number()),
-  // IDs of sub-calendars within this account to actively sync.
-  // - Google: calendar ids from /calendarList (e.g. "primary", "xxx@group.calendar.google.com")
-  // - Apple: device localCalendarIds from expo-calendar
-  // - iCal: not applicable (the feed URL is opaque)
-  enabledSubCalendarIds: v.optional(v.array(v.string())),
   // Optimistic-lock nonce written atomically with each token refresh so that
   // concurrent refreshes are serialised: only the first writer wins.
   refreshNonce: v.optional(v.string()),
@@ -42,13 +37,30 @@ export const CalendarConnection = {
   lastSyncedAt: v.optional(v.number()),
   lastSyncError: v.optional(v.string()),
   createdAt: v.number(),
+  // Hex colour assigned to this connection, e.g. "#6366f1"
+  color: v.string(),
+  // Incremented on each sync failure; reset to 0 on success. UI shows a badge when > 3.
+  syncErrorCount: v.number(),
+  // ETag from the last successful iCal feed fetch — used for conditional HTTP requests.
+  icalEtag: v.optional(v.string()),
+  // Last-Modified header from the last successful iCal fetch — used for conditional HTTP requests.
+  icalLastModified: v.optional(v.string()),
+};
+
+export const CalendarSubCalendar = {
+  connectionId: v.id("calendarConnections"),
+  // Provider's identifier for this sub-calendar
+  externalId: v.string(),
+  label: v.string(),
+  // Controls future visibility to other CrewCircle users (does not affect the owner's diary)
+  showAsBusy: v.boolean(),
 };
 
 export const CalendarEvent = {
   userId: v.id("users"),
   connectionId: v.id("calendarConnections"),
-  // Which sub-calendar this event came from. Empty/undefined for iCal feeds.
-  subCalendarId: v.optional(v.string()),
+  // Foreign key to the sub-calendar row this event belongs to
+  subCalendarId: v.id("calendarSubCalendars"),
   // Composite stable identifier: `${subCalendarId}::${providerEventId}` when a
   // sub-calendar applies, else the raw provider event id. Ensures uniqueness
   // across sub-calendars of the same connection.
@@ -73,8 +85,10 @@ export const CalendarEvent = {
 
 export const calendarsSchema = {
   calendarConnections: defineTable(CalendarConnection).index("byUser", ["userId"]),
+  calendarSubCalendars: defineTable(CalendarSubCalendar).index("byConnection", ["connectionId"]),
   calendarEvents: defineTable(CalendarEvent)
     .index("byConnection", ["connectionId"])
     .index("byConnectionExternal", ["connectionId", "externalId"])
+    .index("bySubCalendar", ["subCalendarId"])
     .index("byUserStartsAt", ["userId", "startsAt"]),
 };

--- a/convex/users/domain/syncUser.test.ts
+++ b/convex/users/domain/syncUser.test.ts
@@ -100,12 +100,23 @@ describe("deleteUser", () => {
         provider: "ical",
         label: "Feed",
         createdAt: Date.now(),
+        color: "#6366f1",
+        syncErrorCount: 0,
+      }),
+    );
+    const subCalendarId = await t.run((ctx) =>
+      ctx.db.insert("calendarSubCalendars", {
+        connectionId,
+        externalId: "default",
+        label: "Default",
+        showAsBusy: true,
       }),
     );
     await t.run((ctx) =>
       ctx.db.insert("calendarEvents", {
         userId,
         connectionId,
+        subCalendarId,
         externalId: "evt-1",
         title: "Meeting",
         startsAt: Date.now(),
@@ -137,6 +148,8 @@ describe("deleteUser", () => {
         provider: "ical",
         label: "Untouched",
         createdAt: Date.now(),
+        color: "#6366f1",
+        syncErrorCount: 0,
       }),
     );
     await t.run((ctx) => deleteUser(ctx, { externalAuthId: "nope" }));


### PR DESCRIPTION
## Summary

- Removes `enabledSubCalendarIds` from `calendarConnections` (replaced by the new table)
- Adds `color` (required string), `syncErrorCount` (required number), `icalEtag` (optional string), and `icalLastModified` (optional string) to `calendarConnections`
- Introduces new `calendarSubCalendars` table with `connectionId`, `externalId`, `label`, `showAsBusy` fields and a `byConnection` index
- Changes `calendarEvents.subCalendarId` from `v.optional(v.string())` to required `v.id("calendarSubCalendars")`
- Adds `bySubCalendar` index to `calendarEvents` to support efficient cascade deletion
- Updates all affected test fixtures to satisfy new required fields

## Test Plan

- [x] TypeScript compiles with zero errors (`npx tsc --noEmit`)
- [x] Lint passes (`npm run lint`)
- [x] Formatting passes (`npm run fmt:check`)
- [x] All 83 tests pass (`npm run test`)

## Checklist
- [x] TypeScript compiles with zero errors
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass

Closes #113