### PR TITLE
feat(calendars): #128 syncWithRetry + syncAfterConnect

### DIFF
--- a/convex/calendars/db/incrementSyncError.ts
+++ b/convex/calendars/db/incrementSyncError.ts
@@ -1,0 +1,26 @@
+import { v } from "convex/values";
+
+import { internalMutation } from "../../_generated/server";
+
+// Record a sync failure on a Calendar Connection: bump the failure counter
+// and store the error message. Returns the new count so the caller (the
+// retry wrapper) can decide whether to schedule another attempt without a
+// second round-trip to the database.
+export const incrementSyncError = internalMutation({
+  args: {
+    connectionId: v.id("calendarConnections"),
+    errorMessage: v.string(),
+  },
+  handler: async (ctx, args): Promise<number> => {
+    const connection = await ctx.db.get(args.connectionId);
+    if (!connection) {
+      throw new Error(`Calendar Connection ${args.connectionId} not found`);
+    }
+    const newCount = connection.syncErrorCount + 1;
+    await ctx.db.patch(args.connectionId, {
+      syncErrorCount: newCount,
+      lastSyncError: args.errorMessage,
+    });
+    return newCount;
+  },
+});

--- a/convex/calendars/service/connect.test.ts
+++ b/convex/calendars/service/connect.test.ts
@@ -7,7 +7,7 @@ import type {
 } from "@shared/calendars";
 /// <reference types="vite/client" />
 import { convexTest, type TestConvex } from "convex-test";
