### PR TITLE
feat(calendars): #118 iCal URL validator domain module

### DIFF
--- a/convex/calendars/domain/isSecureUrl.test.ts
+++ b/convex/calendars/domain/isSecureUrl.test.ts
@@ -31,10 +31,23 @@ describe("isSecureUrl", () => {
       ["[::ffff:10.0.0.1]", "http://[::ffff:10.0.0.1]/"], // IPv4-mapped RFC 1918
       ["[fc00::1]", "http://[fc00::1]/"], // IPv6 unique local
       ["[fd12:3456::1]", "http://[fd12:3456::1]/"], // IPv6 unique local
-      ["[fe80::1]", "http://[fe80::1]/"], // IPv6 link-local
+      ["[fe80::1]", "http://[fe80::1]/"], // IPv6 link-local fe80::/10
+      ["[fe90::1]", "http://[fe90::1]/"], // IPv6 link-local fe80::/10
+      ["[fea0::1]", "http://[fea0::1]/"], // IPv6 link-local fe80::/10
+      ["[feb0::1]", "http://[feb0::1]/"], // IPv6 link-local fe80::/10
+      ["[febf::1]", "http://[febf::1]/"], // IPv6 link-local fe80::/10 upper bound
     ])("blocks %s", (_label, rawUrl) => {
       expect(isSecureUrl(url(rawUrl))).toBe(false);
     });
