### PR TITLE
feat(calendars): #126 CalendarService.setEnabledSubCalendars

### DIFF
--- a/convex/calendars/db/setEnabledSubCalendars.test.ts
+++ b/convex/calendars/db/setEnabledSubCalendars.test.ts
@@ -1,0 +1,261 @@
+/// <reference types="vite/client" />
+import { convexTest, type TestConvex } from "convex-test";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { internal } from "../../_generated/api";
+import type { Id } from "../../_generated/dataModel";
+import schema from "../../schema";
+
+const modules = import.meta.glob("/convex/**/*.ts");
+
+async function insertUser(t: TestConvex<typeof schema>, externalAuthId: string) {
+  return t.run((ctx) =>
+    ctx.db.insert("users", {
+      externalAuthId,
+      email: `${externalAuthId}@example.com`,
+      hasCompletedOnboarding: false,
+      isPublic: false,
+    }),
+  );
+}
+
+async function insertConnection(t: TestConvex<typeof schema>, userId: Id<"users">) {
+  return t.run((ctx) =>
+    ctx.db.insert("calendarConnections", {
+      userId,
+      provider: "google",
+      label: "Work",
+      createdAt: Date.now(),
+      color: "#6366f1",
+      syncErrorCount: 0,
+    }),
+  );
+}
+
+async function insertSubCalendar(
+  t: TestConvex<typeof schema>,
+  connectionId: Id<"calendarConnections">,
+  externalId: string,
+  label: string,
+) {
+  return t.run((ctx) =>
+    ctx.db.insert("calendarSubCalendars", {
+      connectionId,
+      externalId,
+      label,
+      showAsBusy: true,
+    }),
+  );
+}
+
+async function insertEvent(
+  t: TestConvex<typeof schema>,
+  userId: Id<"users">,
+  connectionId: Id<"calendarConnections">,
+  subCalendarId: Id<"calendarSubCalendars">,
+  externalId: string,
+) {
+  return t.run((ctx) =>
+    ctx.db.insert("calendarEvents", {
+      userId,
+      connectionId,
+      subCalendarId,
+      externalId,
+      title: externalId,
+      startsAt: Date.now(),
+      endsAt: Date.now() + 60_000,
+      isAllDay: false,
+      updatedAt: Date.now(),
+    }),
+  );
+}
+
+describe("setEnabledSubCalendars", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("inserts a row with showAsBusy=true for each newly selected sub-calendar", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t, "owner");
+    const connectionId = await insertConnection(t, userId);
+
+    await t.mutation(internal.calendars.db.setEnabledSubCalendars.setEnabledSubCalendars, {
+      connectionId,
+      selections: [
+        { externalId: "work@example.com", label: "Work" },
+        { externalId: "personal@example.com", label: "Personal" },
+      ],
+    });
+
+    const rows = await t.run((ctx) =>
+      ctx.db
+        .query("calendarSubCalendars")
+        .withIndex("byConnection", (q) => q.eq("connectionId", connectionId))
+        .collect(),
+    );
+    expect(rows).toHaveLength(2);
+    expect(rows.every((r) => r.showAsBusy === true)).toBe(true);
+    expect(rows.map((r) => r.externalId).sort()).toEqual([
+      "personal@example.com",
+      "work@example.com",
+    ]);
+  });
+
+  test("leaves an existing row untouched when its externalId is still selected", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t, "owner");
+    const connectionId = await insertConnection(t, userId);
+    const existingId = await insertSubCalendar(t, connectionId, "work@example.com", "Work");
+
+    await t.mutation(internal.calendars.db.setEnabledSubCalendars.setEnabledSubCalendars, {
+      connectionId,
+      selections: [{ externalId: "work@example.com", label: "Work" }],
+    });
+
+    const rows = await t.run((ctx) =>
+      ctx.db
+        .query("calendarSubCalendars")
+        .withIndex("byConnection", (q) => q.eq("connectionId", connectionId))
+        .collect(),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]._id).toBe(existingId);
+  });
+
+  test("does not overwrite a custom showAsBusy=false on an unchanged row", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t, "owner");
+    const connectionId = await insertConnection(t, userId);
+    const existingId = await t.run((ctx) =>
+      ctx.db.insert("calendarSubCalendars", {
+        connectionId,
+        externalId: "work@example.com",
+        label: "Work",
+        showAsBusy: false,
+      }),
+    );
+
+    await t.mutation(internal.calendars.db.setEnabledSubCalendars.setEnabledSubCalendars, {
+      connectionId,
+      selections: [{ externalId: "work@example.com", label: "Work" }],
+    });
+
+    const row = await t.run((ctx) => ctx.db.get(existingId));
+    expect(row?.showAsBusy).toBe(false);
+  });
+
+  test("deletes rows whose externalId is no longer in the selection", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t, "owner");
+    const connectionId = await insertConnection(t, userId);
+    await insertSubCalendar(t, connectionId, "work@example.com", "Work");
+    await insertSubCalendar(t, connectionId, "old@example.com", "Old");
+
+    await t.mutation(internal.calendars.db.setEnabledSubCalendars.setEnabledSubCalendars, {
+      connectionId,
+      selections: [{ externalId: "work@example.com", label: "Work" }],
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const rows = await t.run((ctx) =>
+      ctx.db
+        .query("calendarSubCalendars")
+        .withIndex("byConnection", (q) => q.eq("connectionId", connectionId))
+        .collect(),
+    );
+    expect(rows.map((r) => r.externalId)).toEqual(["work@example.com"]);
+  });
+
+  test("schedules deleteConnectionEvents for each removed sub-calendar so its events drain", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t, "owner");
+    const connectionId = await insertConnection(t, userId);
+    const removed = await insertSubCalendar(t, connectionId, "old@example.com", "Old");
+    const kept = await insertSubCalendar(t, connectionId, "work@example.com", "Work");
+    await insertEvent(t, userId, connectionId, removed, "removed-evt-1");
+    await insertEvent(t, userId, connectionId, removed, "removed-evt-2");
+    await insertEvent(t, userId, connectionId, kept, "kept-evt");
+
+    await t.mutation(internal.calendars.db.setEnabledSubCalendars.setEnabledSubCalendars, {
+      connectionId,
+      selections: [{ externalId: "work@example.com", label: "Work" }],
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const events = await t.run((ctx) => ctx.db.query("calendarEvents").collect());
+    expect(events.map((e) => e.externalId)).toEqual(["kept-evt"]);
+  });
+
+  test("removes every row when the selection is empty", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t, "owner");
+    const connectionId = await insertConnection(t, userId);
+    const oldA = await insertSubCalendar(t, connectionId, "a@example.com", "A");
+    const oldB = await insertSubCalendar(t, connectionId, "b@example.com", "B");
+    await insertEvent(t, userId, connectionId, oldA, "a-1");
+    await insertEvent(t, userId, connectionId, oldB, "b-1");
+
+    await t.mutation(internal.calendars.db.setEnabledSubCalendars.setEnabledSubCalendars, {
+      connectionId,
+      selections: [],
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const rows = await t.run((ctx) =>
+      ctx.db
+        .query("calendarSubCalendars")
+        .withIndex("byConnection", (q) => q.eq("connectionId", connectionId))
+        .collect(),
+    );
+    const events = await t.run((ctx) => ctx.db.query("calendarEvents").collect());
+    expect(rows).toEqual([]);
+    expect(events).toEqual([]);
+  });
+
+  test("does not touch sub-calendars that belong to a different connection", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t, "owner");
+    const connectionId = await insertConnection(t, userId);
+    const otherConnectionId = await insertConnection(t, userId);
+    const otherRow = await insertSubCalendar(t, otherConnectionId, "other@example.com", "Other");
+
+    await t.mutation(internal.calendars.db.setEnabledSubCalendars.setEnabledSubCalendars, {
+      connectionId,
+      selections: [{ externalId: "new@example.com", label: "New" }],
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const stillThere = await t.run((ctx) => ctx.db.get(otherRow));
+    expect(stillThere).not.toBeNull();
+  });
+
+  test("performs both adds and removals in a single call", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t, "owner");
+    const connectionId = await insertConnection(t, userId);
+    await insertSubCalendar(t, connectionId, "keep@example.com", "Keep");
+    await insertSubCalendar(t, connectionId, "drop@example.com", "Drop");
+
+    await t.mutation(internal.calendars.db.setEnabledSubCalendars.setEnabledSubCalendars, {
+      connectionId,
+      selections: [
+        { externalId: "keep@example.com", label: "Keep" },
+        { externalId: "new@example.com", label: "New" },
+      ],
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const rows = await t.run((ctx) =>
+      ctx.db
+        .query("calendarSubCalendars")
+        .withIndex("byConnection", (q) => q.eq("connectionId", connectionId))
+        .collect(),
+    );
+    expect(rows.map((r) => r.externalId).sort()).toEqual(["keep@example.com", "new@example.com"]);
+  });
+});

