### PR TITLE
feat(calendars): #133 Microsoft provider — PKCE connect and server-side token exchange

### DIFF
--- a/convex/calendars/providers/microsoft.test.ts
+++ b/convex/calendars/providers/microsoft.test.ts
@@ -170,10 +170,11 @@ describe("MicrosoftCalendarProvider.connect", () => {
     const t = convexTest(schema, modules);
 
     const fetchSpy = vi.fn().mockImplementation((url: string) => {
-      if (url.includes("login.microsoftonline.com")) {
+      const { hostname, pathname } = new URL(url);
+      if (hostname === "login.microsoftonline.com") {
         return Promise.resolve({ ok: true, json: async () => FAKE_TOKEN_RESPONSE });
       }
-      if (url.includes("graph.microsoft.com/v1.0/me")) {
+      if (hostname === "graph.microsoft.com" && pathname.startsWith("/v1.0/me")) {
         return Promise.resolve({ ok: true, json: async () => FAKE_ME_RESPONSE });
       }
       return Promise.resolve({ ok: true, json: async () => ({ value: [] }) });

--- a/convex/calendars/providers/microsoft.test.ts
+++ b/convex/calendars/providers/microsoft.test.ts
@@ -166,6 +166,64 @@ describe("MicrosoftCalendarProvider.connect", () => {
     ).rejects.toMatchObject({ kind: "auth" });
   });
 
+  test("paginates /me/calendars by following @odata.nextLink", async () => {
+    const t = convexTest(schema, modules);
+
+    const page1Url = "https://graph.microsoft.com/v1.0/me/calendars";
+    const page2Url = "https://graph.microsoft.com/v1.0/me/calendars?$skiptoken=PAGE2";
+
+    const fetchSpy = vi.fn().mockImplementation((url: string) => {
+      const parsed = new URL(url);
+      if (parsed.hostname === "login.microsoftonline.com") {
+        return Promise.resolve({ ok: true, json: async () => FAKE_TOKEN_RESPONSE });
+      }
+      if (parsed.hostname === "graph.microsoft.com" && parsed.pathname === "/v1.0/me") {
+        return Promise.resolve({ ok: true, json: async () => FAKE_ME_RESPONSE });
+      }
+      if (url === page1Url) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            value: [{ id: "cal-1", name: "Calendar", isDefaultCalendar: true }],
+            "@odata.nextLink": page2Url,
+          }),
+        });
+      }
+      if (url === page2Url) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            value: [{ id: "cal-2", name: "Birthdays", isDefaultCalendar: false }],
+          }),
+        });
+      }
+      return Promise.resolve({ ok: false, text: async () => "unexpected url" });
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await t.action((ctx) =>
+      MicrosoftCalendarProvider.connect(
+        ctx,
+        {
+          provider: "microsoft",
+          authCode: "auth-code",
+          codeVerifier: "verifier",
+          clientId: "client-id",
+          redirectUri: "https://app.example/callback",
+          label: "Work",
+        },
+        { userId: "user-1", color: "#6366f1" },
+      ),
+    );
+
+    expect(result.subCalendars).toHaveLength(2);
+    expect(result.subCalendars[0]).toMatchObject({ externalId: "cal-1", label: "Calendar" });
+    expect(result.subCalendars[1]).toMatchObject({ externalId: "cal-2", label: "Birthdays" });
+    expect(fetchSpy.mock.calls.filter((c) => String(c[0]).includes("/me/calendars"))).toHaveLength(
+      2,
+    );
+  });
+
   test("token POST targets the Microsoft common tenant endpoint", async () => {
     const t = convexTest(schema, modules);
 

--- a/convex/calendars/providers/microsoft.test.ts
+++ b/convex/calendars/providers/microsoft.test.ts
@@ -1,0 +1,210 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import schema from "../../schema";
+import { MicrosoftCalendarProvider } from "./microsoft";
+
+const modules = import.meta.glob("/convex/**/*.ts");
+
+// Base64-encoded 32-byte test key (all 0x01 bytes)
+const TEST_KEY = btoa(String.fromCharCode(...new Array(32).fill(1)));
+
+const FAKE_TOKEN_RESPONSE = {
+  access_token: "ms-access-token",
+  refresh_token: "ms-refresh-token",
+  expires_in: 3600,
+  scope: "Calendars.Read",
+  token_type: "Bearer",
+};
+
+const FAKE_ME_RESPONSE = {
+  mail: "user@example.com",
+  userPrincipalName: "user@tenant.onmicrosoft.com",
+};
+
+const FAKE_CALENDARS_RESPONSE = {
+  value: [
+    { id: "cal-1", name: "Calendar", isDefaultCalendar: true },
+    { id: "cal-2", name: "Birthdays", isDefaultCalendar: false },
+  ],
+};
+
+function mockFetch(
+  responses: Array<{ ok: boolean; json?: () => Promise<unknown>; text?: () => Promise<string> }>,
+) {
+  let callIndex = 0;
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockImplementation(() => {
+      const resp = responses[callIndex++];
+      return Promise.resolve(resp);
+    }),
+  );
+}
+
+describe("MicrosoftCalendarProvider.connect", () => {
+  beforeEach(() => {
+    vi.stubEnv("CALENDAR_ENCRYPTION_KEY", TEST_KEY);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  test("exchanges auth code, fetches /me, lists calendars and returns encrypted result", async () => {
+    const t = convexTest(schema, modules);
+
+    mockFetch([
+      { ok: true, json: async () => FAKE_TOKEN_RESPONSE },
+      { ok: true, json: async () => FAKE_ME_RESPONSE },
+      { ok: true, json: async () => FAKE_CALENDARS_RESPONSE },
+    ]);
+
+    const result = await t.action((ctx) =>
+      MicrosoftCalendarProvider.connect(
+        ctx,
+        {
+          provider: "microsoft",
+          authCode: "auth-code",
+          codeVerifier: "verifier",
+          clientId: "client-id",
+          redirectUri: "https://app.example/callback",
+          label: "Work",
+        },
+        { userId: "user-1", color: "#6366f1" },
+      ),
+    );
+
+    expect(result.connection.externalAccountId).toBe("user@example.com");
+    expect(result.connection.oauthClientId).toBe("client-id");
+    expect(result.connection.scope).toBe("Calendars.Read");
+    expect(result.connection.tokenExpiresAt).toBeGreaterThan(Date.now());
+    expect(result.connection.encryptedTokens).toBeInstanceOf(ArrayBuffer);
+    expect(result.subCalendars).toHaveLength(2);
+    expect(result.subCalendars[0]).toMatchObject({ externalId: "cal-1", label: "Calendar" });
+    expect(result.subCalendars[1]).toMatchObject({ externalId: "cal-2", label: "Birthdays" });
+  });
+
+  test("falls back to userPrincipalName when mail is null", async () => {
+    const t = convexTest(schema, modules);
+
+    mockFetch([
+      { ok: true, json: async () => FAKE_TOKEN_RESPONSE },
+      {
+        ok: true,
+        json: async () => ({ mail: null, userPrincipalName: "upn@tenant.onmicrosoft.com" }),
+      },
+      { ok: true, json: async () => ({ value: [] }) },
+    ]);
+
+    const result = await t.action((ctx) =>
+      MicrosoftCalendarProvider.connect(
+        ctx,
+        {
+          provider: "microsoft",
+          authCode: "auth-code",
+          codeVerifier: "verifier",
+          clientId: "client-id",
+          redirectUri: "https://app.example/callback",
+          label: "Work",
+        },
+        { userId: "user-1", color: "#6366f1" },
+      ),
+    );
+
+    expect(result.connection.externalAccountId).toBe("upn@tenant.onmicrosoft.com");
+  });
+
+  test("throws auth SyncError when token exchange fails", async () => {
+    const t = convexTest(schema, modules);
+
+    mockFetch([{ ok: false, text: async () => "invalid_grant" }]);
+
+    await expect(
+      t.action((ctx) =>
+        MicrosoftCalendarProvider.connect(
+          ctx,
+          {
+            provider: "microsoft",
+            authCode: "bad-code",
+            codeVerifier: "verifier",
+            clientId: "client-id",
+            redirectUri: "https://app.example/callback",
+            label: "Work",
+          },
+          { userId: "user-1", color: "#6366f1" },
+        ),
+      ),
+    ).rejects.toMatchObject({ kind: "auth" });
+  });
+
+  test("throws auth SyncError when /me fetch fails", async () => {
+    const t = convexTest(schema, modules);
+
+    mockFetch([
+      { ok: true, json: async () => FAKE_TOKEN_RESPONSE },
+      { ok: false, text: async () => "Unauthorized" },
+    ]);
+
+    await expect(
+      t.action((ctx) =>
+        MicrosoftCalendarProvider.connect(
+          ctx,
+          {
+            provider: "microsoft",
+            authCode: "auth-code",
+            codeVerifier: "verifier",
+            clientId: "client-id",
+            redirectUri: "https://app.example/callback",
+            label: "Work",
+          },
+          { userId: "user-1", color: "#6366f1" },
+        ),
+      ),
+    ).rejects.toMatchObject({ kind: "auth" });
+  });
+
+  test("token POST targets the Microsoft common tenant endpoint", async () => {
+    const t = convexTest(schema, modules);
+
+    const fetchSpy = vi.fn().mockImplementation((url: string) => {
+      if (url.includes("login.microsoftonline.com")) {
+        return Promise.resolve({ ok: true, json: async () => FAKE_TOKEN_RESPONSE });
+      }
+      if (url.includes("graph.microsoft.com/v1.0/me")) {
+        return Promise.resolve({ ok: true, json: async () => FAKE_ME_RESPONSE });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({ value: [] }) });
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await t.action((ctx) =>
+      MicrosoftCalendarProvider.connect(
+        ctx,
+        {
+          provider: "microsoft",
+          authCode: "auth-code",
+          codeVerifier: "verifier",
+          clientId: "client-id",
+          redirectUri: "https://app.example/callback",
+          label: "Work",
+        },
+        { userId: "user-1", color: "#6366f1" },
+      ),
+    );
+
+    const tokenCall = fetchSpy.mock.calls[0];
+    expect(tokenCall[0]).toBe("https://login.microsoftonline.com/common/oauth2/v2.0/token");
+    expect(tokenCall[1].method).toBe("POST");
+
+    const body = new URLSearchParams(tokenCall[1].body as string);
+    expect(body.get("grant_type")).toBe("authorization_code");
+    expect(body.get("code")).toBe("auth-code");
+    expect(body.get("code_verifier")).toBe("verifier");
+    expect(body.get("client_id")).toBe("client-id");
+    expect(body.get("redirect_uri")).toBe("https://app.example/callback");
+    expect(body.get("client_secret")).toBeNull();
+  });
+});

--- a/convex/calendars/providers/microsoft.ts
+++ b/convex/calendars/providers/microsoft.ts
@@ -43,6 +43,7 @@ type MicrosoftCalendarItem = {
 
 type MicrosoftCalendarListResponse = {
   value?: MicrosoftCalendarItem[];
+  "@odata.nextLink"?: string;
 };
 
 function throwAuthError(message: string): never {
@@ -105,12 +106,14 @@ export const MicrosoftCalendarProvider: CalendarProvider = {
     const meData = (await meResponse.json()) as MicrosoftUserInfo;
     const externalAccountId = meData.mail ?? meData.userPrincipalName;
 
-    // 3. List calendars so the connection is immediately syncable
+    // 3. List calendars so the connection is immediately syncable — follow @odata.nextLink across pages
     const subCalendars: SubCalendarBlueprint[] = [];
-    const calResponse = await fetch("https://graph.microsoft.com/v1.0/me/calendars", {
-      headers: { Authorization: `Bearer ${accessToken}` },
-    });
-    if (calResponse.ok) {
+    let nextUrl: string | undefined = "https://graph.microsoft.com/v1.0/me/calendars";
+    while (nextUrl) {
+      const calResponse: Response = await fetch(nextUrl, {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      if (!calResponse.ok) break;
       const calData = (await calResponse.json()) as MicrosoftCalendarListResponse;
       for (const item of calData.value ?? []) {
         subCalendars.push({
@@ -119,6 +122,7 @@ export const MicrosoftCalendarProvider: CalendarProvider = {
           showAsBusy: true,
         });
       }
+      nextUrl = calData["@odata.nextLink"];
     }
 
     // 4. Encrypt tokens — never leave the server unencrypted

--- a/convex/calendars/providers/microsoft.ts
+++ b/convex/calendars/providers/microsoft.ts
@@ -1,3 +1,5 @@
+"use node";
+
 import type {
   CalendarConnectContext,
   CalendarConnectParams,
@@ -6,10 +8,13 @@ import type {
   CalendarProviderCapabilities,
   IncomingEvent,
   SubCalendar,
+  SubCalendarBlueprint,
   SyncWindow,
   WriteError,
   WriteSuccess,
 } from "@shared/calendars";
+
+import { encryptJson } from "../domain/crypto";
 
 export const microsoftCapabilities: CalendarProviderCapabilities = {
   serverSidePullable: true,
@@ -17,15 +22,118 @@ export const microsoftCapabilities: CalendarProviderCapabilities = {
   hasSubCalendars: true,
 };
 
+type MicrosoftTokenResponse = {
+  access_token: string;
+  refresh_token?: string;
+  expires_in: number;
+  scope: string;
+  token_type: string;
+};
+
+type MicrosoftUserInfo = {
+  mail: string | null;
+  userPrincipalName: string;
+};
+
+type MicrosoftCalendarItem = {
+  id: string;
+  name: string;
+  isDefaultCalendar: boolean;
+};
+
+type MicrosoftCalendarListResponse = {
+  value?: MicrosoftCalendarItem[];
+};
+
+function throwAuthError(message: string): never {
+  throw Object.assign(new Error(message), { kind: "auth" as const });
+}
+
 export const MicrosoftCalendarProvider: CalendarProvider = {
   capabilities: microsoftCapabilities,
 
   async connect(
     _ctx: unknown,
-    _params: CalendarConnectParams,
+    params: CalendarConnectParams,
     _context: CalendarConnectContext,
   ): Promise<CalendarConnectResult> {
-    throw new Error("Not implemented: Microsoft Calendar connect");
+    if (params.provider !== "microsoft") {
+      throw new Error("MicrosoftCalendarProvider.connect called with non-Microsoft params");
+    }
+
+    const { authCode, codeVerifier, clientId, redirectUri } = params;
+
+    // 1. Exchange auth code for tokens — public client, no client secret
+    const tokenResponse = await fetch(
+      "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          code: authCode,
+          code_verifier: codeVerifier,
+          client_id: clientId,
+          redirect_uri: redirectUri,
+        }).toString(),
+      },
+    );
+
+    if (!tokenResponse.ok) {
+      const errorText = await tokenResponse.text().catch(() => String(tokenResponse.status));
+      throwAuthError(`Microsoft token exchange failed (${tokenResponse.status}): ${errorText}`);
+    }
+
+    const tokenData = (await tokenResponse.json()) as MicrosoftTokenResponse;
+    const {
+      access_token: accessToken,
+      refresh_token: refreshToken,
+      expires_in: expiresIn,
+      scope,
+      token_type: tokenType,
+    } = tokenData;
+
+    // 2. Fetch user identity from Microsoft Graph
+    const meResponse = await fetch("https://graph.microsoft.com/v1.0/me", {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+
+    if (!meResponse.ok) {
+      throwAuthError(`Microsoft Graph /me fetch failed (${meResponse.status})`);
+    }
+
+    const meData = (await meResponse.json()) as MicrosoftUserInfo;
+    const externalAccountId = meData.mail ?? meData.userPrincipalName;
+
+    // 3. List calendars so the connection is immediately syncable
+    const subCalendars: SubCalendarBlueprint[] = [];
+    const calResponse = await fetch("https://graph.microsoft.com/v1.0/me/calendars", {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    if (calResponse.ok) {
+      const calData = (await calResponse.json()) as MicrosoftCalendarListResponse;
+      for (const item of calData.value ?? []) {
+        subCalendars.push({
+          externalId: item.id,
+          label: item.name,
+          showAsBusy: true,
+        });
+      }
+    }
+
+    // 4. Encrypt tokens — never leave the server unencrypted
+    const encryptedTokens = await encryptJson({ accessToken, refreshToken, tokenType });
+
+    return {
+      connection: {
+        externalAccountId,
+        oauthClientId: clientId,
+        encryptedTokens,
+        tokenExpiresAt: Date.now() + expiresIn * 1000,
+        scope,
+      },
+      subCalendars,
+    };
   },
 
   async fetchEvents(


### PR DESCRIPTION
## Summary

- Implements `MicrosoftCalendarProvider.connect` using the same pattern as the Google provider (#129)
- POSTs to `https://login.microsoftonline.com/common/oauth2/v2.0/token` with `authorization_code` grant — no client secret (public client / mobile app)
- Fetches `https://graph.microsoft.com/v1.0/me` for `externalAccountId` (prefers `mail`, falls back to `userPrincipalName`)
- Lists calendars from `/me/calendars` as `SubCalendarBlueprint[]`
- Encrypts tokens via `encryptJson` before returning
- Throws `{ kind: "auth" }` on token exchange or `/me` failure

## Test Plan

- 5 new tests in `microsoft.test.ts` covering:
  - Happy path: token exchange + `/me` + calendar list → correct `CalendarConnectResult`
  - `mail: null` → falls back to `userPrincipalName` as `externalAccountId`
  - Token exchange HTTP failure → throws auth error
  - `/me` HTTP failure → throws auth error
  - Verifies token POST targets correct endpoint, correct payload shape, no `client_secret`

## Checklist

- [x] TypeScript compiles with zero errors
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass (295/295)

Closes #133