### PR TITLE
feat(calendars): #134 Microsoft provider — ensureAccessToken with nonce lock

### DIFF
--- a/convex/calendars/providers/microsoft.test.ts
+++ b/convex/calendars/providers/microsoft.test.ts
@@ -1,9 +1,11 @@
 /// <reference types="vite/client" />
-import { convexTest } from "convex-test";
+import { convexTest, type TestConvex } from "convex-test";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
+import type { Id } from "../../_generated/dataModel";
 import schema from "../../schema";
-import { MicrosoftCalendarProvider } from "./microsoft";
+import { decryptJson, encryptJson } from "../domain/crypto";
+import { ensureAccessToken, MicrosoftCalendarProvider } from "./microsoft";
 
 const modules = import.meta.glob("/convex/**/*.ts");
 
@@ -265,5 +267,297 @@ describe("MicrosoftCalendarProvider.connect", () => {
     expect(body.get("client_id")).toBe("client-id");
     expect(body.get("redirect_uri")).toBe("https://app.example/callback");
     expect(body.get("client_secret")).toBeNull();
+  });
+});
+
+async function insertUser(t: TestConvex<typeof schema>) {
+  return t.run((ctx) =>
+    ctx.db.insert("users", {
+      externalAuthId: "owner",
+      email: "owner@example.com",
+      hasCompletedOnboarding: false,
+      isPublic: false,
+    }),
+  );
+}
+
+async function insertConnection(
+  t: TestConvex<typeof schema>,
+  userId: Id<"users">,
+  overrides: Partial<{
+    encryptedTokens: ArrayBuffer;
+    tokenExpiresAt: number;
+    refreshNonce: string;
+  }> = {},
+) {
+  return t.run((ctx) =>
+    ctx.db.insert("calendarConnections", {
+      userId,
+      provider: "microsoft",
+      label: "Work",
+      color: "#6366f1",
+      createdAt: 0,
+      syncErrorCount: 0,
+      oauthClientId: "test-client-id",
+      ...overrides,
+    }),
+  );
+}
+
+describe("ensureAccessToken", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    vi.stubEnv("CALENDAR_ENCRYPTION_KEY", TEST_KEY);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  test("returns existing access token without refresh when expiry is more than 60s away", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t);
+    const encryptedTokens = await encryptJson({
+      accessToken: "valid-token",
+      refreshToken: "refresh-token",
+      tokenType: "Bearer",
+    });
+    const connectionId = await insertConnection(t, userId, {
+      encryptedTokens,
+      tokenExpiresAt: Date.now() + 120_000,
+    });
+    const connection = await t.run((ctx) => ctx.db.get(connectionId));
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const token = await t.action((ctx) => ensureAccessToken(ctx, connection!, "client-id"));
+
+    expect(token).toBe("valid-token");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test("refreshes and returns new token when within 60 seconds of expiry", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t);
+    const encryptedTokens = await encryptJson({
+      accessToken: "old-token",
+      refreshToken: "refresh-token",
+      tokenType: "Bearer",
+    });
+    const connectionId = await insertConnection(t, userId, {
+      encryptedTokens,
+      tokenExpiresAt: Date.now() + 30_000,
+    });
+    const connection = await t.run((ctx) => ctx.db.get(connectionId));
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: "new-token",
+          expires_in: 3600,
+          token_type: "Bearer",
+        }),
+      }),
+    );
+
+    const token = await t.action((ctx) => ensureAccessToken(ctx, connection!, "client-id"));
+
+    expect(token).toBe("new-token");
+    const updated = await t.run((ctx) => ctx.db.get(connectionId));
+    expect(updated?.tokenExpiresAt).toBeGreaterThan(Date.now() + 3_500_000);
+    expect(updated?.refreshNonce).toBeTypeOf("string");
+  });
+
+  test("also refreshes when tokenExpiresAt is not set", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t);
+    const encryptedTokens = await encryptJson({
+      accessToken: "old-token",
+      refreshToken: "refresh-token",
+      tokenType: "Bearer",
+    });
+    const connectionId = await insertConnection(t, userId, {
+      encryptedTokens,
+    });
+    const connection = await t.run((ctx) => ctx.db.get(connectionId));
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: "new-token",
+          expires_in: 3600,
+          token_type: "Bearer",
+        }),
+      }),
+    );
+
+    const token = await t.action((ctx) => ensureAccessToken(ctx, connection!, "client-id"));
+    expect(token).toBe("new-token");
+  });
+
+  test("throws auth SyncError when no refresh token and token is expiring", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t);
+    const encryptedTokens = await encryptJson({
+      accessToken: "old-token",
+      tokenType: "Bearer",
+    });
+    const connectionId = await insertConnection(t, userId, {
+      encryptedTokens,
+      tokenExpiresAt: Date.now() + 30_000,
+    });
+    const connection = await t.run((ctx) => ctx.db.get(connectionId));
+
+    await expect(
+      t.action((ctx) => ensureAccessToken(ctx, connection!, "client-id")),
+    ).rejects.toMatchObject({ kind: "auth" });
+  });
+
+  test("throws auth SyncError when token refresh HTTP request fails", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t);
+    const encryptedTokens = await encryptJson({
+      accessToken: "old-token",
+      refreshToken: "refresh-token",
+      tokenType: "Bearer",
+    });
+    const connectionId = await insertConnection(t, userId, {
+      encryptedTokens,
+      tokenExpiresAt: Date.now() + 30_000,
+    });
+    const connection = await t.run((ctx) => ctx.db.get(connectionId));
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        text: async () => "Unauthorized",
+      }),
+    );
+
+    await expect(
+      t.action((ctx) => ensureAccessToken(ctx, connection!, "client-id")),
+    ).rejects.toMatchObject({ kind: "auth" });
+  });
+
+  test("refresh POST targets Microsoft token endpoint without client_secret", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t);
+    const encryptedTokens = await encryptJson({
+      accessToken: "old-token",
+      refreshToken: "refresh-token",
+      tokenType: "Bearer",
+    });
+    const connectionId = await insertConnection(t, userId, {
+      encryptedTokens,
+      tokenExpiresAt: Date.now() + 30_000,
+    });
+    const connection = await t.run((ctx) => ctx.db.get(connectionId));
+
+    const fetchSpy = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        access_token: "new-token",
+        expires_in: 3600,
+        token_type: "Bearer",
+      }),
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await t.action((ctx) => ensureAccessToken(ctx, connection!, "client-id"));
+
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://login.microsoftonline.com/common/oauth2/v2.0/token");
+    expect(init.method).toBe("POST");
+    const body = new URLSearchParams(init.body as string);
+    expect(body.get("grant_type")).toBe("refresh_token");
+    expect(body.get("refresh_token")).toBe("refresh-token");
+    expect(body.get("client_id")).toBe("client-id");
+    expect(body.get("client_secret")).toBeNull();
+  });
+
+  test("returns concurrent winner's token when nonce does not match", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t);
+
+    const staleTokens = await encryptJson({
+      accessToken: "stale-token",
+      refreshToken: "refresh-token",
+      tokenType: "Bearer",
+    });
+    const concurrentTokens = await encryptJson({
+      accessToken: "concurrent-token",
+      refreshToken: "refresh-token",
+      tokenType: "Bearer",
+    });
+
+    const connectionId = await insertConnection(t, userId, {
+      encryptedTokens: staleTokens,
+      tokenExpiresAt: Date.now() + 30_000,
+    });
+
+    const staleConnection = await t.run((ctx) => ctx.db.get(connectionId));
+
+    await t.run((ctx) =>
+      ctx.db.patch(connectionId, {
+        refreshNonce: "concurrent-winner-nonce",
+        encryptedTokens: concurrentTokens,
+        tokenExpiresAt: Date.now() + 3_600_000,
+      }),
+    );
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: "our-new-token",
+          expires_in: 3600,
+          token_type: "Bearer",
+        }),
+      }),
+    );
+
+    const token = await t.action((ctx) => ensureAccessToken(ctx, staleConnection!, "client-id"));
+    expect(token).toBe("concurrent-token");
+  });
+
+  test("preserves existing refresh token when Microsoft does not return a new one", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t);
+    const encryptedTokens = await encryptJson({
+      accessToken: "old-token",
+      refreshToken: "long-lived-refresh",
+      tokenType: "Bearer",
+    });
+    const connectionId = await insertConnection(t, userId, {
+      encryptedTokens,
+      tokenExpiresAt: Date.now() + 30_000,
+    });
+    const connection = await t.run((ctx) => ctx.db.get(connectionId));
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: "new-access",
+          expires_in: 3600,
+          token_type: "Bearer",
+        }),
+      }),
+    );
+
+    await t.action((ctx) => ensureAccessToken(ctx, connection!, "client-id"));
+
+    const updated = await t.run((ctx) => ctx.db.get(connectionId));
+    const stored = await decryptJson(updated!.encryptedTokens!);
+    expect(stored.refreshToken).toBe("long-lived-refresh");
   });
 });

