### PR TITLE
feat(calendars): #138 iCal provider — feed parsing and full-replace sync strategy

### DIFF
--- a/convex/calendars/providers/convertICalEvent.test.ts
+++ b/convex/calendars/providers/convertICalEvent.test.ts
@@ -53,6 +53,20 @@ END:VCALENDAR`);
     expect(convertICalEvent(vevent, SUB_CAL_ID)).toBeNull();
   });
 
+  test("returns null for lowercase transparent (case-insensitive per RFC 5545)", () => {
+    const vevent = parseVevent(`BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:transparent-lower@example.com
+DTSTART:20250601T100000Z
+DTEND:20250601T110000Z
+SUMMARY:Lowercase transparent
+TRANSP:transparent
+END:VEVENT
+END:VCALENDAR`);
+
+    expect(convertICalEvent(vevent, SUB_CAL_ID)).toBeNull();
+  });
+
   test("includes OPAQUE events", () => {
     const vevent = parseVevent(`BEGIN:VCALENDAR
 BEGIN:VEVENT

--- a/convex/calendars/providers/convertICalEvent.test.ts
+++ b/convex/calendars/providers/convertICalEvent.test.ts
@@ -1,0 +1,186 @@
+/// <reference types="vite/client" />
+import ICAL from "ical.js";
+import { describe, expect, test } from "vitest";
+
+import { convertICalEvent } from "./convertICalEvent";
+
+const SUB_CAL_ID = "default";
+
+function parseVevent(icalText: string): InstanceType<typeof ICAL.Component> {
+  const parsed = ICAL.parse(icalText);
+  const comp = new ICAL.Component(parsed);
+  return comp.getAllSubcomponents("vevent")[0];
+}
+
+describe("convertICalEvent", () => {
+  test("maps basic VEVENT fields to IncomingEvent", () => {
+    const vevent = parseVevent(`BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:basic@example.com
+DTSTART:20250601T100000Z
+DTEND:20250601T110000Z
+SUMMARY:Team meeting
+DESCRIPTION:Discuss Q2 plans
+LOCATION:Conference Room A
+END:VEVENT
+END:VCALENDAR`);
+
+    const result = convertICalEvent(vevent, SUB_CAL_ID);
+
+    expect(result).not.toBeNull();
+    expect(result!.uid).toBe("basic@example.com");
+    expect(result!.externalId).toBe("default::basic@example.com");
+    expect(result!.subCalendarId).toBe("default");
+    expect(result!.title).toBe("Team meeting");
+    expect(result!.description).toBe("Discuss Q2 plans");
+    expect(result!.location).toBe("Conference Room A");
+    expect(result!.isAllDay).toBe(false);
+    expect(result!.startsAt).toBe(new Date("2025-06-01T10:00:00Z").getTime());
+    expect(result!.endsAt).toBe(new Date("2025-06-01T11:00:00Z").getTime());
+  });
+
+  test("returns null for TRANSPARENT events", () => {
+    const vevent = parseVevent(`BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:transparent@example.com
+DTSTART:20250601T100000Z
+DTEND:20250601T110000Z
+SUMMARY:Blocked time
+TRANSP:TRANSPARENT
+END:VEVENT
+END:VCALENDAR`);
+
+    expect(convertICalEvent(vevent, SUB_CAL_ID)).toBeNull();
+  });
+
+  test("includes OPAQUE events", () => {
+    const vevent = parseVevent(`BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:opaque@example.com
+DTSTART:20250601T100000Z
+DTEND:20250601T110000Z
+SUMMARY:Opaque event
+TRANSP:OPAQUE
+END:VEVENT
+END:VCALENDAR`);
+
+    expect(convertICalEvent(vevent, SUB_CAL_ID)).not.toBeNull();
+  });
+
+  test("detects all-day events from DATE DTSTART", () => {
+    const vevent = parseVevent(`BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:allday@example.com
+DTSTART;VALUE=DATE:20250601
+DTEND;VALUE=DATE:20250602
+SUMMARY:All day event
+END:VEVENT
+END:VCALENDAR`);
+
+    const result = convertICalEvent(vevent, SUB_CAL_ID);
+
+    expect(result).not.toBeNull();
+    expect(result!.isAllDay).toBe(true);
+  });
+
+  test("extracts TZID from DTSTART into originalTimezone", () => {
+    const vevent = parseVevent(`BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:tz@example.com
+DTSTART;TZID=America/New_York:20250601T100000
+DTEND;TZID=America/New_York:20250601T110000
+SUMMARY:Timezone event
+END:VEVENT
+END:VCALENDAR`);
+
+    const result = convertICalEvent(vevent, SUB_CAL_ID);
+
+    expect(result).not.toBeNull();
+    expect(result!.originalTimezone).toBe("America/New_York");
+  });
+
+  test("sets rrule from RRULE property (value only, no RRULE: prefix)", () => {
+    const vevent = parseVevent(`BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:recurring@example.com
+DTSTART:20250601T100000Z
+DTEND:20250601T110000Z
+SUMMARY:Weekly meeting
+RRULE:FREQ=WEEKLY;COUNT=4
+END:VEVENT
+END:VCALENDAR`);
+
+    const result = convertICalEvent(vevent, SUB_CAL_ID);
+
+    expect(result).not.toBeNull();
+    expect(result!.rrule).toBe("FREQ=WEEKLY;COUNT=4");
+  });
+
+  test("leaves rrule undefined when no RRULE property", () => {
+    const vevent = parseVevent(`BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:nonrecurring@example.com
+DTSTART:20250601T100000Z
+DTEND:20250601T110000Z
+SUMMARY:One-time event
+END:VEVENT
+END:VCALENDAR`);
+
+    const result = convertICalEvent(vevent, SUB_CAL_ID);
+
+    expect(result).not.toBeNull();
+    expect(result!.rrule).toBeUndefined();
+  });
+
+  test("converts dates to UTC milliseconds", () => {
+    const vevent = parseVevent(`BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:utcms@example.com
+DTSTART:20250601T120000Z
+DTEND:20250601T130000Z
+SUMMARY:UTC test
+END:VEVENT
+END:VCALENDAR`);
+
+    const result = convertICalEvent(vevent, SUB_CAL_ID);
+
+    expect(result).not.toBeNull();
+    expect(result!.startsAt).toBe(Date.UTC(2025, 5, 1, 12, 0, 0));
+    expect(result!.endsAt).toBe(Date.UTC(2025, 5, 1, 13, 0, 0));
+  });
+
+  test("leaves description and location undefined when absent", () => {
+    const vevent = parseVevent(`BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:minimal@example.com
+DTSTART:20250601T100000Z
+DTEND:20250601T110000Z
+SUMMARY:Minimal
+END:VEVENT
+END:VCALENDAR`);
+
+    const result = convertICalEvent(vevent, SUB_CAL_ID);
+
+    expect(result).not.toBeNull();
+    expect(result!.description).toBeUndefined();
+    expect(result!.location).toBeUndefined();
+    expect(result!.originalTimezone).toBeUndefined();
+  });
+
+  test("uses provided subCalendarId for externalId prefix and subCalendarId field", () => {
+    const vevent = parseVevent(`BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:subcal@example.com
+DTSTART:20250601T100000Z
+DTEND:20250601T110000Z
+SUMMARY:Sub-cal test
+END:VEVENT
+END:VCALENDAR`);
+
+    const result = convertICalEvent(vevent, "my-calendar");
+
+    expect(result).not.toBeNull();
+    expect(result!.subCalendarId).toBe("my-calendar");
+    expect(result!.externalId).toBe("my-calendar::subcal@example.com");
+  });
+});

