### PR TITLE
feat(calendars): #129 Google provider — PKCE connect + server-side token exchange

### DIFF
--- a/convex/calendars/domain/crypto.ts
+++ b/convex/calendars/domain/crypto.ts
@@ -1,0 +1,22 @@
+import { createCipheriv, randomBytes } from "node:crypto";
+
+// Encrypts arbitrary JSON data using AES-256-GCM.
+// Layout of returned buffer: [12-byte IV][16-byte auth tag][ciphertext]
+// Key must be a base64-encoded 32-byte value in CALENDAR_ENCRYPTION_KEY env var.
+export async function encryptJson(data: unknown): Promise<ArrayBuffer> {
+  const keyEnv = process.env.CALENDAR_ENCRYPTION_KEY;
+  if (!keyEnv) throw new Error("CALENDAR_ENCRYPTION_KEY env var not set");
+
+  const key = Buffer.from(keyEnv, "base64");
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", key, iv);
+  const json = JSON.stringify(data);
+  const ciphertext = Buffer.concat([cipher.update(json, "utf8"), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+
+  const result = new Uint8Array(12 + 16 + ciphertext.length);
+  result.set(iv, 0);
+  result.set(authTag, 12);
+  result.set(ciphertext, 28);
+  return result.buffer;
+}

--- a/convex/calendars/providers/google.ts
+++ b/convex/calendars/providers/google.ts
@@ -38,7 +38,6 @@ type GoogleUserInfo = {
 type GoogleCalendarListItem = {
   id: string;
   summary: string;
-  primary?: boolean;
 };
 
 type GoogleCalendarListResponse = {
@@ -120,7 +119,7 @@ export const GoogleCalendarProvider: CalendarProvider = {
         subCalendars.push({
           externalId: item.id,
           label: item.summary,
-          showAsBusy: !!item.primary,
+          showAsBusy: true,
         });
       }
     }

--- a/convex/calendars/providers/google.ts
+++ b/convex/calendars/providers/google.ts
@@ -1,3 +1,5 @@
+"use node";
+
 import type {
   CalendarConnectContext,
   CalendarConnectParams,
@@ -6,10 +8,13 @@ import type {
   CalendarProviderCapabilities,
   IncomingEvent,
   SubCalendar,
+  SubCalendarBlueprint,
   SyncWindow,
   WriteError,
   WriteSuccess,
 } from "@shared/calendars";
+
+import { encryptJson } from "../domain/crypto";
 
 export const googleCapabilities: CalendarProviderCapabilities = {
   serverSidePullable: true,
@@ -17,15 +22,122 @@ export const googleCapabilities: CalendarProviderCapabilities = {
   hasSubCalendars: true,
 };
 
+type GoogleTokenResponse = {
+  access_token: string;
+  refresh_token?: string;
+  expires_in: number;
+  scope: string;
+  token_type: string;
+};
+
+type GoogleUserInfo = {
+  sub: string;
+  email: string;
+};
+
+type GoogleCalendarListItem = {
+  id: string;
+  summary: string;
+  primary?: boolean;
+};
+
+type GoogleCalendarListResponse = {
+  items?: GoogleCalendarListItem[];
+};
+
+function throwAuthError(message: string): never {
+  throw Object.assign(new Error(message), { kind: "auth" as const });
+}
+
 export const GoogleCalendarProvider: CalendarProvider = {
   capabilities: googleCapabilities,
 
   async connect(
     _ctx: unknown,
-    _params: CalendarConnectParams,
+    params: CalendarConnectParams,
     _context: CalendarConnectContext,
   ): Promise<CalendarConnectResult> {
-    throw new Error("Not implemented: Google Calendar connect");
+    if (params.provider !== "google") {
+      throw new Error("GoogleCalendarProvider.connect called with non-Google params");
+    }
+
+    const { authCode, codeVerifier, clientId, redirectUri } = params;
+
+    // 1. Exchange auth code for tokens (server-side PKCE flow)
+    const tokenBody: Record<string, string> = {
+      grant_type: "authorization_code",
+      code: authCode,
+      code_verifier: codeVerifier,
+      client_id: clientId,
+      redirect_uri: redirectUri,
+    };
+    const clientSecret = process.env.GOOGLE_CALENDAR_CLIENT_SECRET;
+    if (clientSecret) {
+      tokenBody.client_secret = clientSecret;
+    }
+
+    const tokenResponse = await fetch("https://oauth2.googleapis.com/token", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams(tokenBody).toString(),
+    });
+
+    if (!tokenResponse.ok) {
+      const errorText = await tokenResponse.text().catch(() => String(tokenResponse.status));
+      throwAuthError(`Google token exchange failed (${tokenResponse.status}): ${errorText}`);
+    }
+
+    const tokenData = (await tokenResponse.json()) as GoogleTokenResponse;
+    const {
+      access_token: accessToken,
+      refresh_token: refreshToken,
+      expires_in: expiresIn,
+      scope,
+      token_type: tokenType,
+    } = tokenData;
+
+    // 2. Fetch userinfo — sub is stable Google user identifier
+    const userInfoResponse = await fetch("https://openidconnect.googleapis.com/v1/userinfo", {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+
+    if (!userInfoResponse.ok) {
+      throwAuthError(`Google userinfo fetch failed (${userInfoResponse.status})`);
+    }
+
+    const userInfo = (await userInfoResponse.json()) as GoogleUserInfo;
+    const externalAccountId = userInfo.sub;
+
+    // 3. List sub-calendars so the connection is immediately syncable
+    const subCalendars: SubCalendarBlueprint[] = [];
+    const calListResponse = await fetch(
+      "https://www.googleapis.com/calendar/v3/users/me/calendarList",
+      { headers: { Authorization: `Bearer ${accessToken}` } },
+    );
+    if (calListResponse.ok) {
+      const calList = (await calListResponse.json()) as GoogleCalendarListResponse;
+      for (const item of calList.items ?? []) {
+        subCalendars.push({
+          externalId: item.id,
+          label: item.summary,
+          showAsBusy: !!item.primary,
+        });
+      }
+    }
+
+    // 4. Encrypt tokens — never leave the server unencrypted
+    const encryptedTokens = await encryptJson({ accessToken, refreshToken, tokenType });
+
+    return {
+      connection: {
+        externalAccountId,
+        oauthClientId: clientId,
+        encryptedTokens,
+        tokenExpiresAt: Date.now() + expiresIn * 1000,
+        scope,
+      },
+      subCalendars,
+    };
   },
 
   async fetchEvents(

--- a/types/calendars.ts
+++ b/types/calendars.ts
@@ -100,7 +100,7 @@ export type CalendarConnectionBlueprint = {
   localCalendarId?: string;
   scope?: string;
   oauthClientId?: string;
-  encryptedTokens?: Uint8Array;
+  encryptedTokens?: ArrayBuffer;
   tokenExpiresAt?: number;
 };
 


### PR DESCRIPTION
## Summary

- Implements `GoogleCalendarProvider.connect`: server-side PKCE auth code exchange, userinfo fetch, Google Calendar list population, and token encryption — returning the connection blueprint for the service to persist atomically
- Creates `convex/calendars/domain/crypto.ts` with `encryptJson` (AES-256-GCM; layout: `[12-byte IV][16-byte auth tag][ciphertext]`)
- Fixes `CalendarConnectionBlueprint.encryptedTokens` type: `Uint8Array → ArrayBuffer` to match `v.bytes()` / `insertCalendarConnection` validator

## Implementation notes

- `"use node"` added to `google.ts` — Node runtime required for crypto and fetch
- Supports both public-client (PKCE-only) and confidential-client flows via optional `GOOGLE_CALENDAR_CLIENT_SECRET` env var
- Calls Google Calendar List API during `connect` so the connection is immediately syncable (sub-calendars pre-populated); user can adjust via `setEnabledSubCalendars`
- Throws a `kind: "auth"` tagged error on non-200 token exchange or userinfo response

## Checklist

- [x] TypeScript compiles with zero errors
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass (254/254)

Closes #129