### PR TITLE
feat(calendars): #130 ensureAccessToken with nonce-based optimistic lock

### DIFF
--- a/convex/calendars/db/updateTokensIfNonce.ts
+++ b/convex/calendars/db/updateTokensIfNonce.ts
@@ -1,0 +1,28 @@
+import { v } from "convex/values";
+
+import { internalMutation } from "../../_generated/server";
+
+// Atomically refresh OAuth tokens only when the caller holds the current nonce.
+// Two concurrent cron actions can race to refresh the same connection's tokens.
+// The first writer sets a new nonce; the second's expectedNonce no longer matches,
+// so it returns false and reads the freshly written token instead of overwriting it.
+export const updateTokensIfNonce = internalMutation({
+  args: {
+    connectionId: v.id("calendarConnections"),
+    expectedNonce: v.optional(v.string()),
+    encryptedTokens: v.bytes(),
+    tokenExpiresAt: v.number(),
+    newNonce: v.string(),
+  },
+  handler: async (ctx, args): Promise<boolean> => {
+    const connection = await ctx.db.get(args.connectionId);
+    if (!connection) return false;
+    if (connection.refreshNonce !== args.expectedNonce) return false;
+    await ctx.db.patch(args.connectionId, {
+      encryptedTokens: args.encryptedTokens,
+      tokenExpiresAt: args.tokenExpiresAt,
+      refreshNonce: args.newNonce,
+    });
+    return true;
+  },
+});

--- a/convex/calendars/domain/crypto.ts
+++ b/convex/calendars/domain/crypto.ts
@@ -1,22 +1,44 @@
-import { createCipheriv, randomBytes } from "node:crypto";
-
-// Encrypts arbitrary JSON data using AES-256-GCM.
-// Layout of returned buffer: [12-byte IV][16-byte auth tag][ciphertext]
+// AES-256-GCM encryption/decryption using WebCrypto (SubtleCrypto).
+// Works in both Convex edge and Node.js runtimes, and in test environments.
+// Layout of encrypted buffer: [12-byte IV][16-byte auth tag][ciphertext]
 // Key must be a base64-encoded 32-byte value in CALENDAR_ENCRYPTION_KEY env var.