-import { describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import type { Id } from "../../_generated/dataModel";
 import schema from "../../schema";
@@ -90,6 +90,19 @@ const emptyResult = (): CalendarConnectResult => ({
 });
 
 describe("CalendarService.connect", () => {
+  // Fake timers prevent the post-connect runAfter(0, ...) callback from
+  // firing on the next tick — its production target invokes the real
+  // iCal provider (which throws "Not implemented") outside any
+  // transaction and surfaces as an unhandled rejection. Real timers are
+  // restored in afterEach without firing the queued callbacks.
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   test("throws when the caller is not authenticated", async () => {
     const t = convexTest(schema, modules);
     const calls: StubCall[] = [];
@@ -263,5 +276,46 @@ describe("CalendarService.connect", () => {
 
     expect(microsoftCalls).toHaveLength(1);
     expect(otherCalls).toEqual([]);
+  });
+
+  test("schedules an immediate post-connect sync for non-native providers", async () => {
+    const t = convexTest(schema, modules);
+    await insertUser(t, identity.subject);
+
+    const calls: StubCall[] = [];
+    const service = createCalendarService(buildRegistry(emptyResult, calls));
+
+    const newConnectionId = await t.withIdentity(identity).action(async (ctx) =>
+      service.connect(ctx, {
+        provider: "ical",
+        url: "https://example.com/cal.ics",
+        label: "Family iCloud",
+      }),
+    );
+
+    const scheduled = await t.run((ctx) => ctx.db.system.query("_scheduled_functions").collect());
+    const retries = scheduled.filter((row) => row.name === "calendars/syncWithRetry:syncWithRetry");
+    expect(retries).toHaveLength(1);
+    expect(retries[0].args).toEqual([{ connectionId: newConnectionId }]);
+  });
+
+  test("does NOT schedule a post-connect sync for native connections", async () => {
+    const t = convexTest(schema, modules);
+    await insertUser(t, identity.subject);
+
+    const calls: StubCall[] = [];
+    const service = createCalendarService(buildRegistry(emptyResult, calls));
+
+    await t.withIdentity(identity).action(async (ctx) =>
+      service.connect(ctx, {
+        provider: "native",
+        deviceCalendarId: "device-cal-1",
+        label: "Phone",
+      }),
+    );
+
+    const scheduled = await t.run((ctx) => ctx.db.system.query("_scheduled_functions").collect());
+    const retries = scheduled.filter((row) => row.name === "calendars/syncWithRetry:syncWithRetry");
+    expect(retries).toEqual([]);
   });
 });

--- a/convex/calendars/service/index.ts
+++ b/convex/calendars/service/index.ts
@@ -13,6 +13,7 @@ import { requireOwnedConnection } from "../auth/requireOwnedConnection";
 import { assignPaletteColour } from "../domain/assignPaletteColour";
 import { expandRecurrence } from "../domain/expandRecurrence";
 import { filterSubCalendars } from "../domain/filterSubCalendars";
+import { syncAfterConnect } from "../syncAfterConnect";
 
 export function currentSyncWindow(): SyncWindow {
   return {
@@ -66,7 +67,7 @@ export function createCalendarService(providers: CalendarProviderRegistry) {
       // two-mutation flow (provider wrote the connection row, service
       // wrote the sub-calendar) which could orphan an iCal connection
       // without its synthetic Sub-Calendar on partial failure.
-      return ctx.runMutation(
+      const connectionId: Id<"calendarConnections"> = await ctx.runMutation(
         internal.calendars.db.insertCalendarConnection.insertCalendarConnection,
         {
           userId: user._id,
@@ -77,6 +78,17 @@ export function createCalendarService(providers: CalendarProviderRegistry) {
           subCalendars: result.subCalendars,
         },
       );
+
+      // Kick off an immediate sync so the user sees their events without
+      // waiting for the cron sweep. Native connections sync from the
+      // device, not the server — scheduling a server-side sync there
+      // would just hit the "native syncs from the device" guard and burn
+      // through the retry budget.
+      if (params.provider !== "native") {
+        await syncAfterConnect(ctx, connectionId);
+      }
+
+      return connectionId;
     },
 
     async disconnect(ctx: ActionCtx, connectionId: Id<"calendarConnections">): Promise<void> {

--- a/convex/calendars/syncAfterConnect.test.ts
+++ b/convex/calendars/syncAfterConnect.test.ts
@@ -1,0 +1,63 @@
+/// <reference types="vite/client" />
+import { convexTest, type TestConvex } from "convex-test";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { Id } from "../_generated/dataModel";
+import schema from "../schema";
+import { syncAfterConnect } from "./syncAfterConnect";
+
+const modules = import.meta.glob("/convex/**/*.ts");
+
+async function insertUser(t: TestConvex<typeof schema>) {
+  return t.run((ctx) =>
+    ctx.db.insert("users", {
+      externalAuthId: "owner",
+      email: "owner@example.com",
+      hasCompletedOnboarding: false,
+      isPublic: false,
+    }),
+  );
+}
+
+async function insertConnection(t: TestConvex<typeof schema>, userId: Id<"users">) {
+  return t.run((ctx) =>
+    ctx.db.insert("calendarConnections", {
+      userId,
+      provider: "ical",
+      label: "Test",
+      color: "#6366f1",
+      createdAt: 0,
+      syncErrorCount: 0,
+    }),
+  );
+}
+
+describe("syncAfterConnect", () => {
+  // Fake timers prevent the runAfter(0, ...) callback from firing on the
+  // next tick — its production target invokes the real iCal provider
+  // (which throws "Not implemented") outside any transaction and surfaces
+  // as an unhandled rejection. Real timers are restored in afterEach
+  // without firing the queued callbacks.
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("schedules syncWithRetry with no delay for the given connection", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t);
+    const connectionId = await insertConnection(t, userId);
+
+    const before = Date.now();
+    await t.action((ctx) => syncAfterConnect(ctx, connectionId));
+
+    const scheduled = await t.run((ctx) => ctx.db.system.query("_scheduled_functions").collect());
+    const retries = scheduled.filter((row) => row.name === "calendars/syncWithRetry:syncWithRetry");
+    expect(retries).toHaveLength(1);
+    expect(retries[0].scheduledTime - before).toBeLessThan(1000);
+    expect(retries[0].args).toEqual([{ connectionId }]);
+  });
+});

--- a/convex/calendars/syncAfterConnect.ts
+++ b/convex/calendars/syncAfterConnect.ts
@@ -1,0 +1,14 @@
+import { internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import type { ActionCtx } from "../_generated/server";
+
+// Schedule an immediate sync for a freshly-connected Calendar Connection
+// so the user sees their events appear without waiting up to 15 minutes
+// for the cron sweep. Routed through syncWithRetry so the same backoff
+// and error tracking applies as a cron-driven sync.
+export async function syncAfterConnect(
+  ctx: ActionCtx,
+  connectionId: Id<"calendarConnections">,
+): Promise<void> {
+  await ctx.scheduler.runAfter(0, internal.calendars.syncWithRetry.syncWithRetry, { connectionId });
+}

--- a/convex/calendars/syncWithRetry.test.ts
+++ b/convex/calendars/syncWithRetry.test.ts
@@ -1,0 +1,214 @@
+/// <reference types="vite/client" />
+import { convexTest, type TestConvex } from "convex-test";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import schema from "../schema";
+import { RETRY_DELAYS_MS, runSyncWithRetry } from "./syncWithRetry";
+
+const modules = import.meta.glob("/convex/**/*.ts");
+
+async function insertUser(t: TestConvex<typeof schema>) {
+  return t.run((ctx) =>
+    ctx.db.insert("users", {
+      externalAuthId: "owner",
+      email: "owner@example.com",
+      hasCompletedOnboarding: false,
+      isPublic: false,
+    }),
+  );
+}
+
+async function insertConnection(
+  t: TestConvex<typeof schema>,
+  userId: Id<"users">,
+  overrides: Partial<{
+    syncErrorCount: number;
+    lastSyncError: string;
+    lastSyncedAt: number;
+  }> = {},
+) {
+  return t.run((ctx) =>
+    ctx.db.insert("calendarConnections", {
+      userId,
+      provider: "ical",
+      label: "Test",
+      color: "#6366f1",
+      createdAt: 0,
+      syncErrorCount: 0,
+      ...overrides,
+    }),
+  );
+}
+
+async function listScheduledSyncRetries(t: TestConvex<typeof schema>) {
+  const all = await t.run((ctx) => ctx.db.system.query("_scheduled_functions").collect());
+  return all.filter((row) => row.name === "calendars/syncWithRetry:syncWithRetry");
+}
+
+describe("runSyncWithRetry", () => {
+  // Fake timers prevent the queued retry's setTimeout from firing on
+  // teardown — its production target invokes the real iCal provider
+  // (which throws "Not implemented") outside any transaction and surfaces
+  // as an unhandled rejection. Real timers are restored in afterEach
+  // without firing the queued callbacks.
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("does not touch error state when sync resolves", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t);
+    const connectionId = await insertConnection(t, userId);
+    const sync = vi.fn(async () => {});
+
+    await t.action((ctx) => runSyncWithRetry(ctx, connectionId, sync));
+
+    expect(sync).toHaveBeenCalledTimes(1);
+    const conn = await t.run((ctx) => ctx.db.get(connectionId));
+    expect(conn?.syncErrorCount).toBe(0);
+    expect(conn?.lastSyncError).toBeUndefined();
+    const scheduled = await listScheduledSyncRetries(t);
+    expect(scheduled).toHaveLength(0);
+  });
+
+  test("on first failure increments syncErrorCount and stores the error message", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t);
+    const connectionId = await insertConnection(t, userId);
+
+    await t.action((ctx) =>
+      runSyncWithRetry(ctx, connectionId, async () => {
+        throw new Error("provider unreachable");
+      }),
+    );
+
+    const conn = await t.run((ctx) => ctx.db.get(connectionId));
+    expect(conn?.syncErrorCount).toBe(1);
+    expect(conn?.lastSyncError).toBe("provider unreachable");
+  });
+
+  test("schedules the next attempt 15 minutes out after the 1st failure", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t);
+    const connectionId = await insertConnection(t, userId);
+
+    const before = Date.now();
+    await t.action((ctx) =>
+      runSyncWithRetry(ctx, connectionId, async () => {
+        throw new Error("boom");
+      }),
+    );
+
+    const scheduled = await listScheduledSyncRetries(t);
+    expect(scheduled).toHaveLength(1);
+    expect(scheduled[0].scheduledTime - before).toBeGreaterThanOrEqual(RETRY_DELAYS_MS[0]);
+    expect(scheduled[0].scheduledTime - before).toBeLessThan(RETRY_DELAYS_MS[0] + 1000);
+    expect(scheduled[0].args).toEqual([{ connectionId }]);
+  });
+
+  test("schedules the next attempt 30 minutes out after the 2nd failure", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t);
+    const connectionId = await insertConnection(t, userId, { syncErrorCount: 1 });
+
+    const before = Date.now();
+    await t.action((ctx) =>
+      runSyncWithRetry(ctx, connectionId, async () => {
+        throw new Error("boom");
+      }),
+    );
+
+    const scheduled = await listScheduledSyncRetries(t);
+    expect(scheduled).toHaveLength(1);
+    expect(scheduled[0].scheduledTime - before).toBeGreaterThanOrEqual(RETRY_DELAYS_MS[1]);
+    expect(scheduled[0].scheduledTime - before).toBeLessThan(RETRY_DELAYS_MS[1] + 1000);
+  });
+
+  test("schedules the next attempt 60 minutes out after the 3rd failure", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t);
+    const connectionId = await insertConnection(t, userId, { syncErrorCount: 2 });
+
+    const before = Date.now();
+    await t.action((ctx) =>
+      runSyncWithRetry(ctx, connectionId, async () => {
+        throw new Error("boom");
+      }),
+    );
+
+    const scheduled = await listScheduledSyncRetries(t);
+    expect(scheduled).toHaveLength(1);
+    expect(scheduled[0].scheduledTime - before).toBeGreaterThanOrEqual(RETRY_DELAYS_MS[2]);
+    expect(scheduled[0].scheduledTime - before).toBeLessThan(RETRY_DELAYS_MS[2] + 1000);
+  });
+
+  test("stops scheduling once syncErrorCount exceeds the retry budget", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t);
+    const connectionId = await insertConnection(t, userId, { syncErrorCount: 3 });
+
+    await t.action((ctx) =>
+      runSyncWithRetry(ctx, connectionId, async () => {
+        throw new Error("still down");
+      }),
+    );
+
+    const conn = await t.run((ctx) => ctx.db.get(connectionId));
+    expect(conn?.syncErrorCount).toBe(4);
+    expect(conn?.lastSyncError).toBe("still down");
+    const scheduled = await listScheduledSyncRetries(t);
+    expect(scheduled).toHaveLength(0);
+  });
+
+  test("coerces non-Error thrown values to a string before storing", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t);
+    const connectionId = await insertConnection(t, userId);
+
+    await t.action((ctx) =>
+      runSyncWithRetry(ctx, connectionId, async () => {
+        // eslint-disable-next-line @typescript-eslint/only-throw-error
+        throw "oh no";
+      }),
+    );
+
+    const conn = await t.run((ctx) => ctx.db.get(connectionId));
+    expect(conn?.lastSyncError).toBe("oh no");
+  });
+
+  test("on success, the injected sync's reset of error state is preserved", async () => {
+    // runSyncWithRetry alone does not reset on success — that responsibility
+    // sits with CalendarService.sync's success-path write
+    // (markConnectionSynced). This test pins the contract: when the
+    // injected sync DOES touch the connection (as the real sync does),
+    // runSyncWithRetry preserves those writes and adds nothing of its own.
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t);
+    const connectionId = await insertConnection(t, userId, {
+      syncErrorCount: 5,
+      lastSyncError: "old failure",
+    });
+
+    const sync = async (
+      ctx: Parameters<typeof runSyncWithRetry>[0],
+      id: Id<"calendarConnections">,
+    ) => {
+      await ctx.runMutation(internal.calendars.db.markConnectionSynced.markConnectionSynced, {
+        connectionId: id,
+      });
+    };
+
+    await t.action((ctx) => runSyncWithRetry(ctx, connectionId, sync));
+
+    const conn = await t.run((ctx) => ctx.db.get(connectionId));
+    expect(conn?.syncErrorCount).toBe(0);
+    expect(conn?.lastSyncError).toBeUndefined();
+    expect(conn?.lastSyncedAt).toBeTypeOf("number");
+  });
+});