+  });
+
+  describe("fe80::/10 boundary", () => {
+    test("blocks fe80::1 (start of range)", () =>
+      expect(isSecureUrl(url("http://[fe80::1]/"))).toBe(false));
+    test("blocks febf::1 (end of range)", () =>
+      expect(isSecureUrl(url("http://[febf::1]/"))).toBe(false));
+    test("allows fec0::1 (just above range)", () =>
+      expect(isSecureUrl(url("http://[fec0::1]/"))).toBe(true));
   });
 
   describe("172.16.0.0/12 boundary", () => {

--- a/convex/calendars/domain/isSecureUrl.test.ts
+++ b/convex/calendars/domain/isSecureUrl.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "vitest";
+
+import { isSecureUrl } from "./isSecureUrl";
+
+const url = (s: string) => new URL(s);
+
+describe("isSecureUrl", () => {
+  describe("protocol", () => {
+    test("allows http", () => expect(isSecureUrl(url("http://example.com/"))).toBe(true));
+    test("allows https", () => expect(isSecureUrl(url("https://example.com/"))).toBe(true));
+    test("blocks ftp", () => expect(isSecureUrl(url("ftp://example.com/"))).toBe(false));
+    test("blocks file", () => expect(isSecureUrl(url("file:///etc/passwd"))).toBe(false));
+  });
+
+  describe("private / loopback hosts", () => {
+    test.each([
+      ["localhost", "http://localhost/"],
+      ["0.0.0.0", "http://0.0.0.0/"],
+      ["127.0.0.1", "http://127.0.0.1/"],
+      ["127.255.255.255", "http://127.255.255.255/"],
+      ["10.0.0.1", "http://10.0.0.1/"],
+      ["10.255.255.255", "http://10.255.255.255/"],
+      ["192.168.0.1", "http://192.168.0.1/"],
+      ["192.168.255.255", "http://192.168.255.255/"],
+      ["172.16.0.1", "http://172.16.0.1/"],
+      ["172.31.255.255", "http://172.31.255.255/"],
+      ["169.254.169.254", "http://169.254.169.254/"], // cloud metadata
+      ["169.254.0.1", "http://169.254.0.1/"],
+      ["[::1]", "http://[::1]/"], // IPv6 loopback
+      ["[::ffff:127.0.0.1]", "http://[::ffff:127.0.0.1]/"], // IPv4-mapped loopback
+      ["[::ffff:10.0.0.1]", "http://[::ffff:10.0.0.1]/"], // IPv4-mapped RFC 1918
+      ["[fc00::1]", "http://[fc00::1]/"], // IPv6 unique local
+      ["[fd12:3456::1]", "http://[fd12:3456::1]/"], // IPv6 unique local
+      ["[fe80::1]", "http://[fe80::1]/"], // IPv6 link-local
+    ])("blocks %s", (_label, rawUrl) => {
+      expect(isSecureUrl(url(rawUrl))).toBe(false);
+    });
+  });
+
+  describe("172.16.0.0/12 boundary", () => {
+    test("blocks 172.16.0.1 (inside range)", () =>
+      expect(isSecureUrl(url("http://172.16.0.1/"))).toBe(false));
+    test("blocks 172.31.255.255 (inside range)", () =>
+      expect(isSecureUrl(url("http://172.31.255.255/"))).toBe(false));
+    test("allows 172.15.0.1 (just below range)", () =>
+      expect(isSecureUrl(url("http://172.15.0.1/"))).toBe(true));
+    test("allows 172.32.0.1 (just above range)", () =>
+      expect(isSecureUrl(url("http://172.32.0.1/"))).toBe(true));
+  });
+
+  describe("public hosts", () => {
+    test.each([
+      ["example.com", "https://example.com/feed.ics"],
+      ["8.8.8.8", "https://8.8.8.8/"],
+      ["172.15.0.1", "http://172.15.0.1/"],
+      ["172.32.0.1", "http://172.32.0.1/"],
+    ])("allows %s", (_label, rawUrl) => {
+      expect(isSecureUrl(url(rawUrl))).toBe(true);
+    });
+  });
+});

--- a/convex/calendars/domain/isSecureUrl.ts
+++ b/convex/calendars/domain/isSecureUrl.ts
@@ -10,7 +10,8 @@ const PRIVATE_PREFIXES = [
   "[::ffff:", // IPv4-mapped IPv6 — can encode any IPv4 address including private ones
   "[fc", // IPv6 unique local (fc00::/7)
   "[fd", // IPv6 unique local (fc00::/7)
-  "[fe80", // IPv6 link-local (fe80::/10)
+  // IPv6 link-local (fe80::/10 = fe80:: through febf::).
+  // Third hex nibble must be 8–b; checked explicitly below rather than as a prefix.
 ];
 
 function isPrivateHostname(hostname: string): boolean {
@@ -18,6 +19,9 @@ function isPrivateHostname(hostname: string): boolean {
 
   if (PRIVATE_EXACT.has(h)) return true;
   if (PRIVATE_PREFIXES.some((prefix) => h.startsWith(prefix))) return true;
+
+  // fe80::/10 link-local: third nibble is 8, 9, a, or b (fe80:: through febf::)
+  if (h.startsWith("[fe") && "89ab".includes(h[3] ?? "")) return true;
 
   // 172.16.0.0/12 — covers 172.16.x.x through 172.31.x.x
   const parts = h.split(".");

--- a/convex/calendars/domain/isSecureUrl.ts
+++ b/convex/calendars/domain/isSecureUrl.ts
@@ -1,0 +1,40 @@
+const ALLOWED_PROTOCOLS = new Set(["http:", "https:"]);
+
+const PRIVATE_EXACT = new Set(["localhost", "0.0.0.0", "[::1]"]);
+
+const PRIVATE_PREFIXES = [
+  "127.", // IPv4 loopback
+  "10.", // RFC 1918
+  "192.168.", // RFC 1918
+  "169.254.", // link-local / cloud metadata (AWS, GCP, Azure all use 169.254.169.254)
+  "[::ffff:", // IPv4-mapped IPv6 — can encode any IPv4 address including private ones
+  "[fc", // IPv6 unique local (fc00::/7)
+  "[fd", // IPv6 unique local (fc00::/7)
+  "[fe80", // IPv6 link-local (fe80::/10)
+];
+
+function isPrivateHostname(hostname: string): boolean {
+  const h = hostname.toLowerCase();
+
+  if (PRIVATE_EXACT.has(h)) return true;
+  if (PRIVATE_PREFIXES.some((prefix) => h.startsWith(prefix))) return true;
+
+  // 172.16.0.0/12 — covers 172.16.x.x through 172.31.x.x
+  const parts = h.split(".");
+  if (parts.length === 4 && parts[0] === "172") {
+    const second = parseInt(parts[1], 10);
+    if (second >= 16 && second <= 31) return true;
+  }
+
+  return false;
+}
+
+// Returns true if the URL is safe to fetch: protocol is http or https, and the
+// hostname is not a private, loopback, or link-local address.
+// Note: DNS rebinding (a public hostname that resolves to a private IP at
+// fetch time) cannot be prevented at this layer.
+export function isSecureUrl(url: URL): boolean {
+  if (!ALLOWED_PROTOCOLS.has(url.protocol)) return false;
+  if (isPrivateHostname(url.hostname)) return false;
+  return true;
+}

--- a/convex/calendars/domain/validateICalUrl.test.ts
+++ b/convex/calendars/domain/validateICalUrl.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
-import { validateICalUrl } from "./validateICalUrl";
+import { readBodyWithLimit, validateICalUrl } from "./validateICalUrl";
 
 const VALID_ICAL_BODY = [
   "BEGIN:VCALENDAR",
@@ -9,9 +9,63 @@ const VALID_ICAL_BODY = [
   "END:VCALENDAR",
 ].join("\r\n");
 
-function makeResponse(body: string, status = 200): Response {
-  return new Response(body, { status });
+function makeResponse(body: string, status = 200, headers: Record<string, string> = {}): Response {
+  return new Response(body, { status, headers });
 }
+
+function makeStreamingResponse(chunks: string[]): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  });
+  return new Response(stream, { status: 200 });
+}
+
+// ─── readBodyWithLimit ────────────────────────────────────────────────────────
+
+describe("readBodyWithLimit", () => {
+  test("returns body text when under the limit", async () => {
+    const response = makeStreamingResponse(["BEGIN:VCALENDAR", "\r\nEND:VCALENDAR"]);
+    const result = await readBodyWithLimit(response, 1024);
+    expect(result).toContain("BEGIN:VCALENDAR");
+  });
+
+  test("returns null and cancels the reader when the limit is exceeded mid-stream", async () => {
+    const chunk = "x".repeat(512);
+    const response = makeStreamingResponse([chunk, chunk, chunk]); // 1536 bytes total
+    const result = await readBodyWithLimit(response, 1024);
+    expect(result).toBeNull();
+  });
+
+  test("exits early after finding BEGIN:VCALENDAR without reading the rest of the stream", async () => {
+    let chunksRead = 0;
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode("BEGIN:VCALENDAR\r\n"));
+        controller.enqueue(encoder.encode("x".repeat(1024 * 1024)));
+        controller.close();
+      },
+      pull() {
+        chunksRead++;
+      },
+    });
+    const response = new Response(stream);
+    const result = await readBodyWithLimit(response, 10 * 1024 * 1024);
+    expect(result).toContain("BEGIN:VCALENDAR");
+    expect(chunksRead).toBe(0);
+  });
+
+  test("returns empty string for a response with no body", async () => {
+    const result = await readBodyWithLimit(new Response(null, { status: 200 }), 1024);
+    expect(result).toBe("");
+  });
+});
+
+// ─── validateICalUrl ──────────────────────────────────────────────────────────
 
 describe("validateICalUrl", () => {
   let fetchMock: ReturnType<typeof vi.fn>;
@@ -25,55 +79,95 @@ describe("validateICalUrl", () => {
     vi.unstubAllGlobals();
   });
 
+  // Happy path
   test("returns valid when the response body contains BEGIN:VCALENDAR", async () => {
     fetchMock.mockResolvedValue(makeResponse(VALID_ICAL_BODY));
-    const result = await validateICalUrl("https://example.com/feed.ics");
-    expect(result).toEqual({ valid: true });
+    expect(await validateICalUrl("https://example.com/feed.ics")).toEqual({ valid: true });
   });
 
-  test("returns invalid when the response body is HTML rather than iCal", async () => {
-    fetchMock.mockResolvedValue(makeResponse("<html><body>Not a feed</body></html>"));
-    const result = await validateICalUrl("https://example.com/feed.ics");
-    expect(result.valid).toBe(false);
-    if (result.valid === false) {
-      expect(result.reason).toBe("invalid");
-    }
+  // URL validation — fetch must never be called for any of these
+  test("returns invalid for a malformed URL string", async () => {
+    const result = await validateICalUrl("not a url");
+    expect(result).toMatchObject({ valid: false, reason: "invalid" });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  test.each([
+    ["ftp protocol", "ftp://example.com/feed.ics"],
+    ["localhost", "http://localhost/calendar.ics"],
+    ["IPv4 loopback", "http://127.0.0.1/calendar.ics"],
+    ["RFC 1918 10.x", "http://10.0.0.1/calendar.ics"],
+    ["RFC 1918 192.168.x", "http://192.168.1.1/calendar.ics"],
+    ["RFC 1918 172.16.x", "http://172.16.0.1/calendar.ics"],
+    ["cloud metadata endpoint", "http://169.254.169.254/latest/meta-data/"],
+    ["IPv6 loopback", "http://[::1]/calendar.ics"],
+    ["IPv4-mapped IPv6 loopback", "http://[::ffff:127.0.0.1]/calendar.ics"],
+  ])("returns invalid without fetching — %s", async (_label, url) => {
+    const result = await validateICalUrl(url);
+    expect(result).toMatchObject({ valid: false, reason: "invalid" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  // Redirect chains
+  test("passes redirect:error to fetch to block SSRF via redirects", async () => {
+    fetchMock.mockRejectedValue(new TypeError("redirect not allowed"));
+    await validateICalUrl("https://example.com/redirecting.ics");
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ redirect: "error" }),
+    );
+  });
+
+  test("returns unreachable when a redirect is encountered", async () => {
+    fetchMock.mockRejectedValue(new TypeError("redirect not allowed"));
+    expect(await validateICalUrl("https://example.com/redirecting.ics")).toMatchObject({
+      valid: false,
+      reason: "unreachable",
+    });
+  });
+
+  // Network errors
   test("returns unreachable when fetch throws a network error", async () => {
     fetchMock.mockRejectedValue(new Error("network down"));
-    const result = await validateICalUrl("https://example.com/feed.ics");
-    expect(result.valid).toBe(false);
-    if (result.valid === false) {
-      expect(result.reason).toBe("unreachable");
-    }
+    expect(await validateICalUrl("https://example.com/feed.ics")).toMatchObject({
+      valid: false,
+      reason: "unreachable",
+    });
   });
 
   test("returns unreachable when the server responds with HTTP 404", async () => {
     fetchMock.mockResolvedValue(makeResponse("Not Found", 404));
     const result = await validateICalUrl("https://example.com/missing.ics");
-    expect(result.valid).toBe(false);
-    if (result.valid === false) {
-      expect(result.reason).toBe("unreachable");
-      expect(result.message).toContain("404");
-    }
+    expect(result).toMatchObject({ valid: false, reason: "unreachable" });
+    if (result.valid === false) expect(result.message).toContain("404");
   });
 
-  test("returns invalid when the URL string is malformed", async () => {
-    const result = await validateICalUrl("not a url");
-    expect(result.valid).toBe(false);
-    if (result.valid === false) {
-      expect(result.reason).toBe("invalid");
-    }
-    expect(fetchMock).not.toHaveBeenCalled();
+  // Memory exhaustion
+  test("returns invalid when Content-Length header exceeds 10 MB", async () => {
+    fetchMock.mockResolvedValue(
+      makeResponse(VALID_ICAL_BODY, 200, { "content-length": String(11 * 1024 * 1024) }),
+    );
+    expect(await validateICalUrl("https://example.com/feed.ics")).toMatchObject({
+      valid: false,
+      reason: "invalid",
+    });
   });
 
-  test("returns invalid when the protocol is not http or https", async () => {
-    const result = await validateICalUrl("ftp://example.com/feed.ics");
-    expect(result.valid).toBe(false);
-    if (result.valid === false) {
-      expect(result.reason).toBe("invalid");
-    }
-    expect(fetchMock).not.toHaveBeenCalled();
+  test("returns invalid when streamed body exceeds 10 MB even without Content-Length", async () => {
+    const chunk = "x".repeat(1024 * 1024);
+    fetchMock.mockResolvedValue(makeStreamingResponse(Array(11).fill(chunk)));
+    expect(await validateICalUrl("https://example.com/feed.ics")).toMatchObject({
+      valid: false,
+      reason: "invalid",
+    });
+  });
+
+  // Content checks
+  test("returns invalid when the response body is HTML rather than iCal", async () => {
+    fetchMock.mockResolvedValue(makeResponse("<html><body>Not a feed</body></html>"));
+    expect(await validateICalUrl("https://example.com/feed.ics")).toMatchObject({
+      valid: false,
+      reason: "invalid",
+    });
   });
 });

--- a/convex/calendars/domain/validateICalUrl.test.ts
+++ b/convex/calendars/domain/validateICalUrl.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { validateICalUrl } from "./validateICalUrl";
+
+const VALID_ICAL_BODY = [
+  "BEGIN:VCALENDAR",
+  "VERSION:2.0",
+  "PRODID:-//Test//EN",
+  "END:VCALENDAR",
+].join("\r\n");
+
+function makeResponse(body: string, status = 200): Response {
+  return new Response(body, { status });
+}
+
+describe("validateICalUrl", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("returns valid when the response body contains BEGIN:VCALENDAR", async () => {
+    fetchMock.mockResolvedValue(makeResponse(VALID_ICAL_BODY));
+    const result = await validateICalUrl("https://example.com/feed.ics");
+    expect(result).toEqual({ valid: true });
+  });
+
+  test("returns invalid when the response body is HTML rather than iCal", async () => {
+    fetchMock.mockResolvedValue(makeResponse("<html><body>Not a feed</body></html>"));
+    const result = await validateICalUrl("https://example.com/feed.ics");
+    expect(result.valid).toBe(false);
+    if (result.valid === false) {
+      expect(result.reason).toBe("invalid");
+    }
+  });
+
+  test("returns unreachable when fetch throws a network error", async () => {
+    fetchMock.mockRejectedValue(new Error("network down"));
+    const result = await validateICalUrl("https://example.com/feed.ics");
+    expect(result.valid).toBe(false);
+    if (result.valid === false) {
+      expect(result.reason).toBe("unreachable");
+    }
+  });
+
+  test("returns unreachable when the server responds with HTTP 404", async () => {
+    fetchMock.mockResolvedValue(makeResponse("Not Found", 404));
+    const result = await validateICalUrl("https://example.com/missing.ics");
+    expect(result.valid).toBe(false);
+    if (result.valid === false) {
+      expect(result.reason).toBe("unreachable");
+      expect(result.message).toContain("404");
+    }
+  });
+
+  test("returns invalid when the URL string is malformed", async () => {
+    const result = await validateICalUrl("not a url");
+    expect(result.valid).toBe(false);
+    if (result.valid === false) {
+      expect(result.reason).toBe("invalid");
+    }
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("returns invalid when the protocol is not http or https", async () => {
+    const result = await validateICalUrl("ftp://example.com/feed.ics");
+    expect(result.valid).toBe(false);
+    if (result.valid === false) {
+      expect(result.reason).toBe("invalid");
+    }
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/convex/calendars/domain/validateICalUrl.ts
+++ b/convex/calendars/domain/validateICalUrl.ts
@@ -1,3 +1,5 @@
+import { isSecureUrl } from "./isSecureUrl";
+
 export type ICalValidationResult =
   | { valid: true }
   | { valid: false; reason: "unreachable"; message: string }
@@ -5,6 +7,50 @@ export type ICalValidationResult =
 
 const FETCH_TIMEOUT_MS = 10_000;
 const ICAL_HEADER = "BEGIN:VCALENDAR";
+const MAX_RESPONSE_BYTES = 10 * 1024 * 1024; // 10 MB
+
+// Streams the response body up to maxBytes, returning the accumulated text.
+// Returns null if the limit is exceeded before the stream ends, cancelling
+// the reader immediately so the connection is dropped rather than drained.
+// Using streaming rather than response.text() prevents memory exhaustion from
+// a malicious server that omits Content-Length and streams indefinitely.
+export async function readBodyWithLimit(
+  response: Response,
+  maxBytes: number,
+): Promise<string | null> {
+  const reader = response.body?.getReader();
+  if (!reader) return "";
+
+  const decoder = new TextDecoder();
+  let text = "";
+  let bytesRead = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      bytesRead += value.byteLength;
+      if (bytesRead > maxBytes) {
+        reader.cancel();
+        return null;
+      }
+
+      text += decoder.decode(value, { stream: true });
+
+      // Exit early once the iCal header is confirmed — no need to read further.
+      if (text.includes(ICAL_HEADER)) {
+        reader.cancel();
+        break;
+      }
+    }
+    text += decoder.decode();
+  } finally {
+    reader.cancel().catch(() => {});
+  }
+
+  return text;
+}
 
 export async function validateICalUrl(url: string): Promise<ICalValidationResult> {
   let parsed: URL;
@@ -14,11 +60,11 @@ export async function validateICalUrl(url: string): Promise<ICalValidationResult
     return { valid: false, reason: "invalid", message: "URL is not valid" };
   }
 
-  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+  if (!isSecureUrl(parsed)) {
     return {
       valid: false,
       reason: "invalid",
-      message: `URL protocol must be http or https (got ${parsed.protocol})`,
+      message: "URL must use http or https and be a publicly reachable address",
     };
   }
 
@@ -27,6 +73,9 @@ export async function validateICalUrl(url: string): Promise<ICalValidationResult
     response = await fetch(url, {
       headers: { Accept: "text/calendar" },
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      // Prevents SSRF via redirect chains: a public URL redirecting to an
+      // internal address would bypass the isSecureUrl check above.
+      redirect: "error",
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown fetch error";
@@ -41,12 +90,23 @@ export async function validateICalUrl(url: string): Promise<ICalValidationResult
     };
   }
 
-  let body: string;
-  try {
-    body = await response.text();
-  } catch (error) {
-    const message = error instanceof Error ? error.message : "Failed to read response body";
-    return { valid: false, reason: "unreachable", message };
+  // Fast reject based on declared size before reading any bytes.
+  const contentLength = response.headers.get("content-length");
+  if (contentLength !== null && parseInt(contentLength, 10) > MAX_RESPONSE_BYTES) {
+    return {
+      valid: false,
+      reason: "invalid",
+      message: "Response is too large to be a valid iCal feed",
+    };
+  }
+
+  const body = await readBodyWithLimit(response, MAX_RESPONSE_BYTES);
+  if (body === null) {
+    return {
+      valid: false,
+      reason: "invalid",
+      message: "Response is too large to be a valid iCal feed",
+    };
   }
 
   if (!body.includes(ICAL_HEADER)) {

--- a/convex/calendars/domain/validateICalUrl.ts
+++ b/convex/calendars/domain/validateICalUrl.ts
@@ -41,7 +41,14 @@ export async function validateICalUrl(url: string): Promise<ICalValidationResult
     };
   }
 
-  const body = await response.text();
+  let body: string;
+  try {
+    body = await response.text();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to read response body";
+    return { valid: false, reason: "unreachable", message };
+  }
+
   if (!body.includes(ICAL_HEADER)) {
     return { valid: false, reason: "invalid", message: "Response is not a valid iCal feed" };
   }

--- a/convex/calendars/domain/validateICalUrl.ts
+++ b/convex/calendars/domain/validateICalUrl.ts
@@ -1,0 +1,50 @@
+export type ICalValidationResult =
+  | { valid: true }
+  | { valid: false; reason: "unreachable"; message: string }
+  | { valid: false; reason: "invalid"; message: string };
+
+const FETCH_TIMEOUT_MS = 10_000;
+const ICAL_HEADER = "BEGIN:VCALENDAR";
+
+export async function validateICalUrl(url: string): Promise<ICalValidationResult> {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { valid: false, reason: "invalid", message: "URL is not valid" };
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return {
+      valid: false,
+      reason: "invalid",
+      message: `URL protocol must be http or https (got ${parsed.protocol})`,
+    };
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      headers: { Accept: "text/calendar" },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown fetch error";
+    return { valid: false, reason: "unreachable", message };
+  }
+
+  if (!response.ok) {
+    return {
+      valid: false,
+      reason: "unreachable",
+      message: `HTTP ${response.status} ${response.statusText}`.trim(),
+    };
+  }
+
+  const body = await response.text();
+  if (!body.includes(ICAL_HEADER)) {
+    return { valid: false, reason: "invalid", message: "Response is not a valid iCal feed" };
+  }
+
+  return { valid: true };
+}

--- a/convex/calendars/domain/validateICalUrl.ts
+++ b/convex/calendars/domain/validateICalUrl.ts
@@ -32,7 +32,7 @@ export async function readBodyWithLimit(
 
       bytesRead += value.byteLength;
       if (bytesRead > maxBytes) {
-        reader.cancel();
+        reader.cancel().catch(() => {});
         return null;
       }
 


### PR DESCRIPTION
## Summary

Adds `validateICalUrl(url)` — a server-side domain function that performs a real HTTP fetch and inspects the response body to confirm the URL points at a valid iCal feed. Returns a typed `ICalValidationResult` union (`{ valid: true }` | `{ valid: false, reason: 'unreachable' | 'invalid', message }`) and never throws.

The function checks, in order:
1. URL parses and uses `http:` or `https:`
2. Fetch succeeds within a 10s `AbortSignal.timeout` and returns 2xx
3. Response body contains `BEGIN:VCALENDAR`

## Test Plan

- [x] `npx tsc --noEmit` — zero errors
- [x] `npm run lint` — zero warnings/errors
- [x] `npm run fmt:check` — passes
- [x] `npm run test` — 106 tests pass (incl. 6 new for `validateICalUrl`)

Test cases cover:
- Valid iCal content
- Non-iCal HTML response → `invalid`
- Network error (fetch throws) → `unreachable`
- HTTP 404 → `unreachable` (status in message)
- Malformed URL string → `invalid` (no fetch issued)
- Non-http(s) protocol → `invalid` (no fetch issued)

## Checklist

- [x] TypeScript compiles with zero errors
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass

Closes #118