-export async function encryptJson(data: unknown): Promise<ArrayBuffer> {
+
+export type DecryptedTokens = { accessToken: string; refreshToken?: string; tokenType: string };
+
+async function importKey(usage: "encrypt" | "decrypt"): Promise<CryptoKey> {
   const keyEnv = process.env.CALENDAR_ENCRYPTION_KEY;
   if (!keyEnv) throw new Error("CALENDAR_ENCRYPTION_KEY env var not set");
+  const keyBytes = Uint8Array.from(atob(keyEnv), (c) => c.charCodeAt(0));
+  return globalThis.crypto.subtle.importKey("raw", keyBytes, { name: "AES-GCM" }, false, [usage]);
+}
 
-  const key = Buffer.from(keyEnv, "base64");
-  const iv = randomBytes(12);
-  const cipher = createCipheriv("aes-256-gcm", key, iv);
-  const json = JSON.stringify(data);
-  const ciphertext = Buffer.concat([cipher.update(json, "utf8"), cipher.final()]);
-  const authTag = cipher.getAuthTag();
-
-  const result = new Uint8Array(12 + 16 + ciphertext.length);
+export async function encryptJson(data: unknown): Promise<ArrayBuffer> {
+  const key = await importKey("encrypt");
+  const iv = globalThis.crypto.getRandomValues(new Uint8Array(12));
+  const json = new TextEncoder().encode(JSON.stringify(data));
+  // WebCrypto AES-GCM appends the 16-byte auth tag after the ciphertext.
+  // Re-pack to [IV(12)][authTag(16)][ciphertext] to match the stored layout.
+  const encrypted = new Uint8Array(
+    await globalThis.crypto.subtle.encrypt({ name: "AES-GCM", iv }, key, json),
+  );
+  const ciphertextLen = encrypted.length - 16;
+  const result = new Uint8Array(12 + 16 + ciphertextLen);
   result.set(iv, 0);
-  result.set(authTag, 12);
-  result.set(ciphertext, 28);
+  result.set(encrypted.slice(ciphertextLen), 12);
+  result.set(encrypted.slice(0, ciphertextLen), 28);
   return result.buffer;
+}
+
+export async function decryptJson(buffer: ArrayBuffer): Promise<DecryptedTokens> {
+  const key = await importKey("decrypt");
+  const bytes = new Uint8Array(buffer);
+  const iv = bytes.slice(0, 12);
+  const authTag = bytes.slice(12, 28);
+  const ciphertext = bytes.slice(28);
+  // WebCrypto AES-GCM decrypt expects ciphertext || authTag concatenated.
+  const combined = new Uint8Array(ciphertext.length + 16);
+  combined.set(ciphertext, 0);
+  combined.set(authTag, ciphertext.length);
+  const decrypted = await globalThis.crypto.subtle.decrypt({ name: "AES-GCM", iv }, key, combined);
+  return JSON.parse(new TextDecoder().decode(decrypted)) as DecryptedTokens;
 }

--- a/convex/calendars/providers/google.test.ts
+++ b/convex/calendars/providers/google.test.ts
@@ -1,0 +1,248 @@
+/// <reference types="vite/client" />
+import { convexTest, type TestConvex } from "convex-test";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { Id } from "../../_generated/dataModel";
+import schema from "../../schema";
+import { decryptJson, encryptJson } from "../domain/crypto";
+import { ensureAccessToken } from "./google";
+
+const modules = import.meta.glob("/convex/**/*.ts");
+
+// Base64-encoded 32-byte test key (all 0x01 bytes)
+const TEST_KEY = btoa(String.fromCharCode(...new Array(32).fill(1)));
+
+async function insertUser(t: TestConvex<typeof schema>) {
+  return t.run((ctx) =>
+    ctx.db.insert("users", {
+      externalAuthId: "owner",
+      email: "owner@example.com",
+      hasCompletedOnboarding: false,
+      isPublic: false,
+    }),
+  );
+}
+
+async function insertConnection(
+  t: TestConvex<typeof schema>,
+  userId: Id<"users">,
+  overrides: Partial<{
+    encryptedTokens: ArrayBuffer;
+    tokenExpiresAt: number;
+    refreshNonce: string;
+  }> = {},
+) {
+  return t.run((ctx) =>
+    ctx.db.insert("calendarConnections", {
+      userId,
+      provider: "google",
+      label: "Work",
+      color: "#6366f1",
+      createdAt: 0,
+      syncErrorCount: 0,
+      oauthClientId: "test-client-id",
+      ...overrides,
+    }),
+  );
+}
+
+describe("ensureAccessToken", () => {
+  beforeEach(() => {
+    vi.stubEnv("CALENDAR_ENCRYPTION_KEY", TEST_KEY);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  test("returns existing access token without refresh when expiry is more than 60s away", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t);
+    const encryptedTokens = await encryptJson({
+      accessToken: "valid-token",
+      refreshToken: "refresh-token",
+      tokenType: "Bearer",
+    });
+    const connectionId = await insertConnection(t, userId, {
+      encryptedTokens,
+      tokenExpiresAt: Date.now() + 120_000,
+    });
+    const connection = await t.run((ctx) => ctx.db.get(connectionId));
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const token = await t.action((ctx) => ensureAccessToken(ctx, connection!, "client-id"));
+
+    expect(token).toBe("valid-token");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test("refreshes and returns new token when within 60 seconds of expiry", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t);
+    const encryptedTokens = await encryptJson({
+      accessToken: "old-token",
+      refreshToken: "refresh-token",
+      tokenType: "Bearer",
+    });
+    const connectionId = await insertConnection(t, userId, {
+      encryptedTokens,
+      tokenExpiresAt: Date.now() + 30_000,
+    });
+    const connection = await t.run((ctx) => ctx.db.get(connectionId));
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: "new-token",
+          expires_in: 3600,
+          token_type: "Bearer",
+        }),
+      }),
+    );
+
+    const token = await t.action((ctx) => ensureAccessToken(ctx, connection!, "client-id"));
+
+    expect(token).toBe("new-token");
+    const updated = await t.run((ctx) => ctx.db.get(connectionId));
+    expect(updated?.tokenExpiresAt).toBeGreaterThan(Date.now() + 3_500_000);
+    expect(updated?.refreshNonce).toBeTypeOf("string");
+  });
+
+  test("also refreshes when tokenExpiresAt is not set", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t);
+    const encryptedTokens = await encryptJson({
+      accessToken: "old-token",
+      refreshToken: "refresh-token",
+      tokenType: "Bearer",
+    });
+    const connectionId = await insertConnection(t, userId, {
+      encryptedTokens,
+      // no tokenExpiresAt
+    });
+    const connection = await t.run((ctx) => ctx.db.get(connectionId));
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: "new-token",
+          expires_in: 3600,
+          token_type: "Bearer",
+        }),
+      }),
+    );
+
+    const token = await t.action((ctx) => ensureAccessToken(ctx, connection!, "client-id"));
+    expect(token).toBe("new-token");
+  });
+
+  test("throws auth SyncError when no refresh token and token is expiring", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t);
+    const encryptedTokens = await encryptJson({
+      accessToken: "old-token",
+      tokenType: "Bearer",
+      // no refreshToken
+    });
+    const connectionId = await insertConnection(t, userId, {
+      encryptedTokens,
+      tokenExpiresAt: Date.now() + 30_000,
+    });
+    const connection = await t.run((ctx) => ctx.db.get(connectionId));
+
+    await expect(
+      t.action((ctx) => ensureAccessToken(ctx, connection!, "client-id")),
+    ).rejects.toMatchObject({ kind: "auth" });
+  });
+
+  test("returns concurrent winner's token when nonce does not match", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t);
+
+    const staleTokens = await encryptJson({
+      accessToken: "stale-token",
+      refreshToken: "refresh-token",
+      tokenType: "Bearer",
+    });
+    const concurrentTokens = await encryptJson({
+      accessToken: "concurrent-token",
+      refreshToken: "refresh-token",
+      tokenType: "Bearer",
+    });
+
+    const connectionId = await insertConnection(t, userId, {
+      encryptedTokens: staleTokens,
+      tokenExpiresAt: Date.now() + 30_000,
+      // no refreshNonce — first refresh ever
+    });
+
+    // Read the stale snapshot that ensureAccessToken will receive
+    const staleConnection = await t.run((ctx) => ctx.db.get(connectionId));
+
+    // Simulate a concurrent action winning the race: it writes a nonce before our action does
+    await t.run((ctx) =>
+      ctx.db.patch(connectionId, {
+        refreshNonce: "concurrent-winner-nonce",
+        encryptedTokens: concurrentTokens,
+        tokenExpiresAt: Date.now() + 3_600_000,
+      }),
+    );
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: "our-new-token",
+          expires_in: 3600,
+          token_type: "Bearer",
+        }),
+      }),
+    );
+
+    // Our action uses the stale snapshot (refreshNonce=undefined), but the DB
+    // now has refreshNonce="concurrent-winner-nonce", so updateTokensIfNonce
+    // returns false and we re-read the fresh token.
+    const token = await t.action((ctx) => ensureAccessToken(ctx, staleConnection!, "client-id"));
+    expect(token).toBe("concurrent-token");
+  });
+
+  test("preserves existing refresh token when Google does not return a new one", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t);
+    const encryptedTokens = await encryptJson({
+      accessToken: "old-token",
+      refreshToken: "long-lived-refresh",
+      tokenType: "Bearer",
+    });
+    const connectionId = await insertConnection(t, userId, {
+      encryptedTokens,
+      tokenExpiresAt: Date.now() + 30_000,
+    });
+    const connection = await t.run((ctx) => ctx.db.get(connectionId));
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: "new-access",
+          expires_in: 3600,
+          token_type: "Bearer",
+          // no refresh_token in response
+        }),
+      }),
+    );
+
+    await t.action((ctx) => ensureAccessToken(ctx, connection!, "client-id"));
+
+    const updated = await t.run((ctx) => ctx.db.get(connectionId));
+    const stored = await decryptJson(updated!.encryptedTokens!);
+    expect(stored.refreshToken).toBe("long-lived-refresh");
+  });
+});

