### PR TITLE
feat(calendars): #137 iCal provider — HTTP fetch with ETag conditional and encrypted URL decryption

### DIFF
--- a/convex/calendars/db/insertCalendarConnection.test.ts
+++ b/convex/calendars/db/insertCalendarConnection.test.ts
@@ -1,11 +1,14 @@
 /// <reference types="vite/client" />
 import { convexTest, type TestConvex } from "convex-test";
-import { describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import { internal } from "../../_generated/api";
 import schema from "../../schema";
+import { encryptJson } from "../domain/crypto";
 
 const modules = import.meta.glob("/convex/**/*.ts");
+
+const TEST_KEY = btoa(String.fromCharCode(...new Array(32).fill(1)));
 
 async function insertUser(t: TestConvex<typeof schema>, externalAuthId: string) {
   return t.run((ctx) =>
@@ -19,9 +22,18 @@ async function insertUser(t: TestConvex<typeof schema>, externalAuthId: string) 
 }
 
 describe("insertCalendarConnection", () => {
+  beforeEach(() => {
+    vi.stubEnv("CALENDAR_ENCRYPTION_KEY", TEST_KEY);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   test("inserts the connection row with service-owned and blueprint fields merged", async () => {
     const t = convexTest(schema, modules);
     const userId = await insertUser(t, "user1");
+    const encryptedUrl = await encryptJson("https://example.com/cal.ics");
 
     const connectionId = await t.mutation(
       internal.calendars.db.insertCalendarConnection.insertCalendarConnection,
@@ -30,7 +42,7 @@ describe("insertCalendarConnection", () => {
         provider: "ical",
         label: "Family iCloud",
         color: "#6366f1",
-        blueprint: { icalUrl: "https://example.com/cal.ics" },
+        blueprint: { icalUrl: encryptedUrl },
         subCalendars: [],
       },
     );
@@ -47,9 +59,9 @@ describe("insertCalendarConnection", () => {
       provider: "ical",
       label: "Family iCloud",
       color: "#6366f1",
-      icalUrl: "https://example.com/cal.ics",
       syncErrorCount: 0,
     });
+    expect(row?.icalUrl).toBeInstanceOf(ArrayBuffer);
     expect(row?.createdAt).toBeTypeOf("number");
   });
 

--- a/convex/calendars/db/insertCalendarConnection.ts
+++ b/convex/calendars/db/insertCalendarConnection.ts
@@ -22,7 +22,7 @@ export const insertCalendarConnection = internalMutation({
     color: v.string(),
     blueprint: v.object({
       externalAccountId: v.optional(v.string()),
-      icalUrl: v.optional(v.string()),
+      icalUrl: v.optional(v.bytes()),
       localCalendarId: v.optional(v.string()),
       scope: v.optional(v.string()),
       oauthClientId: v.optional(v.string()),

--- a/convex/calendars/db/updateICalMeta.ts
+++ b/convex/calendars/db/updateICalMeta.ts
@@ -1,0 +1,17 @@
+import { v } from "convex/values";
+
+import { internalMutation } from "../../_generated/server";
+
+export const updateICalMeta = internalMutation({
+  args: {
+    connectionId: v.id("calendarConnections"),
+    icalEtag: v.optional(v.string()),
+    icalLastModified: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.connectionId, {
+      icalEtag: args.icalEtag,
+      icalLastModified: args.icalLastModified,
+    });
+  },
+});

--- a/convex/calendars/domain/crypto.ts
+++ b/convex/calendars/domain/crypto.ts
@@ -29,7 +29,7 @@ export async function encryptJson(data: unknown): Promise<ArrayBuffer> {
   return result.buffer;
 }
 
-export async function decryptJson(buffer: ArrayBuffer): Promise<DecryptedTokens> {
+export async function decryptJson<T = DecryptedTokens>(buffer: ArrayBuffer): Promise<T> {
   const key = await importKey("decrypt");
   const bytes = new Uint8Array(buffer);
   const iv = bytes.slice(0, 12);
@@ -40,5 +40,5 @@ export async function decryptJson(buffer: ArrayBuffer): Promise<DecryptedTokens>
   combined.set(ciphertext, 0);
   combined.set(authTag, ciphertext.length);
   const decrypted = await globalThis.crypto.subtle.decrypt({ name: "AES-GCM", iv }, key, combined);
-  return JSON.parse(new TextDecoder().decode(decrypted)) as DecryptedTokens;
+  return JSON.parse(new TextDecoder().decode(decrypted)) as T;
 }

--- a/convex/calendars/providers/ical.test.ts
+++ b/convex/calendars/providers/ical.test.ts
@@ -1,0 +1,270 @@
+/// <reference types="vite/client" />
+import { convexTest, type TestConvex } from "convex-test";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { Id } from "../../_generated/dataModel";
+import schema from "../../schema";
+import { encryptJson } from "../domain/crypto";
+import { fetchICalFeed } from "./ical";
+
+const modules = import.meta.glob("/convex/**/*.ts");
+
+const TEST_KEY = btoa(String.fromCharCode(...new Array(32).fill(1)));
+
+async function insertUser(t: TestConvex<typeof schema>) {
+  return t.run((ctx) =>
+    ctx.db.insert("users", {
+      externalAuthId: "owner",
+      email: "owner@example.com",
+      hasCompletedOnboarding: false,
+      isPublic: false,
+    }),
+  );
+}
+
+async function insertICalConnection(
+  t: TestConvex<typeof schema>,
+  userId: Id<"users">,
+  overrides: Partial<{
+    icalUrl: ArrayBuffer;
+    icalEtag: string;
+    icalLastModified: string;
+  }> = {},
+) {
+  return t.run((ctx) =>
+    ctx.db.insert("calendarConnections", {
+      userId,
+      provider: "ical",
+      label: "Test Feed",
+      color: "#6366f1",
+      createdAt: 0,
+      syncErrorCount: 0,
+      ...overrides,
+    }),
+  );
+}
+
+describe("fetchICalFeed", () => {
+  beforeEach(() => {
+    vi.stubEnv("CALENDAR_ENCRYPTION_KEY", TEST_KEY);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  test("returns text on a 200 response", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t);
+    const encryptedUrl = await encryptJson("https://example.com/cal.ics");
+    const connectionId = await insertICalConnection(t, userId, { icalUrl: encryptedUrl });
+    const connection = await t.run((ctx) => ctx.db.get(connectionId));
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: { get: () => null },
+        text: async () => "BEGIN:VCALENDAR\nEND:VCALENDAR",
+      }),
+    );
+
+    const result = await t.action((ctx) => fetchICalFeed(ctx, connection!));
+
+    expect(result).toEqual({ unchanged: false, text: "BEGIN:VCALENDAR\nEND:VCALENDAR" });
+  });
+
+  test("sends If-None-Match header when icalEtag is stored", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t);
+    const encryptedUrl = await encryptJson("https://example.com/cal.ics");
+    const connectionId = await insertICalConnection(t, userId, {
+      icalUrl: encryptedUrl,
+      icalEtag: '"abc123"',
+    });
+    const connection = await t.run((ctx) => ctx.db.get(connectionId));
+
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      text: async () => "BEGIN:VCALENDAR\nEND:VCALENDAR",
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await t.action((ctx) => fetchICalFeed(ctx, connection!));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://example.com/cal.ics",
+      expect.objectContaining({
+        headers: expect.objectContaining({ "If-None-Match": '"abc123"' }),
+      }),
+    );
+  });
+
+  test("sends If-Modified-Since header when icalLastModified is stored", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t);
+    const encryptedUrl = await encryptJson("https://example.com/cal.ics");
+    const connectionId = await insertICalConnection(t, userId, {
+      icalUrl: encryptedUrl,
+      icalLastModified: "Wed, 01 Jan 2025 00:00:00 GMT",
+    });
+    const connection = await t.run((ctx) => ctx.db.get(connectionId));
+
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      text: async () => "BEGIN:VCALENDAR\nEND:VCALENDAR",
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await t.action((ctx) => fetchICalFeed(ctx, connection!));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://example.com/cal.ics",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "If-Modified-Since": "Wed, 01 Jan 2025 00:00:00 GMT",
+        }),
+      }),
+    );
+  });
+
+  test("returns { unchanged: true } on 304", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t);
+    const encryptedUrl = await encryptJson("https://example.com/cal.ics");
+    const connectionId = await insertICalConnection(t, userId, {
+      icalUrl: encryptedUrl,
+      icalEtag: '"abc123"',
+    });
+    const connection = await t.run((ctx) => ctx.db.get(connectionId));
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce({
+        ok: false,
+        status: 304,
+        headers: { get: () => null },
+      }),
+    );
+
+    const result = await t.action((ctx) => fetchICalFeed(ctx, connection!));
+
+    expect(result).toEqual({ unchanged: true });
+  });
+
+  test("throws SyncError { kind: 'network' } on non-ok response", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t);
+    const encryptedUrl = await encryptJson("https://example.com/cal.ics");
+    const connectionId = await insertICalConnection(t, userId, { icalUrl: encryptedUrl });
+    const connection = await t.run((ctx) => ctx.db.get(connectionId));
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        headers: { get: () => null },
+      }),
+    );
+
+    await expect(t.action((ctx) => fetchICalFeed(ctx, connection!))).rejects.toMatchObject({
+      kind: "network",
+      message: "HTTP 503",
+    });
+  });
+
+  test("stores ETag from response headers after successful fetch", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t);
+    const encryptedUrl = await encryptJson("https://example.com/cal.ics");
+    const connectionId = await insertICalConnection(t, userId, { icalUrl: encryptedUrl });
+    const connection = await t.run((ctx) => ctx.db.get(connectionId));
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: {
+          get: (name: string) => (name === "ETag" ? '"newetag"' : null),
+        },
+        text: async () => "BEGIN:VCALENDAR\nEND:VCALENDAR",
+      }),
+    );
+
+    await t.action((ctx) => fetchICalFeed(ctx, connection!));
+
+    const updated = await t.run((ctx) => ctx.db.get(connectionId));
+    expect(updated?.icalEtag).toBe('"newetag"');
+  });
+
+  test("stores Last-Modified from response headers after successful fetch", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t);
+    const encryptedUrl = await encryptJson("https://example.com/cal.ics");
+    const connectionId = await insertICalConnection(t, userId, { icalUrl: encryptedUrl });
+    const connection = await t.run((ctx) => ctx.db.get(connectionId));
+
+    const lastMod = "Thu, 01 May 2025 12:00:00 GMT";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: {
+          get: (name: string) => (name === "Last-Modified" ? lastMod : null),
+        },
+        text: async () => "BEGIN:VCALENDAR\nEND:VCALENDAR",
+      }),
+    );
+
+    await t.action((ctx) => fetchICalFeed(ctx, connection!));
+
+    const updated = await t.run((ctx) => ctx.db.get(connectionId));
+    expect(updated?.icalLastModified).toBe(lastMod);
+  });
+
+  test("does not call updateICalMeta when no cache headers are present", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t);
+    const encryptedUrl = await encryptJson("https://example.com/cal.ics");
+    const connectionId = await insertICalConnection(t, userId, {
+      icalUrl: encryptedUrl,
+      icalEtag: '"existing"',
+    });
+    const connection = await t.run((ctx) => ctx.db.get(connectionId));
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: { get: () => null },
+        text: async () => "BEGIN:VCALENDAR\nEND:VCALENDAR",
+      }),
+    );
+
+    await t.action((ctx) => fetchICalFeed(ctx, connection!));
+
+    const updated = await t.run((ctx) => ctx.db.get(connectionId));
+    expect(updated?.icalEtag).toBe('"existing"');
+  });
+
+  test("throws SyncError { kind: 'network' } when icalUrl is missing", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t);
+    const connectionId = await insertICalConnection(t, userId);
+    const connection = await t.run((ctx) => ctx.db.get(connectionId));
+
+    await expect(t.action((ctx) => fetchICalFeed(ctx, connection!))).rejects.toMatchObject({
+      kind: "network",
+    });
+  });
+});

