### PR TITLE
feat(calendars): #132 Google provider — listSubCalendars

### DIFF
--- a/convex/calendars/providers/google.ts
+++ b/convex/calendars/providers/google.ts
@@ -41,10 +41,13 @@ type GoogleUserInfo = {
 type GoogleCalendarListItem = {
   id: string;
   summary: string;
+  summaryOverride?: string;
+  primary?: boolean;
 };
 
 type GoogleCalendarListResponse = {
   items?: GoogleCalendarListItem[];
+  nextPageToken?: string;
 };
 
 function throwAuthError(message: string): never {
@@ -245,6 +248,42 @@ export const GoogleCalendarProvider: CalendarProvider = {
   },
 
   async listSubCalendars(_ctx: unknown, _connection: unknown): Promise<SubCalendar[]> {
-    throw new Error("Not implemented: Google Calendar is not yet supported");
+    const ctx = _ctx as ActionCtx;
+    const connection = _connection as Doc<"calendarConnections">;
+    if (!connection.oauthClientId) {
+      throwAuthError("Google connection missing oauthClientId");
+    }
+
+    const accessToken = await ensureAccessToken(ctx, connection, connection.oauthClientId);
+
+    const subCalendars: SubCalendar[] = [];
+    let pageToken: string | undefined;
+
+    do {
+      const url = new URL("https://www.googleapis.com/calendar/v3/users/me/calendarList");
+      url.searchParams.set("maxResults", "250");
+      if (pageToken) url.searchParams.set("pageToken", pageToken);
+
+      const response = await fetch(url.toString(), {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      if (!response.ok) {
+        throwAuthError(`Google calendarList fetch failed (${response.status})`);
+      }
+
+      const data = (await response.json()) as GoogleCalendarListResponse;
+      for (const item of data.items ?? []) {
+        subCalendars.push({
+          id: item.id,
+          label: item.summaryOverride ?? item.summary,
+          primary: item.primary ?? false,
+        });
+      }
+
+      pageToken = data.nextPageToken;
+    } while (pageToken);
+
+    return subCalendars;
   },
 };

--- a/convex/calendars/providers/listSubCalendars.test.ts
+++ b/convex/calendars/providers/listSubCalendars.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { Doc, Id } from "../../_generated/dataModel";
+import type { ActionCtx } from "../../_generated/server";
+
+vi.mock("../domain/crypto", () => ({
+  decryptJson: vi.fn().mockResolvedValue({
+    accessToken: "test-access-token",
+    refreshToken: "test-refresh-token",
+    tokenType: "Bearer",
+  }),
+  encryptJson: vi.fn().mockResolvedValue(new ArrayBuffer(8)),
+}));
+
+vi.mock("../../_generated/api", () => ({
+  internal: {
+    calendars: {
+      db: {
+        updateTokensIfNonce: {
+          updateTokensIfNonce: "internal:calendars/db/updateTokensIfNonce:updateTokensIfNonce",
+        },
+        getConnectionInternal: {
+          getConnectionInternal:
+            "internal:calendars/db/getConnectionInternal:getConnectionInternal",
+        },
+      },
+    },
+  },
+}));
+
+const connectionId = "conn-1" as Id<"calendarConnections">;
+
+function makeConnection(
+  overrides: Partial<Doc<"calendarConnections">> = {},
+): Doc<"calendarConnections"> {
+  return {
+    _id: connectionId,
+    _creationTime: 0,
+    userId: "user-1" as Id<"users">,
+    provider: "google",
+    label: "Work",
+    color: "#6366f1",
+    createdAt: 0,
+    syncErrorCount: 0,
+    oauthClientId: "client-123",
+    encryptedTokens: new ArrayBuffer(8),
+    // Far in the future — ensureAccessToken returns existing token without refresh
+    tokenExpiresAt: Date.now() + 3_600_000,
+    ...overrides,
+  } as Doc<"calendarConnections">;
+}
+
+function makeCtx(): ActionCtx {
+  return {
+    runMutation: vi.fn().mockResolvedValue(true),
+    runQuery: vi.fn(),
+  } as unknown as ActionCtx;
+}
+
+function makeCalendarListResponse(
+  items: Array<{
+    id: string;
+    summary: string;
+    summaryOverride?: string;
+    primary?: boolean;
+  }>,
+  nextPageToken?: string,
+) {
+  return Response.json({ items, ...(nextPageToken ? { nextPageToken } : {}) });
+}
+
+describe("GoogleCalendarProvider.listSubCalendars", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  test("maps id, summary, and primary=false for a standard calendar", async () => {
+    const { GoogleCalendarProvider } = await import("./google");
+    const ctx = makeCtx();
+    const conn = makeConnection();
+
+    vi.mocked(fetch).mockResolvedValueOnce(
+      makeCalendarListResponse([{ id: "work@example.com", summary: "Work" }]),
+    );
+
+    const result = await GoogleCalendarProvider.listSubCalendars!(ctx, conn);
+
+    expect(result).toEqual([{ id: "work@example.com", label: "Work", primary: false }]);
+  });
+
+  test("uses summaryOverride as label when present", async () => {
+    const { GoogleCalendarProvider } = await import("./google");
+    const ctx = makeCtx();
+    const conn = makeConnection();
+
+    vi.mocked(fetch).mockResolvedValueOnce(
+      makeCalendarListResponse([
+        { id: "cal@example.com", summary: "My Calendar", summaryOverride: "Custom Label" },
+      ]),
+    );
+
+    const result = await GoogleCalendarProvider.listSubCalendars!(ctx, conn);
+
+    expect(result[0].label).toBe("Custom Label");
+  });
+
+  test("sets primary=true for the primary calendar entry", async () => {
+    const { GoogleCalendarProvider } = await import("./google");
+    const ctx = makeCtx();
+    const conn = makeConnection();
+
+    vi.mocked(fetch).mockResolvedValueOnce(
+      makeCalendarListResponse([{ id: "primary@example.com", summary: "Primary", primary: true }]),
+    );
+
+    const result = await GoogleCalendarProvider.listSubCalendars!(ctx, conn);
+
+    expect(result[0].primary).toBe(true);
+  });
+
+  test("handles pagination by following nextPageToken until exhausted", async () => {
+    const { GoogleCalendarProvider } = await import("./google");
+    const ctx = makeCtx();
+    const conn = makeConnection();
+
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(
+        makeCalendarListResponse([{ id: "cal-1@example.com", summary: "Cal 1" }], "token-page-2"),
+      )
+      .mockResolvedValueOnce(
+        makeCalendarListResponse([{ id: "cal-2@example.com", summary: "Cal 2" }]),
+      );
+
+    const result = await GoogleCalendarProvider.listSubCalendars!(ctx, conn);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe("cal-1@example.com");
+    expect(result[1].id).toBe("cal-2@example.com");
+    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(2);
+
+    const secondCallUrl = vi.mocked(fetch).mock.calls[1][0] as string;
+    expect(secondCallUrl).toContain("pageToken=token-page-2");
+  });
+
+  test("returns an empty array when Google returns no items", async () => {
+    const { GoogleCalendarProvider } = await import("./google");
+    const ctx = makeCtx();
+    const conn = makeConnection();
+
+    vi.mocked(fetch).mockResolvedValueOnce(Response.json({}));
+
+    const result = await GoogleCalendarProvider.listSubCalendars!(ctx, conn);
+
+    expect(result).toEqual([]);
+  });
+
+  test("throws an auth error when oauthClientId is missing", async () => {
+    const { GoogleCalendarProvider } = await import("./google");
+    const ctx = makeCtx();
+    const conn = makeConnection({ oauthClientId: undefined });
+
+    await expect(GoogleCalendarProvider.listSubCalendars!(ctx, conn)).rejects.toMatchObject({
+      kind: "auth",
+    });
+  });
+
+  test("sends maxResults=250 in the request URL", async () => {
+    const { GoogleCalendarProvider } = await import("./google");
+    const ctx = makeCtx();
+    const conn = makeConnection();
+
+    vi.mocked(fetch).mockResolvedValueOnce(makeCalendarListResponse([]));
+
+    await GoogleCalendarProvider.listSubCalendars!(ctx, conn);
+
+    const calledUrl = vi.mocked(fetch).mock.calls[0][0] as string;
+    expect(calledUrl).toContain("maxResults=250");
+  });
+
+  test("does not set minAccessRole in the request URL", async () => {
+    const { GoogleCalendarProvider } = await import("./google");
+    const ctx = makeCtx();
+    const conn = makeConnection();
+
+    vi.mocked(fetch).mockResolvedValueOnce(makeCalendarListResponse([]));
+
+    await GoogleCalendarProvider.listSubCalendars!(ctx, conn);
+
+    const calledUrl = vi.mocked(fetch).mock.calls[0][0] as string;
+    expect(calledUrl).not.toContain("minAccessRole");
+  });
+
+  test("throws an auth error when Google API returns a non-ok status", async () => {
+    const { GoogleCalendarProvider } = await import("./google");
+    const ctx = makeCtx();
+    const conn = makeConnection();
+
+    vi.mocked(fetch).mockResolvedValueOnce(new Response(null, { status: 401 }));
+
+    await expect(GoogleCalendarProvider.listSubCalendars!(ctx, conn)).rejects.toMatchObject({
+      kind: "auth",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implements `GoogleCalendarProvider.listSubCalendars` — fetches all calendars from Google's `calendarList` API with `maxResults=250`, no `minAccessRole`, and follows `nextPageToken` pagination until exhausted
- Maps each entry to `SubCalendar`: `id → id`, `summaryOverride ?? summary → label`, `primary ?? false → primary`
- Adds prerequisite work from #130: `decryptJson` (AES-256-GCM mirror of `encryptJson`), `ensureAccessToken` (nonce-based optimistic token refresh), and `updateTokensIfNonce` internal mutation

## Test Plan

- 8 new unit tests in `convex/calendars/providers/google.test.ts` covering:
  - Basic field mapping (`id`, `summary`, `primary=false` default)
  - `summaryOverride` takes precedence over `summary`
  - `primary=true` propagated correctly
  - Pagination: two-page response, verifies `pageToken` appears in second request URL
  - Empty items response returns `[]`
  - Missing `oauthClientId` throws auth error
  - `maxResults=250` present in URL
  - `minAccessRole` absent from URL
  - Non-OK Google API response throws auth error
- All 274 tests pass (30 test files)

## Checklist

- [x] TypeScript compiles with zero errors
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass (274/274)

Closes #132