--- a/convex/calendars/providers/google.ts
+++ b/convex/calendars/providers/google.ts
@@ -14,7 +14,10 @@ import type {
   WriteSuccess,
 } from "@shared/calendars";
 
-import { encryptJson } from "../domain/crypto";
+import { internal } from "../../_generated/api";
+import type { Doc } from "../../_generated/dataModel";
+import type { ActionCtx } from "../../_generated/server";
+import { decryptJson, encryptJson } from "../domain/crypto";
 
 export const googleCapabilities: CalendarProviderCapabilities = {
   serverSidePullable: true,
@@ -46,6 +49,92 @@ type GoogleCalendarListResponse = {
 
 function throwAuthError(message: string): never {
   throw Object.assign(new Error(message), { kind: "auth" as const });
+}
+
+// Ensures a valid access token is available for the given connection, refreshing
+// via the OAuth token endpoint if the current token is within 60 seconds of expiry.
+// Uses a nonce-based optimistic lock so that two concurrent cron jobs refreshing the
+// same connection do not overwrite each other — only the first writer wins; the second
+// reads the freshly written token instead.
+export async function ensureAccessToken(
+  ctx: ActionCtx,
+  connection: Doc<"calendarConnections">,
+  clientId: string,
+): Promise<string> {
+  if (!connection.encryptedTokens) {
+    throwAuthError("Reconnect required");
+  }
+
+  const { accessToken, refreshToken } = await decryptJson(connection.encryptedTokens);
+
+  // Return existing token if more than 60 seconds remain before expiry.
+  if (connection.tokenExpiresAt && connection.tokenExpiresAt > Date.now() + 60_000) {
+    return accessToken;
+  }
+
+  if (!refreshToken) {
+    throwAuthError("Reconnect required");
+  }
+
+  const tokenBody: Record<string, string> = {
+    grant_type: "refresh_token",
+    refresh_token: refreshToken,
+    client_id: clientId,
+  };
+  const clientSecret = process.env.GOOGLE_CALENDAR_CLIENT_SECRET;
+  if (clientSecret) {
+    tokenBody.client_secret = clientSecret;
+  }
+
+  const tokenResponse = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams(tokenBody).toString(),
+  });
+
+  if (!tokenResponse.ok) {
+    const errorText = await tokenResponse.text().catch(() => String(tokenResponse.status));
+    throwAuthError(`Google token refresh failed (${tokenResponse.status}): ${errorText}`);
+  }
+
+  const tokenData = (await tokenResponse.json()) as GoogleTokenResponse;
+  const newAccessToken = tokenData.access_token;
+  const newExpiresAt = Date.now() + tokenData.expires_in * 1000;
+
+  const newEncryptedTokens = await encryptJson({
+    accessToken: newAccessToken,
+    refreshToken: tokenData.refresh_token ?? refreshToken,
+    tokenType: tokenData.token_type,
+  });
+
+  const expectedNonce = connection.refreshNonce;
+  const newNonce = globalThis.crypto.randomUUID();
+
+  const wrote: boolean = await ctx.runMutation(
+    internal.calendars.db.updateTokensIfNonce.updateTokensIfNonce,
+    {
+      connectionId: connection._id,
+      expectedNonce,
+      encryptedTokens: newEncryptedTokens,
+      tokenExpiresAt: newExpiresAt,
+      newNonce,
+    },
+  );
+
+  if (!wrote) {
+    // A concurrent action already refreshed. Re-read and return its token.
+    const fresh = await ctx.runQuery(
+      internal.calendars.db.getConnectionInternal.getConnectionInternal,
+      { connectionId: connection._id },
+    );
+    if (!fresh?.encryptedTokens) {
+      throwAuthError("Reconnect required");
+    }
+    const freshTokens = await decryptJson(fresh.encryptedTokens);
+    return freshTokens.accessToken;
+  }
+
+  return newAccessToken;
 }
 
 export const GoogleCalendarProvider: CalendarProvider = {


### PR DESCRIPTION
## Summary

- Rewrites `convex/calendars/domain/crypto.ts` to use WebCrypto (`SubtleCrypto`) instead of `node:crypto`. Same AES-256-GCM binary layout (`[IV][authTag][ciphertext]`) — fully backward-compatible with existing encrypted blobs. Adds `decryptJson` export.
- Adds `convex/calendars/db/updateTokensIfNonce.ts` — an `internalMutation` that atomically writes refreshed tokens only when the caller's `expectedNonce` matches the stored nonce, so the second of two concurrent cron refreshes reads the winner's token rather than overwriting it.
- Adds `ensureAccessToken` to `convex/calendars/providers/google.ts`: decrypts stored tokens, short-circuits if the token has >60s remaining, throws `SyncError { kind: "auth" }` if no refresh token, POSTs to the Google token endpoint, encrypts new tokens, and writes via the nonce lock.

## Test Plan

- 271 tests pass (6 new tests covering all acceptance criteria)
- Returns existing token without calling Google when >60s remains
- Refreshes token when within 60s of expiry and updates DB
- Handles missing `tokenExpiresAt` as needing refresh
- Throws auth error when no refresh token
- Returns concurrent winner's token when nonce race detected (second writer reads fresh DB)
- Preserves existing refresh token when Google doesn't rotate it

## Checklist
- [x] TypeScript compiles with zero errors
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass (271/271)

Closes #130