--- a/convex/calendars/providers/ical.ts
+++ b/convex/calendars/providers/ical.ts
@@ -1,3 +1,5 @@
+"use node";
+
 import type {
   CalendarConnectContext,
   CalendarConnectParams,
@@ -11,6 +13,11 @@ import type {
   WriteSuccess,
 } from "@shared/calendars";
 
+import { internal } from "../../_generated/api";
+import type { Doc } from "../../_generated/dataModel";
+import type { ActionCtx } from "../../_generated/server";
+import { decryptJson, encryptJson } from "../domain/crypto";
+
 export const icalCapabilities: CalendarProviderCapabilities = {
   serverSidePullable: true,
   writable: false,
@@ -21,6 +28,57 @@ export const icalCapabilities: CalendarProviderCapabilities = {
 // Sub-Calendar. The constant externalId reflects that there is no
 // provider-side calendar identifier to track.
 export const ICAL_SYNTHETIC_SUB_CALENDAR_EXTERNAL_ID = "default";
+
+type FetchICalResult = { unchanged: true } | { unchanged: false; text: string };
+
+// Fetches the raw iCal feed text for a connection.
+// Decrypts the stored URL, sends conditional headers when ETag/Last-Modified
+// are available, and persists new cache headers after a successful response.
+// Returns { unchanged: true } on 304 — the caller must skip the sync pass entirely.
+export async function fetchICalFeed(
+  ctx: ActionCtx,
+  connection: Doc<"calendarConnections">,
+): Promise<FetchICalResult> {
+  if (!connection.icalUrl) {
+    throw Object.assign(new Error("iCal connection missing URL"), { kind: "network" as const });
+  }
+
+  const url = await decryptJson<string>(connection.icalUrl);
+
+  const headers: Record<string, string> = {};
+  if (connection.icalEtag) {
+    headers["If-None-Match"] = connection.icalEtag;
+  }
+  if (connection.icalLastModified) {
+    headers["If-Modified-Since"] = connection.icalLastModified;
+  }
+
+  const res = await fetch(url, {
+    headers,
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  if (res.status === 304) {
+    return { unchanged: true };
+  }
+
+  if (!res.ok) {
+    throw Object.assign(new Error(`HTTP ${res.status}`), { kind: "network" as const });
+  }
+
+  const etag = res.headers.get("ETag") ?? undefined;
+  const lastModified = res.headers.get("Last-Modified") ?? undefined;
+
+  if (etag !== undefined || lastModified !== undefined) {
+    await ctx.runMutation(internal.calendars.db.updateICalMeta.updateICalMeta, {
+      connectionId: connection._id,
+      icalEtag: etag,
+      icalLastModified: lastModified,
+    });
+  }
+
+  return { unchanged: false, text: await res.text() };
+}
 
 export const ICalProvider: CalendarProvider = {
   capabilities: icalCapabilities,
@@ -37,9 +95,10 @@ export const ICalProvider: CalendarProvider = {
     if (params.provider !== "ical") {
       throw new Error("ICalProvider.connect called with non-iCal params");
     }
+    const encryptedUrl = await encryptJson(params.url);
     return {
       connection: {
-        icalUrl: params.url,
+        icalUrl: encryptedUrl,
       },
       subCalendars: [
         {

--- a/convex/calendars/queries.test.ts
+++ b/convex/calendars/queries.test.ts
@@ -36,7 +36,7 @@ async function insertConnection(
     scope?: string;
     oauthClientId?: string;
     refreshNonce?: string;
-    icalUrl?: string;
+    icalUrl?: ArrayBuffer;
     lastSyncedAt?: number;
     lastSyncError?: string;
     syncErrorCount?: number;
@@ -136,7 +136,7 @@ describe("getConnections", () => {
       scope: "https://www.googleapis.com/auth/calendar.readonly",
       oauthClientId: "client-123",
       refreshNonce: "nonce-abc",
-      icalUrl: "https://example.com/ical",
+      icalUrl: new ArrayBuffer(8),
       lastSyncedAt: 1_700_000_000_000,
       lastSyncError: "boom",
       syncErrorCount: 2,

--- a/convex/calendars/schema.ts
+++ b/convex/calendars/schema.ts
@@ -15,8 +15,8 @@ export const CalendarConnection = {
   label: v.string(),
   // Provider-side identifier (Google email/sub, Outlook UPN, Apple localCalendarId, etc.)
   externalAccountId: v.optional(v.string()),
-  // For provider="ical" — the subscription URL (stored encrypted at the application layer)
-  icalUrl: v.optional(v.string()),
+  // For provider="ical" — the subscription URL (stored as encrypted bytes at the application layer)
+  icalUrl: v.optional(v.bytes()),
   // For provider="native" — the on-device calendar id from expo-calendar
   localCalendarId: v.optional(v.string()),
   // For provider="google" / "microsoft" — OAuth scope granted

--- a/convex/calendars/service/connect.test.ts
+++ b/convex/calendars/service/connect.test.ts
@@ -11,9 +11,12 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import type { Id } from "../../_generated/dataModel";
 import schema from "../../schema";
+import { encryptJson } from "../domain/crypto";
 import { createCalendarService } from "./index";
 
 const modules = import.meta.glob("/convex/**/*.ts");
+
+const TEST_KEY = btoa(String.fromCharCode(...new Array(32).fill(1)));
 
 const identity = {
   subject: "clerk_user_42",
@@ -97,10 +100,12 @@ describe("CalendarService.connect", () => {
   // restored in afterEach without firing the queued callbacks.
   beforeEach(() => {
     vi.useFakeTimers();
+    vi.stubEnv("CALENDAR_ENCRYPTION_KEY", TEST_KEY);
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.unstubAllEnvs();
   });
 
   test("throws when the caller is not authenticated", async () => {
@@ -170,11 +175,12 @@ describe("CalendarService.connect", () => {
     const t = convexTest(schema, modules);
     await insertUser(t, identity.subject);
 
+    const encryptedUrl = await encryptJson("https://example.com/cal.ics");
     const calls: StubCall[] = [];
     const service = createCalendarService(
       buildRegistry(
         () => ({
-          connection: { icalUrl: "https://example.com/cal.ics" },
+          connection: { icalUrl: encryptedUrl },
           subCalendars: [{ externalId: "default", label: "Family iCloud", showAsBusy: true }],
         }),
         calls,

--- a/types/calendars.ts
+++ b/types/calendars.ts
@@ -96,7 +96,7 @@ export type CalendarConnectContext = {
 // Google sets oauth tokens; Native sets localCalendarId).
 export type CalendarConnectionBlueprint = {
   externalAccountId?: string;
-  icalUrl?: string;
+  icalUrl?: ArrayBuffer;
   localCalendarId?: string;
   scope?: string;
   oauthClientId?: string;


### PR DESCRIPTION
## Summary

- **Encrypted URL storage**: `icalUrl` is now stored as encrypted bytes (`v.bytes()`) matching the same AES-256-GCM pattern as `encryptedTokens`. `ICalProvider.connect()` encrypts the URL via `encryptJson` before returning the blueprint.
- **Generic `decryptJson`**: Made the function generic (`T = DecryptedTokens`) so it can decrypt any JSON-encoded value. Existing token-decryption call sites are unaffected (default `T` is unchanged).
- **`fetchICalFeed`**: New internal async function that decrypts the URL, sends `If-None-Match` / `If-Modified-Since` conditional headers when cached values exist, handles 304 → `{ unchanged: true }`, throws `SyncError { kind: "network" }` on non-ok responses, and persists new `ETag` / `Last-Modified` values via `updateICalMeta`.
- **`updateICalMeta` mutation**: New `internalMutation` at `convex/calendars/db/updateICalMeta.ts` that patches `icalEtag` and `icalLastModified` on the connection row.

## Test Plan

- 8 new tests in `convex/calendars/providers/ical.test.ts` covering: 200 response, conditional header sending, 304 unchanged, 503 network error, ETag persistence, Last-Modified persistence, no-op when no cache headers, missing URL error.
- Existing tests updated to use encrypted `ArrayBuffer` for `icalUrl` where previously plain strings were used.
- All 328 tests pass; TypeScript, lint, and format checks are green.

## Checklist
- [x] TypeScript compiles with zero errors
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass (328/328)

Closes #137