### PR TITLE
feat(calendars): #116 colour palette assigner domain module

### DIFF
--- a/convex/calendars/domain/assignPaletteColour.test.ts
+++ b/convex/calendars/domain/assignPaletteColour.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vitest";
+
+import { assignPaletteColour } from "./assignPaletteColour";
+
+const FIRST_COLOUR = "#6366f1";
+const SECOND_COLOUR = "#10b981";
+const PALETTE_SIZE = 10;
+
+describe("assignPaletteColour", () => {
+  test("returns the first palette colour when no colours are in use", () => {
+    expect(assignPaletteColour([])).toBe(FIRST_COLOUR);
+  });
+
+  test("skips already-used colours and returns the next available one", () => {
+    expect(assignPaletteColour([FIRST_COLOUR])).toBe(SECOND_COLOUR);
+  });
+
+  test("cycles back correctly when all palette colours are in use", () => {
+    const allColours = [
+      "#6366f1",
+      "#10b981",
+      "#f59e0b",
+      "#ef4444",
+      "#3b82f6",
+      "#8b5cf6",
+      "#ec4899",
+      "#14b8a6",
+      "#f97316",
+      "#84cc16",
+    ];
+    expect(allColours).toHaveLength(PALETTE_SIZE);
+    const result = assignPaletteColour(allColours);
+    expect(result).toBe(allColours[allColours.length % PALETTE_SIZE]);
+  });
+
+  test("is pure — calling it twice with the same input returns the same result", () => {
+    const used = [FIRST_COLOUR];
+    const first = assignPaletteColour(used);
+    const second = assignPaletteColour(used);
+    expect(first).toBe(second);
+    expect(used).toEqual([FIRST_COLOUR]);
+  });
+});

--- a/convex/calendars/domain/assignPaletteColour.ts
+++ b/convex/calendars/domain/assignPaletteColour.ts
@@ -1,0 +1,18 @@
+const PALETTE = [
+  "#6366f1", // indigo
+  "#10b981", // emerald
+  "#f59e0b", // amber
+  "#ef4444", // red
+  "#3b82f6", // blue
+  "#8b5cf6", // violet
+  "#ec4899", // pink
+  "#14b8a6", // teal
+  "#f97316", // orange
+  "#84cc16", // lime
+] as const;
+
+export function assignPaletteColour(usedColours: string[]): string {
+  const available = PALETTE.find((colour) => !usedColours.includes(colour));
+  if (available !== undefined) return available;
+  return PALETTE[usedColours.length % PALETTE.length];
+}


### PR DESCRIPTION
## Summary

- Adds `convex/calendars/domain/assignPaletteColour.ts` — a pure domain function that assigns the next available hex colour from a fixed 10-colour accessible palette (indigo, emerald, amber, red, blue, violet, pink, teal, orange, lime)
- Returns the first palette colour not present in `usedColours`; cycles via modulo when all palette colours are in use
- Does not mutate the input array

## Test Plan

- 4 unit tests covering: empty input, skipping used colours, cycling when all are used, and purity guarantee
- All 87 tests pass (`npm run test`)
- TypeScript strict mode: zero errors
- Lint and formatting pass

## Checklist
- [x] TypeScript compiles with zero errors
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass

Closes #116