--- a/convex/calendars/providers/convertICalEvent.ts
+++ b/convex/calendars/providers/convertICalEvent.ts
@@ -8,7 +8,7 @@ export function convertICalEvent(
   subCalendarId: string,
 ): IncomingEvent | null {
   const transp = vevent.getFirstPropertyValue("transp");
-  if (transp === "TRANSPARENT") return null;
+  if (typeof transp === "string" && transp.toUpperCase() === "TRANSPARENT") return null;
 
   const event = new ICAL.Event(vevent);
   const uid = event.uid;

--- a/convex/calendars/providers/convertICalEvent.ts
+++ b/convex/calendars/providers/convertICalEvent.ts
@@ -1,0 +1,44 @@
+import type { IncomingEvent } from "@shared/calendars";
+import ICAL from "ical.js";
+
+// Converts a single VEVENT component into an IncomingEvent.
+// Returns null when the event should be dropped (TRANSP:TRANSPARENT or missing UID).
+export function convertICalEvent(
+  vevent: InstanceType<typeof ICAL.Component>,
+  subCalendarId: string,
+): IncomingEvent | null {
+  const transp = vevent.getFirstPropertyValue("transp");
+  if (transp === "TRANSPARENT") return null;
+
+  const event = new ICAL.Event(vevent);
+  const uid = event.uid;
+  if (!uid) return null;
+
+  const dtStartProp = vevent.getFirstProperty("dtstart");
+  const tzid = (dtStartProp?.getParameter("tzid") as string | undefined) || undefined;
+
+  const rruleProp = vevent.getFirstProperty("rrule");
+  const rrule = rruleProp
+    ? String((rruleProp.getFirstValue() as { toString(): string }).toString())
+    : undefined;
+
+  const startDate = event.startDate;
+  const endDate = event.endDate;
+  const startsAt = startDate.toUnixTime() * 1000;
+  const endsAt = (endDate ?? startDate).toUnixTime() * 1000;
+  const isAllDay = startDate.isDate;
+
+  return {
+    externalId: `${subCalendarId}::${uid}`,
+    subCalendarId,
+    uid,
+    title: event.summary ?? "",
+    description: event.description || undefined,
+    location: event.location || undefined,
+    startsAt,
+    endsAt,
+    isAllDay,
+    originalTimezone: tzid,
+    rrule,
+  };
+}

--- a/convex/calendars/providers/ical.test.ts
+++ b/convex/calendars/providers/ical.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { Id } from "../../_generated/dataModel";
 import schema from "../../schema";
 import { encryptJson } from "../domain/crypto";
-import { fetchICalFeed } from "./ical";
+import { fetchICalFeed, ICalProvider } from "./ical";
 
 const modules = import.meta.glob("/convex/**/*.ts");
 
@@ -266,5 +266,226 @@ describe("fetchICalFeed", () => {
     await expect(t.action((ctx) => fetchICalFeed(ctx, connection!))).rejects.toMatchObject({
       kind: "network",
     });
+  });
+});
+
+describe("ICalProvider.fetchEvents", () => {
+  const WINDOW = {
+    windowStartMs: new Date("2025-06-01T00:00:00Z").getTime(),
+    windowEndMs: new Date("2025-12-31T23:59:59Z").getTime(),
+  };
+
+  beforeEach(() => {
+    vi.stubEnv("CALENDAR_ENCRYPTION_KEY", TEST_KEY);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  test("returns empty array when feed is unchanged (304)", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t);
+    const encryptedUrl = await encryptJson("https://example.com/cal.ics");
+    const connectionId = await insertICalConnection(t, userId, {
+      icalUrl: encryptedUrl,
+      icalEtag: '"abc"',
+    });
+    const connection = await t.run((ctx) => ctx.db.get(connectionId));
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce({ ok: false, status: 304, headers: { get: () => null } }),
+    );
+
+    const result = await t.action((ctx) => ICalProvider.fetchEvents!(ctx, connection!, WINDOW));
+
+    expect(result).toEqual([]);
+  });
+
+  test("parses VEVENT components and returns IncomingEvent array", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t);
+    const encryptedUrl = await encryptJson("https://example.com/cal.ics");
+    const connectionId = await insertICalConnection(t, userId, { icalUrl: encryptedUrl });
+    const connection = await t.run((ctx) => ctx.db.get(connectionId));
+
+    const ical = `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:event1@example.com
+DTSTART:20250615T100000Z
+DTEND:20250615T110000Z
+SUMMARY:June Meeting
+END:VEVENT
+END:VCALENDAR`;
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: { get: () => null },
+        text: async () => ical,
+      }),
+    );
+
+    const result = await t.action((ctx) => ICalProvider.fetchEvents!(ctx, connection!, WINDOW));
+
+    expect(result).toHaveLength(1);
+    expect(result[0].uid).toBe("event1@example.com");
+    expect(result[0].externalId).toBe("default::event1@example.com");
+    expect(result[0].title).toBe("June Meeting");
+    expect(result[0].subCalendarId).toBe("default");
+  });
+
+  test("excludes TRANSPARENT events", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t);
+    const encryptedUrl = await encryptJson("https://example.com/cal.ics");
+    const connectionId = await insertICalConnection(t, userId, { icalUrl: encryptedUrl });
+    const connection = await t.run((ctx) => ctx.db.get(connectionId));
+
+    const ical = `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:opaque@example.com
+DTSTART:20250615T100000Z
+DTEND:20250615T110000Z
+SUMMARY:Opaque
+TRANSP:OPAQUE
+END:VEVENT
+BEGIN:VEVENT
+UID:transparent@example.com
+DTSTART:20250615T100000Z
+DTEND:20250615T110000Z
+SUMMARY:Blocked
+TRANSP:TRANSPARENT
+END:VEVENT
+END:VCALENDAR`;
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: { get: () => null },
+        text: async () => ical,
+      }),
+    );
+
+    const result = await t.action((ctx) => ICalProvider.fetchEvents!(ctx, connection!, WINDOW));
+
+    expect(result).toHaveLength(1);
+    expect(result[0].uid).toBe("opaque@example.com");
+  });
+
+  test("includes recurring events (has RRULE) regardless of DTSTART position", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t);
+    const encryptedUrl = await encryptJson("https://example.com/cal.ics");
+    const connectionId = await insertICalConnection(t, userId, { icalUrl: encryptedUrl });
+    const connection = await t.run((ctx) => ctx.db.get(connectionId));
+
+    // DTSTART is before the window but it has an RRULE — must be included
+    const ical = `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:recurring@example.com
+DTSTART:20240101T100000Z
+DTEND:20240101T110000Z
+RRULE:FREQ=WEEKLY;BYDAY=MO
+SUMMARY:Weekly standup
+END:VEVENT
+END:VCALENDAR`;
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: { get: () => null },
+        text: async () => ical,
+      }),
+    );
+
+    const result = await t.action((ctx) => ICalProvider.fetchEvents!(ctx, connection!, WINDOW));
+
+    expect(result).toHaveLength(1);
+    expect(result[0].rrule).toBe("FREQ=WEEKLY;BYDAY=MO");
+  });
+
+  test("excludes non-recurring events outside the sync window", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t);
+    const encryptedUrl = await encryptJson("https://example.com/cal.ics");
+    const connectionId = await insertICalConnection(t, userId, { icalUrl: encryptedUrl });
+    const connection = await t.run((ctx) => ctx.db.get(connectionId));
+
+    const ical = `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:past@example.com
+DTSTART:20200101T100000Z
+DTEND:20200101T110000Z
+SUMMARY:Old event
+END:VEVENT
+BEGIN:VEVENT
+UID:future@example.com
+DTSTART:20300101T100000Z
+DTEND:20300101T110000Z
+SUMMARY:Far future event
+END:VEVENT
+BEGIN:VEVENT
+UID:inwindow@example.com
+DTSTART:20250615T100000Z
+DTEND:20250615T110000Z
+SUMMARY:In window
+END:VEVENT
+END:VCALENDAR`;
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: { get: () => null },
+        text: async () => ical,
+      }),
+    );
+
+    const result = await t.action((ctx) => ICalProvider.fetchEvents!(ctx, connection!, WINDOW));
+
+    expect(result).toHaveLength(1);
+    expect(result[0].uid).toBe("inwindow@example.com");
+  });
+
+  test("converts dates to UTC milliseconds", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertUser(t);
+    const encryptedUrl = await encryptJson("https://example.com/cal.ics");
+    const connectionId = await insertICalConnection(t, userId, { icalUrl: encryptedUrl });
+    const connection = await t.run((ctx) => ctx.db.get(connectionId));
+
+    const ical = `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:dates@example.com
+DTSTART:20250615T120000Z
+DTEND:20250615T130000Z
+SUMMARY:Date test
+END:VEVENT
+END:VCALENDAR`;
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: { get: () => null },
+        text: async () => ical,
+      }),
+    );
+
+    const result = await t.action((ctx) => ICalProvider.fetchEvents!(ctx, connection!, WINDOW));
+
+    expect(result[0].startsAt).toBe(Date.UTC(2025, 5, 15, 12, 0, 0));
+    expect(result[0].endsAt).toBe(Date.UTC(2025, 5, 15, 13, 0, 0));
   });
 });

