### PR TITLE
feat(calendars): #143 CalendarManagementSheet — shell and connected calendar list display

### DIFF
--- a/src/app/(home)/diary.tsx
+++ b/src/app/(home)/diary.tsx
@@ -6,6 +6,7 @@ import { Calendar, DateData } from "react-native-calendars";
 import { ScrollView } from "react-native-gesture-handler";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
+import { CalendarManagementSheet } from "@/components/calendars/CalendarManagementSheet";
 import { GearIcon } from "@/components/ui/icons/GearIcon";
 
 export default function Diary() {
@@ -15,6 +16,7 @@ export default function Diary() {
   const [_visibleMonth, setVisibleMonth] = useState<string>(() => {
     return format(startOfMonth(new Date()), "yyyy-MM-dd");
   });
+  const [isManagementSheetOpen, setIsManagementSheetOpen] = useState(false);
   const insets = useSafeAreaInsets();
 
   const [accent, accentForeground, foreground, muted] = useThemeColor([
@@ -25,49 +27,56 @@ export default function Diary() {
   ]);
 
   return (
-    <ScrollView style={{ flex: 1, paddingTop: insets.top, paddingBottom: insets.bottom }}>
-      <View className="flex-1">
-        <View className="flex-row items-center justify-between px-4">
-          <Text className="text-2xl font-bold text-foreground">My Diary</Text>
-          <Pressable
-            onPress={() => {}}
-            accessibilityRole="button"
-            accessibilityLabel="Link external calendars"
-            hitSlop={10}
-            className="p-1"
-          >
-            <GearIcon size={22} />
-          </Pressable>
-        </View>
+    <>
+      <ScrollView style={{ flex: 1, paddingTop: insets.top, paddingBottom: insets.bottom }}>
+        <View className="flex-1">
+          <View className="flex-row items-center justify-between px-4">
+            <Text className="text-2xl font-bold text-foreground">My Diary</Text>
+            <Pressable
+              onPress={() => setIsManagementSheetOpen(true)}
+              accessibilityRole="button"
+              accessibilityLabel="Link external calendars"
+              hitSlop={10}
+              className="p-1"
+            >
+              <GearIcon size={22} />
+            </Pressable>
+          </View>
 
-        <Calendar
-          current={todayIso}
-          onDayPress={(day: DateData) => setSelectedDate(day.dateString)}
-          onMonthChange={(m: DateData) => setVisibleMonth(m.dateString)}
-          theme={{
-            backgroundColor: "transparent",
-            calendarBackground: "transparent",
-            selectedDayBackgroundColor: accent,
-            selectedDayTextColor: accentForeground,
-            todayTextColor: accent,
-            dayTextColor: foreground,
-            textDisabledColor: muted,
-            monthTextColor: foreground,
-            arrowColor: accent,
-            textDayFontWeight: "400",
-            textMonthFontWeight: "600",
-            textDayHeaderFontWeight: "500",
-            dotColor: accent,
-            selectedDotColor: accentForeground,
-          }}
-          style={{ marginHorizontal: 8 }}
-        />
+          <Calendar
+            current={todayIso}
+            onDayPress={(day: DateData) => setSelectedDate(day.dateString)}
+            onMonthChange={(m: DateData) => setVisibleMonth(m.dateString)}
+            theme={{
+              backgroundColor: "transparent",
+              calendarBackground: "transparent",
+              selectedDayBackgroundColor: accent,
+              selectedDayTextColor: accentForeground,
+              todayTextColor: accent,
+              dayTextColor: foreground,
+              textDisabledColor: muted,
+              monthTextColor: foreground,
+              arrowColor: accent,
+              textDayFontWeight: "400",
+              textMonthFontWeight: "600",
+              textDayHeaderFontWeight: "500",
+              dotColor: accent,
+              selectedDotColor: accentForeground,
+            }}
+            style={{ marginHorizontal: 8 }}
+          />
 
-        <View className="px-4 mt-4">
-          <Text className="text-sm text-foreground/60">{format(selectedDate, "EEEE")}</Text>
-          <Text className="text-sm text-foreground/60">{format(selectedDate, "d MMMM")}</Text>
+          <View className="mt-4 px-4">
+            <Text className="text-sm text-foreground/60">{format(selectedDate, "EEEE")}</Text>
+            <Text className="text-sm text-foreground/60">{format(selectedDate, "d MMMM")}</Text>
+          </View>
         </View>
-      </View>
-    </ScrollView>
+      </ScrollView>
+
+      <CalendarManagementSheet
+        isOpen={isManagementSheetOpen}
+        onClose={() => setIsManagementSheetOpen(false)}
+      />
+    </>
   );
 }

--- a/src/components/calendars/CalendarManagementSheet.stories.tsx
+++ b/src/components/calendars/CalendarManagementSheet.stories.tsx
@@ -1,0 +1,116 @@
+import type { Id } from "@convex/_generated/dataModel";
+import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
+import type { Meta, StoryObj } from "@storybook/react-native";
+import { View } from "react-native";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
+
+import { CalendarConnectionList, type ConnectionRow } from "./CalendarManagementSheet";
+
+const now = Date.now();
+
+const mockConnections: ConnectionRow[] = [
+  {
+    _id: "conn_google_1" as Id<"calendarConnections">,
+    provider: "google",
+    label: "work@example.com",
+    color: "#6366f1",
+    lastSyncedAt: now - 5 * 60 * 1000,
+    syncErrorCount: 0,
+    subCalendarCount: 3,
+  },
+  {
+    _id: "conn_ical_1" as Id<"calendarConnections">,
+    provider: "ical",
+    label: "Family Calendar",
+    color: "#22c55e",
+    lastSyncedAt: now - 2 * 60 * 60 * 1000,
+    syncErrorCount: 0,
+    subCalendarCount: 1,
+  },
+  {
+    _id: "conn_native_1" as Id<"calendarConnections">,
+    provider: "native",
+    label: "Personal iPhone Calendar",
+    color: "#f59e0b",
+    lastSyncedAt: now - 30 * 60 * 1000,
+    syncErrorCount: 0,
+    subCalendarCount: 2,
+  },
+];
+
+const errorConnection: ConnectionRow = {
+  _id: "conn_ms_1" as Id<"calendarConnections">,
+  provider: "microsoft",
+  label: "outlook@company.com",
+  color: "#ef4444",
+  lastSyncedAt: now - 24 * 60 * 60 * 1000,
+  lastSyncError: "Authentication token expired. Please reconnect your account.",
+  syncErrorCount: 5,
+  subCalendarCount: 0,
+};
+
+const meta = {
+  title: "Calendars/CalendarConnectionList",
+  component: CalendarConnectionList,
+  decorators: [
+    (Story) => (
+      <GestureHandlerRootView style={{ flex: 1 }}>
+        <BottomSheetModalProvider>
+          <View style={{ flex: 1, padding: 16, backgroundColor: "#f9f9f9" }}>
+            <Story />
+          </View>
+        </BottomSheetModalProvider>
+      </GestureHandlerRootView>
+    ),
+  ],
+  tags: ["autodocs"],
+  args: {
+    connections: mockConnections,
+  },
+} satisfies Meta<typeof CalendarConnectionList>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Loading: Story = {
+  args: {
+    connections: undefined,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    connections: [],
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    connections: [errorConnection, ...mockConnections],
+  },
+};
+
+export const SingleConnection: Story = {
+  args: {
+    connections: [mockConnections[0]!],
+  },
+};
+
+export const NeverSynced: Story = {
+  args: {
+    connections: [
+      {
+        _id: "conn_new_1" as Id<"calendarConnections">,
+        provider: "google",
+        label: "new@example.com",
+        color: "#8b5cf6",
+        lastSyncedAt: undefined,
+        syncErrorCount: 0,
+        subCalendarCount: 0,
+      },
+    ],
+  },
+};

--- a/src/components/calendars/CalendarManagementSheet.tsx
+++ b/src/components/calendars/CalendarManagementSheet.tsx
@@ -1,0 +1,132 @@
+import { api } from "@convex/_generated/api";
+import type { Id } from "@convex/_generated/dataModel";
+import { BottomSheetScrollView } from "@gorhom/bottom-sheet";
+import { useQuery } from "convex/react";
+import { formatDistanceToNow } from "date-fns";
+import { BottomSheet, Button, PressableFeedback, Separator, Spinner } from "heroui-native";
+import { Fragment } from "react";
+import { Text, View } from "react-native";
+
+export type ConnectionRow = {
+  _id: Id<"calendarConnections">;
+  provider: string;
+  label: string;
+  color: string;
+  lastSyncedAt?: number;
+  lastSyncError?: string;
+  syncErrorCount: number;
+  subCalendarCount: number;
+};
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+const PROVIDER_LOGO: Record<string, string> = {
+  google: "G",
+  microsoft: "M",
+  ical: "📅",
+  native: "📱",
+};
+
+// Exported for Storybook — renders all visual states without Convex
+export function CalendarConnectionList({
+  connections,
+}: {
+  connections: ConnectionRow[] | undefined;
+}) {
+  if (connections === undefined) {
+    return (
+      <View className="items-center py-8">
+        <Spinner />
+      </View>
+    );
+  }
+
+  if (connections.length === 0) {
+    return (
+      <View className="items-center py-8">
+        <Text className="text-sm text-muted-foreground">No calendars connected yet.</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View className="rounded-xl bg-default-100/40 px-3 py-2">
+      {connections.map((connection, idx) => (
+        <Fragment key={connection._id}>
+          {idx > 0 && <Separator className="my-1" />}
+          <View className="py-3">
+            <View className="flex-row items-center gap-3">
+              <View className="h-9 w-9 items-center justify-center rounded-full bg-default-200">
+                <Text className="text-sm font-semibold text-foreground">
+                  {PROVIDER_LOGO[connection.provider] ?? "?"}
+                </Text>
+              </View>
+
+              <View
+                className="h-3 w-3 rounded-full"
+                style={{ backgroundColor: connection.color }}
+              />
+
+              <PressableFeedback
+                onPress={() => {}}
+                accessibilityRole="button"
+                accessibilityLabel={`Manage ${connection.label}`}
+                className="flex-1"
+              >
+                <Text className="text-sm font-medium text-foreground" numberOfLines={1}>
+                  {connection.label}
+                </Text>
+                <Text className="text-xs text-muted-foreground">
+                  {connection.lastSyncedAt != null
+                    ? `Last synced ${formatDistanceToNow(connection.lastSyncedAt)} ago`
+                    : "Never synced"}
+                </Text>
+              </PressableFeedback>
+
+              <Button
+                variant="tertiary"
+                size="sm"
+                onPress={() => {}}
+                accessibilityLabel={`Disconnect ${connection.label}`}
+              >
+                Disconnect
+              </Button>
+            </View>
+
+            {connection.syncErrorCount > 3 && (
+              <View className="mt-2 rounded-lg bg-danger/10 px-3 py-2">
+                <Text className="text-xs font-medium text-danger">Sync error</Text>
+                {connection.lastSyncError != null && (
+                  <Text className="mt-0.5 text-xs text-danger/80">{connection.lastSyncError}</Text>
+                )}
+              </View>
+            )}
+          </View>
+        </Fragment>
+      ))}
+    </View>
+  );
+}
+
+export function CalendarManagementSheet({ isOpen, onClose }: Props) {
+  const connections = useQuery(api.calendars.queries.getConnections);
+
+  return (
+    <BottomSheet isOpen={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <BottomSheet.Portal disableFullWindowOverlay>
+        <BottomSheet.Overlay />
+        <BottomSheet.Content snapPoints={["55%", "85%"]}>
+          <BottomSheetScrollView contentContainerStyle={{ paddingBottom: 16 }}>
+            <View className="mb-4 gap-1.5 px-1">
+              <BottomSheet.Title>Connected Calendars</BottomSheet.Title>
+            </View>
+            <CalendarConnectionList connections={connections} />
+          </BottomSheetScrollView>
+        </BottomSheet.Content>
+      </BottomSheet.Portal>
+    </BottomSheet>
+  );
+}


### PR DESCRIPTION
## Summary

- Creates `src/components/calendars/CalendarManagementSheet.tsx` — a HeroUI Native `BottomSheet` that queries `getConnections` and renders the user's connected calendars
- Extracts `CalendarConnectionList` as a presentational component (exported for Storybook) showing provider logo, colour swatch, label, last-synced time, error badge, and placeholder disconnect button
- Wires the gear icon in `src/app/(home)/diary.tsx` to open the sheet via `isManagementSheetOpen` state
- Adds `src/components/calendars/CalendarManagementSheet.stories.tsx` with six stories: Default, Loading, Empty, WithError, SingleConnection, NeverSynced

## Test Plan

- [ ] Open the Diary screen — tap the gear icon in the top-right; the CalendarManagementSheet slides up
- [ ] With no connections: "No calendars connected yet." is shown
- [ ] With connections: each card shows provider logo ("G" / "M" / 📅 / 📱), colour circle, label, and last-synced time
- [ ] With `syncErrorCount > 3`: red error badge appears below the connection row
- [ ] While the query is loading: HeroUI Spinner is shown
- [ ] Sheet dismisses correctly on overlay tap or swipe-down

## Checklist

- [x] TypeScript compiles with zero errors
- [x] Lint passes (0 warnings, 0 errors)
- [x] Formatting passes
- [x] Tests pass (380/380)

Closes #143