--- a/convex/calendars/syncWithRetry.ts
+++ b/convex/calendars/syncWithRetry.ts
@@ -1,0 +1,47 @@
+"use node";
+
+import { v } from "convex/values";
+
+import { internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import { type ActionCtx, internalAction } from "../_generated/server";
+import { calendarService } from "./service/registry";
+
+// Backoff schedule keyed by the post-failure error count: count=1 waits 15
+// minutes before the next attempt, count=2 waits 30, count=3 waits 60. A
+// 4th failure (count > schedule length) leaves the badge visible and stops
+// scheduling — the user must manually re-sync from the management sheet.
+export const RETRY_DELAYS_MS: readonly number[] = [15 * 60 * 1000, 30 * 60 * 1000, 60 * 60 * 1000];
+
+// Pure retry orchestration extracted so tests can inject a mock sync
+// without going through the production provider registry. The action
+// handler below wires it to calendarService.sync.
+export async function runSyncWithRetry(
+  ctx: ActionCtx,
+  connectionId: Id<"calendarConnections">,
+  sync: (ctx: ActionCtx, id: Id<"calendarConnections">) => Promise<void>,
+): Promise<void> {
+  try {
+    await sync(ctx, connectionId);
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    const newCount: number = await ctx.runMutation(
+      internal.calendars.db.incrementSyncError.incrementSyncError,
+      { connectionId, errorMessage },
+    );
+    if (newCount <= RETRY_DELAYS_MS.length) {
+      await ctx.scheduler.runAfter(
+        RETRY_DELAYS_MS[newCount - 1],
+        internal.calendars.syncWithRetry.syncWithRetry,
+        { connectionId },
+      );
+    }
+  }
+}
+
+export const syncWithRetry = internalAction({
+  args: { connectionId: v.id("calendarConnections") },
+  handler: async (ctx, args) => {
+    await runSyncWithRetry(ctx, args.connectionId, calendarService.sync);
+  },
+});


### PR DESCRIPTION
## Summary

- Adds `runSyncWithRetry` orchestration with **15 → 30 → 60 minute** exponential backoff via `ctx.scheduler.runAfter`. After three retries the chain stops; the `syncErrorCount > 3` badge stays visible until the user manually re-syncs or reconnects.
- Adds `incrementSyncError` internal mutation that bumps `syncErrorCount` and stores `lastSyncError` in one transaction, returning the new count so the wrapper can decide whether to schedule another attempt without a second round-trip.
- Adds `syncAfterConnect` helper that schedules an immediate retry-wrapped sync; `CalendarService.connect` now invokes it for every non-native provider so users see events appear without waiting for the cron sweep.
- Native is intentionally skipped — server-side sync throws for device-backed connections, so scheduling a retry there would just burn the budget.
- Reuses the existing `markConnectionSynced` for the success path. `CalendarService.sync` already calls it at the end of a successful pass, so the retry wrapper does nothing on success — `resetSyncState` was not added because it would be a strict duplicate.

## Test Plan

- [x] `npx tsc --noEmit` — zero errors
- [x] `npm run lint` — zero warnings
- [x] `npm run fmt:check` — clean
- [x] `npm run test` — 265 tests passing (added 9 new tests covering: retry-on-failure, no-op on success, 1st/2nd/3rd backoff delays, stop-after-budget, non-Error coercion, success path preservation, syncAfterConnect schedule, post-connect schedule for non-native, post-connect skip for native)
- [ ] Manual: trip a sync failure on a Google or iCal connection and verify the badge appears in the management sheet, then verify it clears after a successful retry

## Checklist

- [x] TypeScript compiles with zero errors
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass

Closes #128