--- a/convex/calendars/providers/ical.ts
+++ b/convex/calendars/providers/ical.ts
@@ -12,11 +12,13 @@ import type {
   WriteError,
   WriteSuccess,
 } from "@shared/calendars";
+import ICAL from "ical.js";
 
 import { internal } from "../../_generated/api";
 import type { Doc } from "../../_generated/dataModel";
 import type { ActionCtx } from "../../_generated/server";
 import { decryptJson, encryptJson } from "../domain/crypto";
+import { convertICalEvent } from "./convertICalEvent";
 
 export const icalCapabilities: CalendarProviderCapabilities = {
   serverSidePullable: true,
@@ -113,9 +115,38 @@ export const ICalProvider: CalendarProvider = {
   async fetchEvents(
     _ctx: unknown,
     _connection: unknown,
-    _window: SyncWindow,
+    window: SyncWindow,
   ): Promise<IncomingEvent[]> {
-    throw new Error("Not implemented: iCal Calendar is not yet supported");
+    const ctx = _ctx as ActionCtx;
+    const connection = _connection as Doc<"calendarConnections">;
+
+    const result = await fetchICalFeed(ctx, connection);
+    if (result.unchanged) return [];
+
+    const parsed = ICAL.parse(result.text);
+    const comp = new ICAL.Component(parsed);
+    const vevents = comp.getAllSubcomponents("vevent");
+
+    const events: IncomingEvent[] = [];
+
+    for (const vevent of vevents) {
+      const event = convertICalEvent(vevent, ICAL_SYNTHETIC_SUB_CALENDAR_EXTERNAL_ID);
+      if (!event) continue;
+
+      // Non-recurring events outside the sync window are skipped.
+      // Recurring events are always included — the service layer expands
+      // them via expandRecurrence and filters to the window.
+      if (
+        !event.rrule &&
+        (event.startsAt < window.windowStartMs || event.startsAt > window.windowEndMs)
+      ) {
+        continue;
+      }
+
+      events.push(event);
+    }
+
+    return events;
   },
 
   async writeEvent(

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "expo-status-bar": "~55.0.5",
         "expo-web-browser": "~55.0.14",
         "heroui-native": "^1.0.1",
+        "ical.js": "^2.2.1",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-native": "0.83.6",
@@ -11827,6 +11828,12 @@
       "dependencies": {
         "ms": "^2.0.0"
       }
+    },
+    "node_modules/ical.js": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ical.js/-/ical.js-2.2.1.tgz",
+      "integrity": "sha512-yK/UlPbEs316igb/tjRgbFA8ZV75rCsBJp/hWOatpyaPNlgw0dGDmU+FoicOcwX4xXkeXOkYiOmCqNPFpNPkQg==",
+      "license": "MPL-2.0"
     },
     "node_modules/idb-keyval": {
       "version": "6.2.1",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "expo-status-bar": "~55.0.5",
     "expo-web-browser": "~55.0.14",
     "heroui-native": "^1.0.1",
+    "ical.js": "^2.2.1",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-native": "0.83.6",


### PR DESCRIPTION
## Summary

- Implements `fetchEvents` on `ICalProvider` using `ical.js` to parse raw iCal text from `fetchICalFeed`
- Returns empty array immediately on 304 Not Modified (unchanged feed)
- Extracts VEVENT components, maps to `IncomingEvent[]` via new `convertICalEvent` helper
- Excludes `TRANSP:TRANSPARENT` events; filters non-recurring events to the sync window; passes recurring events (with `rrule` set) for the service layer to expand via `expandRecurrence`
- Installs `ical.js` (pure-JS RFC 5545 parser, works in Convex Node actions)

## Test Plan

- [ ] `convertICalEvent.test.ts` — 10 unit tests covering field mapping, TRANSPARENT exclusion, all-day detection, TZID extraction, RRULE string format, UTC millisecond conversion
- [ ] `ical.test.ts` — 6 new integration tests covering 304 passthrough, VEVENT parsing, transparent exclusion, recurring event inclusion, window filtering, UTC date conversion

## Checklist

- [x] TypeScript compiles with zero errors
- [x] Lint passes (oxlint)
- [x] Formatting passes (oxfmt)
- [x] Tests pass — 344 tests across 35 files

Closes #138