### PR TITLE
feat(calendars): #124 CalendarService.disconnect — ownership check + cascade delete

### DIFF
--- a/convex/calendars/service/disconnect.test.ts
+++ b/convex/calendars/service/disconnect.test.ts
@@ -1,0 +1,177 @@
+import type {
+  CalendarConnectParams,
+  CalendarProvider,
+  CalendarProviderRegistry,
+} from "@shared/calendars";
+import { convexTest, type TestConvex } from "convex-test";
+import { describe, expect, test } from "vitest";
+
+import type { Id } from "../../_generated/dataModel";
+import schema from "../../schema";
+import { createCalendarService } from "./index";
+
+const modules = import.meta.glob("/convex/**/*.ts");
+
+const ownerIdentity = {
+  subject: "owner_clerk",
+  issuer: "https://example.clerk.test",
+  tokenIdentifier: "https://example.clerk.test|owner_clerk",
+};
+
+const otherIdentity = {
+  subject: "other_clerk",
+  issuer: "https://example.clerk.test",
+  tokenIdentifier: "https://example.clerk.test|other_clerk",
+};
+
+const stubProvider: CalendarProvider = {
+  capabilities: { serverSidePullable: false, writable: false, hasSubCalendars: false },
+  async connect(_ctx: unknown, _params: CalendarConnectParams): Promise<void> {
+    throw new Error("not used by disconnect");
+  },
+};
+
+const stubRegistry: CalendarProviderRegistry = {
+  google: stubProvider,
+  ical: stubProvider,
+  microsoft: stubProvider,
+  native: stubProvider,
+};
+
+const service = createCalendarService(stubRegistry);
+
+async function seed(t: TestConvex<typeof schema>) {
+  const owner = await t.run((ctx) =>
+    ctx.db.insert("users", {
+      externalAuthId: ownerIdentity.subject,
+      email: "owner@example.com",
+      hasCompletedOnboarding: false,
+      isPublic: false,
+    }),
+  );
+  const other = await t.run((ctx) =>
+    ctx.db.insert("users", {
+      externalAuthId: otherIdentity.subject,
+      email: "other@example.com",
+      hasCompletedOnboarding: false,
+      isPublic: false,
+    }),
+  );
+  const connectionId = await t.run((ctx) =>
+    ctx.db.insert("calendarConnections", {
+      userId: owner,
+      provider: "ical",
+      label: "Mine",
+      createdAt: Date.now(),
+      color: "#6366f1",
+      syncErrorCount: 0,
+    }),
+  );
+  return { owner, other, connectionId };
+}
+
+async function insertEvent(
+  t: TestConvex<typeof schema>,
+  userId: Id<"users">,
+  connectionId: Id<"calendarConnections">,
+  externalId: string,
+) {
+  const subCalendarId = await t.run((ctx) =>
+    ctx.db.insert("calendarSubCalendars", {
+      connectionId,
+      externalId: "default",
+      label: "Default",
+      showAsBusy: true,
+    }),
+  );
+  await t.run((ctx) =>
+    ctx.db.insert("calendarEvents", {
+      userId,
+      connectionId,
+      subCalendarId,
+      externalId,
+      title: externalId,
+      startsAt: Date.now(),
+      endsAt: Date.now() + 60_000,
+      isAllDay: false,
+      updatedAt: Date.now(),
+    }),
+  );
+}
+
+describe("CalendarService.disconnect", () => {
+  test("deletes the connection and its events when the caller owns it", async () => {
+    const t = convexTest(schema, modules);
+    const { owner, connectionId } = await seed(t);
+    await insertEvent(t, owner, connectionId, "evt-1");
+    await insertEvent(t, owner, connectionId, "evt-2");
+
+    await t.withIdentity(ownerIdentity).action(async (ctx) => {
+      await service.disconnect(ctx, connectionId);
+    });
+
+    const remainingConnection = await t.run((ctx) => ctx.db.get(connectionId));
+    const remainingEvents = await t.run((ctx) =>
+      ctx.db
+        .query("calendarEvents")
+        .withIndex("byConnection", (q) => q.eq("connectionId", connectionId))
+        .collect(),
+    );
+    expect(remainingConnection).toBeNull();
+    expect(remainingEvents).toEqual([]);
+  });
+
+  test("throws when the caller is not the owner", async () => {
+    const t = convexTest(schema, modules);
+    const { connectionId } = await seed(t);
+
+    await expect(
+      t.withIdentity(otherIdentity).action(async (ctx) => {
+        await service.disconnect(ctx, connectionId);
+      }),
+    ).rejects.toThrow(/not found/i);
+
+    const stillThere = await t.run((ctx) => ctx.db.get(connectionId));
+    expect(stillThere).not.toBeNull();
+  });
+
+  test("throws when the connection does not exist", async () => {
+    const t = convexTest(schema, modules);
+    const { connectionId } = await seed(t);
+    await t.run((ctx) => ctx.db.delete(connectionId));
+
+    await expect(
+      t.withIdentity(ownerIdentity).action(async (ctx) => {
+        await service.disconnect(ctx, connectionId);
+      }),
+    ).rejects.toThrow(/not found/i);
+  });
+
+  test("throws when the caller is not authenticated", async () => {
+    const t = convexTest(schema, modules);
+    const { connectionId } = await seed(t);
+
+    await expect(
+      t.action(async (ctx) => {
+        await service.disconnect(ctx, connectionId);
+      }),
+    ).rejects.toThrow(/not authenticated/i);
+  });
+
+  test("throws when the authenticated identity has no matching user record", async () => {
+    const t = convexTest(schema, modules);
+    const { connectionId } = await seed(t);
+
+    await expect(
+      t
+        .withIdentity({
+          subject: "ghost_clerk",
+          issuer: "https://example.clerk.test",
+          tokenIdentifier: "https://example.clerk.test|ghost_clerk",
+        })
+        .action(async (ctx) => {
+          await service.disconnect(ctx, connectionId);
+        }),
+    ).rejects.toThrow();
+  });
+});

