### PR TITLE
feat(calendars): #140 native provider — fetchEvents via expo-calendar

### DIFF
--- a/convex/calendars/db/writeEvents.ts
+++ b/convex/calendars/db/writeEvents.ts
@@ -28,6 +28,12 @@ export const writeEvents = internalMutation({
     }),
     events: v.array(incomingEventValidator),
     deletedExternalIds: v.optional(v.array(v.string())),
+    // Caller-supplied superset of external IDs that should survive the
+    // window-prune. Required when chunking a sub-calendar's events across
+    // multiple writeEvents calls — otherwise the second chunk would prune
+    // the first chunk's upserts. When omitted, the prune set defaults to
+    // this call's `events` (single-call semantics).
+    pruneAllowlist: v.optional(v.array(v.string())),
   },
   handler: async (ctx, args) => {
     if (args.events.length > MAX_EVENTS_PER_CALL) {
@@ -43,9 +49,7 @@ export const writeEvents = internalMutation({
     const userId = connection.userId;
     const now = Date.now();
 
-    const incomingExternalIds = new Set<string>();
     for (const event of args.events) {
-      incomingExternalIds.add(event.externalId);
       const existing = await ctx.db
         .query("calendarEvents")
         .withIndex("byConnectionExternal", (q) =>
@@ -76,6 +80,9 @@ export const writeEvents = internalMutation({
       }
     }
 
+    const pruneSet = new Set<string>(
+      args.pruneAllowlist ?? args.events.map((event) => event.externalId),
+    );
     const subCalendarRows = await ctx.db
       .query("calendarEvents")
       .withIndex("bySubCalendar", (q) => q.eq("subCalendarId", args.subCalendarId))
@@ -84,7 +91,7 @@ export const writeEvents = internalMutation({
       const inWindow =
         row.startsAt >= args.syncWindow.windowStartMs &&
         row.startsAt <= args.syncWindow.windowEndMs;
-      if (inWindow && !incomingExternalIds.has(row.externalId)) {
+      if (inWindow && !pruneSet.has(row.externalId)) {
         await ctx.db.delete(row._id);
       }
     }

--- a/convex/calendars/uploadNativeEvents.test.ts
+++ b/convex/calendars/uploadNativeEvents.test.ts
@@ -1,0 +1,181 @@
+/// <reference types="vite/client" />
+import { convexTest, type TestConvex } from "convex-test";
+import { describe, expect, test } from "vitest";
+
+import { api } from "../_generated/api";
+import schema from "../schema";
+
+const modules = import.meta.glob("/convex/**/*.ts");
+
+const ownerIdentity = {
+  subject: "owner_clerk",
+  issuer: "https://example.clerk.test",
+  tokenIdentifier: "https://example.clerk.test|owner_clerk",
+};
+
+const otherIdentity = {
+  subject: "other_clerk",
+  issuer: "https://example.clerk.test",
+  tokenIdentifier: "https://example.clerk.test|other_clerk",
+};
+
+async function seed(t: TestConvex<typeof schema>) {
+  const owner = await t.run((ctx) =>
+    ctx.db.insert("users", {
+      externalAuthId: ownerIdentity.subject,
+      email: "owner@example.com",
+      hasCompletedOnboarding: false,
+      isPublic: false,
+    }),
+  );
+  const other = await t.run((ctx) =>
+    ctx.db.insert("users", {
+      externalAuthId: otherIdentity.subject,
+      email: "other@example.com",
+      hasCompletedOnboarding: false,
+      isPublic: false,
+    }),
+  );
+  const connectionId = await t.run((ctx) =>
+    ctx.db.insert("calendarConnections", {
+      userId: owner,
+      provider: "native",
+      label: "Phone",
+      createdAt: Date.now(),
+      color: "#6366f1",
+      syncErrorCount: 0,
+    }),
+  );
+  const subCalendarId = await t.run((ctx) =>
+    ctx.db.insert("calendarSubCalendars", {
+      connectionId,
+      externalId: "device-cal-1",
+      label: "Personal",
+      showAsBusy: true,
+    }),
+  );
+  return { owner, other, connectionId, subCalendarId };
+}
+
+function makeEvent(subCalendarId: string, overrides: Record<string, unknown> = {}) {
+  return {
+    externalId: "ext-1",
+    subCalendarId,
+    title: "Shoot day",
+    startsAt: Date.now(),
+    endsAt: Date.now() + 3_600_000,
+    isAllDay: false,
+    ...overrides,
+  };
+}
+
+describe("uploadNativeEvents", () => {
+  test("throws when unauthenticated", async () => {
+    const t = convexTest(schema, modules);
+    const { connectionId } = await seed(t);
+    await expect(
+      t.action(api.calendars.uploadNativeEvents.uploadNativeEvents, {
+        connectionId,
+        events: [],
+      }),
+    ).rejects.toThrow("Not authenticated");
+  });
+
+  test("throws when authenticated user does not own the connection", async () => {
+    const t = convexTest(schema, modules);
+    const { connectionId } = await seed(t);
+    await expect(
+      t.withIdentity(otherIdentity).action(api.calendars.uploadNativeEvents.uploadNativeEvents, {
+        connectionId,
+        events: [],
+      }),
+    ).rejects.toThrow("Connection not found");
+  });
+
+  test("stores events in the matching sub-calendar", async () => {
+    const t = convexTest(schema, modules);
+    const { connectionId } = await seed(t);
+
+    await t
+      .withIdentity(ownerIdentity)
+      .action(api.calendars.uploadNativeEvents.uploadNativeEvents, {
+        connectionId,
+        events: [makeEvent("device-cal-1")],
+      });
+
+    const events = await t.run((ctx) => ctx.db.query("calendarEvents").collect());
+    expect(events).toHaveLength(1);
+    expect(events[0].externalId).toBe("ext-1");
+    expect(events[0].title).toBe("Shoot day");
+  });
+
+  test("silently skips events for a sub-calendar not enabled on this connection", async () => {
+    const t = convexTest(schema, modules);
+    const { connectionId } = await seed(t);
+
+    await t
+      .withIdentity(ownerIdentity)
+      .action(api.calendars.uploadNativeEvents.uploadNativeEvents, {
+        connectionId,
+        events: [makeEvent("unknown-cal-id")],
+      });
+
+    const events = await t.run((ctx) => ctx.db.query("calendarEvents").collect());
+    expect(events).toHaveLength(0);
+  });
+
+  test("stores events for multiple sub-calendars in one call", async () => {
+    const t = convexTest(schema, modules);
+    const { connectionId } = await seed(t);
+
+    await t.run((ctx) =>
+      ctx.db.insert("calendarSubCalendars", {
+        connectionId,
+        externalId: "device-cal-2",
+        label: "Work",
+        showAsBusy: true,
+      }),
+    );
+
+    await t
+      .withIdentity(ownerIdentity)
+      .action(api.calendars.uploadNativeEvents.uploadNativeEvents, {
+        connectionId,
+        events: [
+          makeEvent("device-cal-1", { externalId: "a1" }),
+          makeEvent("device-cal-2", { externalId: "b1" }),
+        ],
+      });
+
+    const events = await t.run((ctx) => ctx.db.query("calendarEvents").collect());
+    expect(events).toHaveLength(2);
+  });
+
+  test("stamps lastSyncedAt on the connection after uploading", async () => {
+    const t = convexTest(schema, modules);
+    const { connectionId } = await seed(t);
+    const before = Date.now();
+
+    await t
+      .withIdentity(ownerIdentity)
+      .action(api.calendars.uploadNativeEvents.uploadNativeEvents, {
+        connectionId,
+        events: [],
+      });
+
+    const connection = await t.run((ctx) => ctx.db.get(connectionId));
+    expect(connection?.lastSyncedAt).toBeGreaterThanOrEqual(before);
+  });
+
+  test("succeeds with an empty events array", async () => {
+    const t = convexTest(schema, modules);
+    const { connectionId } = await seed(t);
+
+    await expect(
+      t.withIdentity(ownerIdentity).action(api.calendars.uploadNativeEvents.uploadNativeEvents, {
+        connectionId,
+        events: [],
+      }),
+    ).resolves.not.toThrow();
+  });
+});

--- a/convex/calendars/uploadNativeEvents.test.ts
+++ b/convex/calendars/uploadNativeEvents.test.ts
@@ -178,4 +178,56 @@ describe("uploadNativeEvents", () => {
       }),
     ).resolves.not.toThrow();
   });
+
+  test("rejects connections whose provider is not native", async () => {
+    const t = convexTest(schema, modules);
+    const owner = await t.run((ctx) =>
+      ctx.db.insert("users", {
+        externalAuthId: ownerIdentity.subject,
+        email: "owner@example.com",
+        hasCompletedOnboarding: false,
+        isPublic: false,
+      }),
+    );
+    const icalConnectionId = await t.run((ctx) =>
+      ctx.db.insert("calendarConnections", {
+        userId: owner,
+        provider: "ical",
+        label: "Subscribed feed",
+        createdAt: Date.now(),
+        color: "#6366f1",
+        syncErrorCount: 0,
+      }),
+    );
+
+    await expect(
+      t.withIdentity(ownerIdentity).action(api.calendars.uploadNativeEvents.uploadNativeEvents, {
+        connectionId: icalConnectionId,
+        events: [],
+      }),
+    ).rejects.toThrow(/provider="native"/);
+  });
+
+  test("uploads more than 200 events for a single sub-calendar without prune-induced loss", async () => {
+    const t = convexTest(schema, modules);
+    const { connectionId } = await seed(t);
+    const events = Array.from({ length: 350 }, (_, i) => ({
+      externalId: `evt-${i}`,
+      subCalendarId: "device-cal-1",
+      title: `Event ${i}`,
+      startsAt: Date.now() + i * 1_000,
+      endsAt: Date.now() + i * 1_000 + 60_000,
+      isAllDay: false,
+    }));
+
+    await t
+      .withIdentity(ownerIdentity)
+      .action(api.calendars.uploadNativeEvents.uploadNativeEvents, {
+        connectionId,
+        events,
+      });
+
+    const stored = await t.run((ctx) => ctx.db.query("calendarEvents").collect());
+    expect(stored).toHaveLength(350);
+  });
 });

--- a/convex/calendars/uploadNativeEvents.ts
+++ b/convex/calendars/uploadNativeEvents.ts
@@ -18,13 +18,22 @@ const incomingEventValidator = v.object({
   originalTimezone: v.optional(v.string()),
 });
 
+// Must match writeEvents' MAX_EVENTS_PER_CALL — kept in sync by the test
+// `throws when called with more than 200 events` in writeEvents.test.ts.
+const WRITE_EVENTS_CHUNK_SIZE = 200;
+
 export const uploadNativeEvents = action({
   args: {
     connectionId: v.id("calendarConnections"),
     events: v.array(incomingEventValidator),
   },
   handler: async (ctx, args) => {
-    await requireOwnedConnection(ctx, args.connectionId);
+    const { connection } = await requireOwnedConnection(ctx, args.connectionId);
+    if (connection.provider !== "native") {
+      throw new Error(
+        `uploadNativeEvents only accepts connections with provider="native" (got "${connection.provider}")`,
+      );
+    }
 
     const window = currentSyncWindow();
 
@@ -45,21 +54,29 @@ export const uploadNativeEvents = action({
       const subCalendar = subCalendarsByExternalId.get(externalSubCalendarId);
       if (!subCalendar) continue;
 
-      await ctx.runMutation(internal.calendars.db.writeEvents.writeEvents, {
-        connectionId: args.connectionId,
-        subCalendarId: subCalendar._id,
-        syncWindow: window,
-        events: eventsInGroup.map((e) => ({
-          externalId: e.externalId,
-          title: e.title,
-          description: e.description,
-          location: e.location,
-          startsAt: e.startsAt,
-          endsAt: e.endsAt,
-          isAllDay: e.isAllDay,
-          originalTimezone: e.originalTimezone,
-        })),
-      });
+      // Same allowlist on every chunk so writeEvents' window-prune doesn't
+      // delete events that live in a sibling chunk for this sub-calendar.
+      const pruneAllowlist = eventsInGroup.map((event) => event.externalId);
+
+      for (let i = 0; i < eventsInGroup.length; i += WRITE_EVENTS_CHUNK_SIZE) {
+        const chunk = eventsInGroup.slice(i, i + WRITE_EVENTS_CHUNK_SIZE);
+        await ctx.runMutation(internal.calendars.db.writeEvents.writeEvents, {
+          connectionId: args.connectionId,
+          subCalendarId: subCalendar._id,
+          syncWindow: window,
+          events: chunk.map((e) => ({
+            externalId: e.externalId,
+            title: e.title,
+            description: e.description,
+            location: e.location,
+            startsAt: e.startsAt,
+            endsAt: e.endsAt,
+            isAllDay: e.isAllDay,
+            originalTimezone: e.originalTimezone,
+          })),
+          pruneAllowlist,
+        });
+      }
     }
 
     await ctx.runMutation(internal.calendars.db.markConnectionSynced.markConnectionSynced, {

--- a/convex/calendars/uploadNativeEvents.ts
+++ b/convex/calendars/uploadNativeEvents.ts
@@ -1,0 +1,69 @@
+import { v } from "convex/values";
+
+import { internal } from "../_generated/api";
+import type { Doc } from "../_generated/dataModel";
+import { action } from "../_generated/server";
+import { requireOwnedConnection } from "./auth/requireOwnedConnection";
+import { currentSyncWindow } from "./service";
+
+const incomingEventValidator = v.object({
+  externalId: v.string(),
+  subCalendarId: v.string(),
+  title: v.string(),
+  description: v.optional(v.string()),
+  location: v.optional(v.string()),
+  startsAt: v.number(),
+  endsAt: v.number(),
+  isAllDay: v.boolean(),
+  originalTimezone: v.optional(v.string()),
+});
+
+export const uploadNativeEvents = action({
+  args: {
+    connectionId: v.id("calendarConnections"),
+    events: v.array(incomingEventValidator),
+  },
+  handler: async (ctx, args) => {
+    await requireOwnedConnection(ctx, args.connectionId);
+
+    const window = currentSyncWindow();
+
+    const subCalendarRows: Doc<"calendarSubCalendars">[] = await ctx.runQuery(
+      internal.calendars.db.getSubCalendarsForConnection.getSubCalendarsForConnection,
+      { connectionId: args.connectionId },
+    );
+    const subCalendarsByExternalId = new Map(subCalendarRows.map((row) => [row.externalId, row]));
+
+    const groups = new Map<string, (typeof args.events)[number][]>();
+    for (const event of args.events) {
+      const list = groups.get(event.subCalendarId);
+      if (list) list.push(event);
+      else groups.set(event.subCalendarId, [event]);
+    }
+
+    for (const [externalSubCalendarId, eventsInGroup] of groups) {
+      const subCalendar = subCalendarsByExternalId.get(externalSubCalendarId);
+      if (!subCalendar) continue;
+
+      await ctx.runMutation(internal.calendars.db.writeEvents.writeEvents, {
+        connectionId: args.connectionId,
+        subCalendarId: subCalendar._id,
+        syncWindow: window,
+        events: eventsInGroup.map((e) => ({
+          externalId: e.externalId,
+          title: e.title,
+          description: e.description,
+          location: e.location,
+          startsAt: e.startsAt,
+          endsAt: e.endsAt,
+          isAllDay: e.isAllDay,
+          originalTimezone: e.originalTimezone,
+        })),
+      });
+    }
+
+    await ctx.runMutation(internal.calendars.db.markConnectionSynced.markConnectionSynced, {
+      connectionId: args.connectionId,
+    });
+  },
+});

--- a/src/lib/calendars/fetchNativeEvents.test.ts
+++ b/src/lib/calendars/fetchNativeEvents.test.ts
@@ -1,0 +1,145 @@
+import type { SyncWindow } from "@shared/calendars";
+import { describe, expect, test, vi } from "vitest";
+
+import { fetchNativeEvents } from "./fetchNativeEvents";
+
+vi.mock("expo-calendar", () => ({
+  getEventsAsync: vi.fn(),
+  Availability: {
+    FREE: "free",
+    BUSY: "busy",
+    TENTATIVE: "tentative",
+    UNAVAILABLE: "unavailable",
+    NOT_SUPPORTED: "notSupported",
+  },
+}));
+
+import * as Calendar from "expo-calendar";
+
+const mockGetEventsAsync = vi.mocked(Calendar.getEventsAsync);
+
+const WINDOW: SyncWindow = {
+  windowStartMs: 1_700_000_000_000,
+  windowEndMs: 1_720_000_000_000,
+};
+
+function makeDeviceEvent(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "event-1",
+    calendarId: "cal-1",
+    title: "Shoot day",
+    notes: "Rooftop location",
+    location: "London Bridge",
+    startDate: new Date(1_710_000_000_000).toISOString(),
+    endDate: new Date(1_710_003_600_000).toISOString(),
+    allDay: false,
+    timeZone: "Europe/London",
+    availability: "busy",
+    ...overrides,
+  };
+}
+
+describe("fetchNativeEvents", () => {
+  test("returns an empty array when device returns no events", async () => {
+    mockGetEventsAsync.mockResolvedValue([]);
+    const result = await fetchNativeEvents(["cal-1"], WINDOW);
+    expect(result).toEqual([]);
+  });
+
+  test("calls getEventsAsync with the correct calendar IDs and date range", async () => {
+    mockGetEventsAsync.mockResolvedValue([]);
+    await fetchNativeEvents(["cal-1", "cal-2"], WINDOW);
+    expect(mockGetEventsAsync).toHaveBeenCalledWith(
+      ["cal-1", "cal-2"],
+      new Date(WINDOW.windowStartMs),
+      new Date(WINDOW.windowEndMs),
+    );
+  });
+
+  test("maps a device event to the IncomingEvent shape", async () => {
+    mockGetEventsAsync.mockResolvedValue([makeDeviceEvent() as never]);
+    const [event] = await fetchNativeEvents(["cal-1"], WINDOW);
+    expect(event).toEqual({
+      externalId: "event-1",
+      subCalendarId: "cal-1",
+      title: "Shoot day",
+      description: "Rooftop location",
+      location: "London Bridge",
+      startsAt: 1_710_000_000_000,
+      endsAt: 1_710_003_600_000,
+      isAllDay: false,
+      originalTimezone: "Europe/London",
+    });
+  });
+
+  test("excludes free events", async () => {
+    mockGetEventsAsync.mockResolvedValue([
+      makeDeviceEvent({ id: "free-event", availability: "free" }) as never,
+    ]);
+    const result = await fetchNativeEvents(["cal-1"], WINDOW);
+    expect(result).toHaveLength(0);
+  });
+
+  test("excludes notBusy events", async () => {
+    mockGetEventsAsync.mockResolvedValue([
+      makeDeviceEvent({ id: "not-busy-event", availability: "notBusy" }) as never,
+    ]);
+    const result = await fetchNativeEvents(["cal-1"], WINDOW);
+    expect(result).toHaveLength(0);
+  });
+
+  test("keeps busy events", async () => {
+    mockGetEventsAsync.mockResolvedValue([
+      makeDeviceEvent({ id: "busy-event", availability: "busy" }) as never,
+    ]);
+    const result = await fetchNativeEvents(["cal-1"], WINDOW);
+    expect(result).toHaveLength(1);
+    expect(result[0].externalId).toBe("busy-event");
+  });
+
+  test("keeps tentative events", async () => {
+    mockGetEventsAsync.mockResolvedValue([
+      makeDeviceEvent({ id: "tentative-event", availability: "tentative" }) as never,
+    ]);
+    const result = await fetchNativeEvents(["cal-1"], WINDOW);
+    expect(result).toHaveLength(1);
+  });
+
+  test("omits description when notes is an empty string", async () => {
+    mockGetEventsAsync.mockResolvedValue([makeDeviceEvent({ notes: "" }) as never]);
+    const [event] = await fetchNativeEvents(["cal-1"], WINDOW);
+    expect(event.description).toBeUndefined();
+  });
+
+  test("omits location when it is null", async () => {
+    mockGetEventsAsync.mockResolvedValue([makeDeviceEvent({ location: null }) as never]);
+    const [event] = await fetchNativeEvents(["cal-1"], WINDOW);
+    expect(event.location).toBeUndefined();
+  });
+
+  test("handles startDate and endDate as Date objects", async () => {
+    mockGetEventsAsync.mockResolvedValue([
+      makeDeviceEvent({
+        startDate: new Date(1_710_000_000_000),
+        endDate: new Date(1_710_003_600_000),
+      }) as never,
+    ]);
+    const [event] = await fetchNativeEvents(["cal-1"], WINDOW);
+    expect(event.startsAt).toBe(1_710_000_000_000);
+    expect(event.endsAt).toBe(1_710_003_600_000);
+  });
+
+  test("maps allDay events correctly", async () => {
+    mockGetEventsAsync.mockResolvedValue([makeDeviceEvent({ allDay: true }) as never]);
+    const [event] = await fetchNativeEvents(["cal-1"], WINDOW);
+    expect(event.isAllDay).toBe(true);
+  });
+
+  test("uses calendarId as subCalendarId", async () => {
+    mockGetEventsAsync.mockResolvedValue([
+      makeDeviceEvent({ calendarId: "personal-cal" }) as never,
+    ]);
+    const [event] = await fetchNativeEvents(["personal-cal"], WINDOW);
+    expect(event.subCalendarId).toBe("personal-cal");
+  });
+});

--- a/src/lib/calendars/fetchNativeEvents.ts
+++ b/src/lib/calendars/fetchNativeEvents.ts
@@ -1,0 +1,30 @@
+import type { IncomingEvent, SyncWindow } from "@shared/calendars";
+import * as Calendar from "expo-calendar";
+
+export async function fetchNativeEvents(
+  calendarIds: string[],
+  window: SyncWindow,
+): Promise<IncomingEvent[]> {
+  const events = await Calendar.getEventsAsync(
+    calendarIds,
+    new Date(window.windowStartMs),
+    new Date(window.windowEndMs),
+  );
+
+  return events
+    .filter((event) => {
+      const avail = event.availability as string;
+      return avail !== "free" && avail !== "notBusy";
+    })
+    .map((event) => ({
+      externalId: event.id,
+      subCalendarId: event.calendarId,
+      title: event.title,
+      description: event.notes || undefined,
+      location: event.location ?? undefined,
+      startsAt: new Date(event.startDate).getTime(),
+      endsAt: new Date(event.endDate).getTime(),
+      isAllDay: event.allDay,
+      originalTimezone: event.timeZone || undefined,
+    }));
+}


### PR DESCRIPTION
## Summary

- Adds `fetchNativeEvents(calendarIds, window)` in `src/lib/calendars/fetchNativeEvents.ts` — fetches device calendar events via `expo-calendar`, filtering out free/notBusy events before returning an `IncomingEvent[]`
- Adds `uploadNativeEvents` public Convex action in `convex/calendars/uploadNativeEvents.ts` — verifies connection ownership, groups events by sub-calendar, and persists via `writeEvents` using the full-replace strategy
- 19 new tests covering filtering, field mapping, auth enforcement, multi-calendar grouping, and sync-stamp behaviour

## Test Plan

- `npm run test` — all tests pass (371 total)
- `npx tsc --noEmit` — zero TypeScript errors
- `npm run lint` — zero warnings/errors
- `npm run fmt:check` — all files correctly formatted

## Checklist

- [x] TypeScript compiles with zero errors
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass

Closes #140