--- a/convex/calendars/providers/microsoft.ts
+++ b/convex/calendars/providers/microsoft.ts
@@ -14,7 +14,10 @@ import type {
   WriteSuccess,
 } from "@shared/calendars";
 
-import { encryptJson } from "../domain/crypto";
+import { internal } from "../../_generated/api";
+import type { Doc } from "../../_generated/dataModel";
+import type { ActionCtx } from "../../_generated/server";
+import { decryptJson, encryptJson } from "../domain/crypto";
 
 export const microsoftCapabilities: CalendarProviderCapabilities = {
   serverSidePullable: true,
@@ -48,6 +51,83 @@ type MicrosoftCalendarListResponse = {
 
 function throwAuthError(message: string): never {
   throw Object.assign(new Error(message), { kind: "auth" as const });
+}
+
+// Ensures a valid access token is available for the given connection, refreshing
+// via the Microsoft OAuth token endpoint if the current token is within 60 seconds
+// of expiry. Uses a nonce-based optimistic lock to prevent concurrent refresh races.
+// Microsoft is a public client — no client_secret is sent.
+export async function ensureAccessToken(
+  ctx: ActionCtx,
+  connection: Doc<"calendarConnections">,
+  clientId: string,
+): Promise<string> {
+  if (!connection.encryptedTokens) {
+    throwAuthError("Reconnect required");
+  }
+
+  const { accessToken, refreshToken } = await decryptJson(connection.encryptedTokens);
+
+  if (connection.tokenExpiresAt && connection.tokenExpiresAt > Date.now() + 60_000) {
+    return accessToken;
+  }
+
+  if (!refreshToken) {
+    throwAuthError("Reconnect required");
+  }
+
+  const tokenResponse = await fetch("https://login.microsoftonline.com/common/oauth2/v2.0/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+      client_id: clientId,
+    }).toString(),
+  });
+
+  if (!tokenResponse.ok) {
+    const errorText = await tokenResponse.text().catch(() => String(tokenResponse.status));
+    throwAuthError(`Microsoft token refresh failed (${tokenResponse.status}): ${errorText}`);
+  }
+
+  const tokenData = (await tokenResponse.json()) as MicrosoftTokenResponse;
+  const newAccessToken = tokenData.access_token;
+  const newExpiresAt = Date.now() + tokenData.expires_in * 1000;
+
+  const newEncryptedTokens = await encryptJson({
+    accessToken: newAccessToken,
+    refreshToken: tokenData.refresh_token ?? refreshToken,
+    tokenType: tokenData.token_type,
+  });
+
+  const expectedNonce = connection.refreshNonce;
+  const newNonce = globalThis.crypto.randomUUID();
+
+  const wrote: boolean = await ctx.runMutation(
+    internal.calendars.db.updateTokensIfNonce.updateTokensIfNonce,
+    {
+      connectionId: connection._id,
+      expectedNonce,
+      encryptedTokens: newEncryptedTokens,
+      tokenExpiresAt: newExpiresAt,
+      newNonce,
+    },
+  );
+
+  if (!wrote) {
+    const fresh = await ctx.runQuery(
+      internal.calendars.db.getConnectionInternal.getConnectionInternal,
+      { connectionId: connection._id },
+    );
+    if (!fresh?.encryptedTokens) {
+      throwAuthError("Reconnect required");
+    }
+    const freshTokens = await decryptJson(fresh.encryptedTokens);
+    return freshTokens.accessToken;
+  }
+
+  return newAccessToken;
 }
 
 export const MicrosoftCalendarProvider: CalendarProvider = {


### PR DESCRIPTION
## Summary

- Implements `ensureAccessToken` for `MicrosoftProvider` following the same nonce-based optimistic lock pattern as the Google provider (#130)
- Refreshes via `https://login.microsoftonline.com/common/oauth2/v2.0/token` with `grant_type=refresh_token`
- Public client flow — no `client_secret` is ever sent, even if the env var is present
- Reuses `updateTokensIfNonce` and `getConnectionInternal` from the existing Convex mutations

## Test Plan

- Returns existing token without network call when expiry is >60s away
- Refreshes and writes new token when within 60s of expiry, or when `tokenExpiresAt` is not set
- Nonce lock: returns concurrent winner's token when `updateTokensIfNonce` returns false
- Throws `SyncError { kind: "auth" }` when no refresh token or when the token endpoint returns a non-2xx
- Preserves existing refresh token when Microsoft does not return a new one
- Verifies refresh POST targets the Microsoft tenant endpoint with no `client_secret` in the body

## Checklist

- [x] TypeScript compiles with zero errors
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass (304/304)

Closes #134