--- a/convex/calendars/service/index.ts
+++ b/convex/calendars/service/index.ts
@@ -4,6 +4,7 @@ import type {
   SyncWindow,
 } from "@shared/calendars";
 
+import { api, internal } from "../../_generated/api";
 import type { Id } from "../../_generated/dataModel";
 import type { ActionCtx } from "../../_generated/server";
 
@@ -20,8 +21,15 @@ export function createCalendarService(_providers: CalendarProviderRegistry) {
       throw new Error("Not implemented: service.connect");
     },
 
-    async disconnect(_ctx: ActionCtx, _connectionId: Id<"calendarConnections">): Promise<void> {
-      throw new Error("Not implemented: service.disconnect");
+    async disconnect(ctx: ActionCtx, connectionId: Id<"calendarConnections">): Promise<void> {
+      const user = await ctx.runQuery(api.users.queries.getCurrentUser, {});
+      if (!user) throw new Error("Not authenticated");
+      const connection = await ctx.runQuery(
+        internal.calendars.actionHelpers.getConnectionForOwner,
+        { connectionId, userId: user._id },
+      );
+      if (!connection) throw new Error("Calendar connection not found");
+      await ctx.runMutation(internal.calendars.mutations.deleteConnection, { connectionId });
     },
 
     async sync(_ctx: ActionCtx, _connectionId: Id<"calendarConnections">): Promise<void> {


### PR DESCRIPTION
## Summary

- Implements `CalendarService.disconnect` in `convex/calendars/service/index.ts`.
- Resolves the authenticated user via `api.users.queries.getCurrentUser`, verifies ownership via `internal.calendars.actionHelpers.getConnectionForOwner`, and only then triggers `internal.calendars.mutations.deleteConnection`.
- Throws `Not authenticated` when no caller identity / user record exists, and `Calendar connection not found` when the connection is missing or owned by another user — keeping privacy (no leak that a foreign connection exists).

## Test Plan

- New `convex/calendars/service/disconnect.test.ts` covers:
  - Owner can disconnect — connection and its events are deleted.
  - Non-owner gets `Calendar connection not found` and the connection is preserved.
  - Missing connection throws `Calendar connection not found`.
  - Unauthenticated caller throws `Not authenticated`.
  - Authenticated identity without a matching `users` row throws.
- `npx tsc --noEmit`, `npm run lint`, `npm run fmt:check`, and `npm run test` all pass (203/203).

## Checklist

- [x] TypeScript compiles with zero errors
- [x] Lint passes (oxlint)
- [x] Formatting passes (oxfmt)
- [x] Tests pass

Closes #124