--- a/convex/calendars/db/setEnabledSubCalendars.test.ts
+++ b/convex/calendars/db/setEnabledSubCalendars.test.ts
@@ -234,6 +234,35 @@ describe("setEnabledSubCalendars", () => {
     expect(stillThere).not.toBeNull();
   });
 
+  test("dedupes selections by externalId so duplicates do not insert duplicate rows", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t, "owner");
+    const connectionId = await insertConnection(t, userId);
+
+    await t.mutation(internal.calendars.db.setEnabledSubCalendars.setEnabledSubCalendars, {
+      connectionId,
+      selections: [
+        { externalId: "work@example.com", label: "Work" },
+        { externalId: "work@example.com", label: "Work (duplicate)" },
+        { externalId: "personal@example.com", label: "Personal" },
+      ],
+    });
+
+    const rows = await t.run((ctx) =>
+      ctx.db
+        .query("calendarSubCalendars")
+        .withIndex("byConnection", (q) => q.eq("connectionId", connectionId))
+        .collect(),
+    );
+    expect(rows.map((r) => r.externalId).sort()).toEqual([
+      "personal@example.com",
+      "work@example.com",
+    ]);
+    // Last entry wins for the duplicated externalId.
+    const work = rows.find((r) => r.externalId === "work@example.com");
+    expect(work?.label).toBe("Work (duplicate)");
+  });
+
   test("performs both adds and removals in a single call", async () => {
     const t = convexTest(schema, modules);
     const userId = await insertUser(t, "owner");

--- a/convex/calendars/db/setEnabledSubCalendars.ts
+++ b/convex/calendars/db/setEnabledSubCalendars.ts
@@ -1,0 +1,52 @@
+import { v } from "convex/values";
+
+import { internal } from "../../_generated/api";
+import { internalMutation } from "../../_generated/server";
+
+// Diff the caller's selection against the existing calendarSubCalendars
+// rows for this connection: insert rows for newly enabled sub-calendars
+// (showAsBusy defaulting to true), delete rows for deselected ones, and
+// schedule deleteConnectionEvents per removed sub-calendar so its cached
+// events drain on the cascade chain rather than blowing this mutation's
+// write budget. Sub-calendar counts are small in practice (<20), so the
+// row-level work runs in one transaction without batching.
+export const setEnabledSubCalendars = internalMutation({
+  args: {
+    connectionId: v.id("calendarConnections"),
+    selections: v.array(
+      v.object({
+        externalId: v.string(),
+        label: v.string(),
+      }),
+    ),
+  },
+  handler: async (ctx, { connectionId, selections }) => {
+    const existing = await ctx.db
+      .query("calendarSubCalendars")
+      .withIndex("byConnection", (q) => q.eq("connectionId", connectionId))
+      .collect();
+
+    const existingByExternalId = new Map(existing.map((row) => [row.externalId, row]));
+    const selectedExternalIds = new Set(selections.map((s) => s.externalId));
+
+    const toAdd = selections.filter((s) => !existingByExternalId.has(s.externalId));
+    const toRemove = existing.filter((row) => !selectedExternalIds.has(row.externalId));
+
+    await Promise.all([
+      ...toAdd.map((sel) =>
+        ctx.db.insert("calendarSubCalendars", {
+          connectionId,
+          externalId: sel.externalId,
+          label: sel.label,
+          showAsBusy: true,
+        }),
+      ),
+      ...toRemove.flatMap((row) => [
+        ctx.scheduler.runAfter(0, internal.calendars.db.cascadeDelete.deleteConnectionEvents, {
+          subCalendarId: row._id,
+        }),
+        ctx.db.delete(row._id),
+      ]),
+    ]);
+  },
+});

--- a/convex/calendars/db/setEnabledSubCalendars.ts
+++ b/convex/calendars/db/setEnabledSubCalendars.ts
@@ -26,10 +26,18 @@ export const setEnabledSubCalendars = internalMutation({
       .withIndex("byConnection", (q) => q.eq("connectionId", connectionId))
       .collect();
 
-    const existingByExternalId = new Map(existing.map((row) => [row.externalId, row]));
-    const selectedExternalIds = new Set(selections.map((s) => s.externalId));
+    // Dedupe selections by externalId — the table has no uniqueness
+    // constraint on (connectionId, externalId), so duplicates in the
+    // caller's input would otherwise insert duplicate sub-calendar rows.
+    // Last entry wins per externalId.
+    const dedupedSelections = Array.from(
+      new Map(selections.map((s) => [s.externalId, s])).values(),
+    );
 
-    const toAdd = selections.filter((s) => !existingByExternalId.has(s.externalId));
+    const existingByExternalId = new Map(existing.map((row) => [row.externalId, row]));
+    const selectedExternalIds = new Set(dedupedSelections.map((s) => s.externalId));
+
+    const toAdd = dedupedSelections.filter((s) => !existingByExternalId.has(s.externalId));
     const toRemove = existing.filter((row) => !selectedExternalIds.has(row.externalId));
 
     await Promise.all([

--- a/convex/calendars/service/index.ts
+++ b/convex/calendars/service/index.ts
@@ -86,11 +86,15 @@ export function createCalendarService(providers: CalendarProviderRegistry) {
     },
 
     async setEnabledSubCalendars(
-      _ctx: ActionCtx,
-      _connectionId: Id<"calendarConnections">,
-      _subCalendarIds: string[],
+      ctx: ActionCtx,
+      connectionId: Id<"calendarConnections">,
+      selections: { externalId: string; label: string }[],
     ): Promise<void> {
-      throw new Error("Not implemented: service.setEnabledSubCalendars");
+      await requireOwnedConnection(ctx, connectionId);
+      await ctx.runMutation(internal.calendars.db.setEnabledSubCalendars.setEnabledSubCalendars, {
+        connectionId,
+        selections,
+      });
     },
   };
 }

--- a/convex/calendars/service/setEnabledSubCalendars.test.ts
+++ b/convex/calendars/service/setEnabledSubCalendars.test.ts
@@ -1,0 +1,220 @@
+/// <reference types="vite/client" />
+import type {
+  CalendarConnectContext,
+  CalendarConnectParams,
+  CalendarConnectResult,
+  CalendarProvider,
+  CalendarProviderRegistry,
+} from "@shared/calendars";
+import { convexTest, type TestConvex } from "convex-test";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { Id } from "../../_generated/dataModel";
+import schema from "../../schema";
+import { createCalendarService } from "./index";
+
+const modules = import.meta.glob("/convex/**/*.ts");
+
+const ownerIdentity = {
+  subject: "owner_clerk",
+  issuer: "https://example.clerk.test",
+  tokenIdentifier: "https://example.clerk.test|owner_clerk",
+};
+
+const otherIdentity = {
+  subject: "other_clerk",
+  issuer: "https://example.clerk.test",
+  tokenIdentifier: "https://example.clerk.test|other_clerk",
+};
+
+const stubProvider: CalendarProvider = {
+  capabilities: { serverSidePullable: false, writable: false, hasSubCalendars: false },
+  async connect(
+    _ctx: unknown,
+    _params: CalendarConnectParams,
+    _context: CalendarConnectContext,
+  ): Promise<CalendarConnectResult> {
+    throw new Error("not used by setEnabledSubCalendars");
+  },
+};
+
+const stubRegistry: CalendarProviderRegistry = {
+  google: stubProvider,
+  ical: stubProvider,
+  microsoft: stubProvider,
+  native: stubProvider,
+};
+
+const service = createCalendarService(stubRegistry);
+
+async function seed(t: TestConvex<typeof schema>) {
+  const owner = await t.run((ctx) =>
+    ctx.db.insert("users", {
+      externalAuthId: ownerIdentity.subject,
+      email: "owner@example.com",
+      hasCompletedOnboarding: false,
+      isPublic: false,
+    }),
+  );
+  const other = await t.run((ctx) =>
+    ctx.db.insert("users", {
+      externalAuthId: otherIdentity.subject,
+      email: "other@example.com",
+      hasCompletedOnboarding: false,
+      isPublic: false,
+    }),
+  );
+  const connectionId = await t.run((ctx) =>
+    ctx.db.insert("calendarConnections", {
+      userId: owner,
+      provider: "google",
+      label: "Work",
+      createdAt: Date.now(),
+      color: "#6366f1",
+      syncErrorCount: 0,
+    }),
+  );
+  return { owner, other, connectionId };
+}
+
+async function insertSubCalendar(
+  t: TestConvex<typeof schema>,
+  connectionId: Id<"calendarConnections">,
+  externalId: string,
+  label: string,
+) {
+  return t.run((ctx) =>
+    ctx.db.insert("calendarSubCalendars", {
+      connectionId,
+      externalId,
+      label,
+      showAsBusy: true,
+    }),
+  );
+}
+
+describe("CalendarService.setEnabledSubCalendars", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("inserts rows for newly selected sub-calendars when the caller owns the connection", async () => {
+    const t = convexTest(schema, modules);
+    const { connectionId } = await seed(t);
+
+    await t.withIdentity(ownerIdentity).action(async (ctx) => {
+      await service.setEnabledSubCalendars(ctx, connectionId, [
+        { externalId: "work@example.com", label: "Work" },
+      ]);
+    });
+
+    const rows = await t.run((ctx) =>
+      ctx.db
+        .query("calendarSubCalendars")
+        .withIndex("byConnection", (q) => q.eq("connectionId", connectionId))
+        .collect(),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      externalId: "work@example.com",
+      label: "Work",
+      showAsBusy: true,
+    });
+  });
+
+  test("removes deselected rows and prunes their events via scheduled deleteConnectionEvents", async () => {
+    const t = convexTest(schema, modules);
+    const { owner, connectionId } = await seed(t);
+    const removed = await insertSubCalendar(t, connectionId, "old@example.com", "Old");
+    await t.run((ctx) =>
+      ctx.db.insert("calendarEvents", {
+        userId: owner,
+        connectionId,
+        subCalendarId: removed,
+        externalId: "evt-1",
+        title: "evt-1",
+        startsAt: Date.now(),
+        endsAt: Date.now() + 60_000,
+        isAllDay: false,
+        updatedAt: Date.now(),
+      }),
+    );
+
+    await t.withIdentity(ownerIdentity).action(async (ctx) => {
+      await service.setEnabledSubCalendars(ctx, connectionId, []);
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const rows = await t.run((ctx) =>
+      ctx.db
+        .query("calendarSubCalendars")
+        .withIndex("byConnection", (q) => q.eq("connectionId", connectionId))
+        .collect(),
+    );
+    const events = await t.run((ctx) => ctx.db.query("calendarEvents").collect());
+    expect(rows).toEqual([]);
+    expect(events).toEqual([]);
+  });
+
+  test("throws when the caller is not authenticated and writes nothing", async () => {
+    const t = convexTest(schema, modules);
+    const { connectionId } = await seed(t);
+
+    await expect(
+      t.action(async (ctx) => {
+        await service.setEnabledSubCalendars(ctx, connectionId, [
+          { externalId: "work@example.com", label: "Work" },
+        ]);
+      }),
+    ).rejects.toThrow(/not authenticated/i);
+
+    const rows = await t.run((ctx) => ctx.db.query("calendarSubCalendars").collect());
+    expect(rows).toEqual([]);
+  });
+
+  test("throws when the caller does not own the connection and writes nothing", async () => {
+    const t = convexTest(schema, modules);
+    const { connectionId } = await seed(t);
+
+    await expect(
+      t.withIdentity(otherIdentity).action(async (ctx) => {
+        await service.setEnabledSubCalendars(ctx, connectionId, [
+          { externalId: "work@example.com", label: "Work" },
+        ]);
+      }),
+    ).rejects.toThrow(/not found/i);
+
+    const rows = await t.run((ctx) => ctx.db.query("calendarSubCalendars").collect());
+    expect(rows).toEqual([]);
+  });
+
+  test("leaves unchanged sub-calendars untouched", async () => {
+    const t = convexTest(schema, modules);
+    const { connectionId } = await seed(t);
+    const keptId = await insertSubCalendar(t, connectionId, "work@example.com", "Work");
+
+    await t.withIdentity(ownerIdentity).action(async (ctx) => {
+      await service.setEnabledSubCalendars(ctx, connectionId, [
+        { externalId: "work@example.com", label: "Work" },
+        { externalId: "personal@example.com", label: "Personal" },
+      ]);
+    });
+
+    const rows = await t.run((ctx) =>
+      ctx.db
+        .query("calendarSubCalendars")
+        .withIndex("byConnection", (q) => q.eq("connectionId", connectionId))
+        .collect(),
+    );
+    const keptRow = rows.find((r) => r.externalId === "work@example.com");
+    expect(keptRow?._id).toBe(keptId);
+    expect(rows.map((r) => r.externalId).sort()).toEqual([
+      "personal@example.com",
+      "work@example.com",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- Implements `CalendarService.setEnabledSubCalendars(connectionId, selections)` per #126.
- Adds `internal.calendars.db.setEnabledSubCalendars` mutation that diffs the caller's selection against existing `calendarSubCalendars` rows and writes the result in one transaction.
- Newly enabled sub-calendars get a row inserted with `showAsBusy: true`. Deselected sub-calendars get their row deleted and a per-sub-calendar `deleteConnectionEvents` job scheduled (from #122) so cached events drain on the cascade chain.
- Ownership is verified via `requireOwnedConnection` before any writes; unauthenticated/non-owner callers get the standard error and write nothing.

## Test Plan

- [x] `npx tsc --noEmit` — zero errors
- [x] `npm run lint`
- [x] `npm run fmt:check`
- [x] `npm run test -- convex/calendars` — 161 passed (16 files), including 8 new mutation-level cases and 5 new service-level cases covering: insert with `showAsBusy=true` default, untouched-row preservation (including custom `showAsBusy=false`), removal + scheduled event prune, empty-selection → wipe, cross-connection isolation, mixed add+remove, ownership/auth rejection.

## Checklist
- [x] TypeScript compiles with zero errors
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass

Closes #126