### PR TITLE
feat(calendars): #146 SubCalendarPicker display component

### DIFF
--- a/convex/calendars/actions.ts
+++ b/convex/calendars/actions.ts
@@ -24,3 +24,10 @@ export const syncNow = action({
     await runSyncWithRetry(ctx, args.connectionId, calendarService.sync);
   },
 });
+
+export const listSubCalendars = action({
+  args: { connectionId: v.id("calendarConnections") },
+  handler: async (ctx, args) => {
+    return await calendarService.listSubCalendars(ctx, args.connectionId);
+  },
+});

--- a/src/components/calendars/SubCalendarPicker.stories.tsx
+++ b/src/components/calendars/SubCalendarPicker.stories.tsx
@@ -1,0 +1,117 @@
+import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
+import type { Meta, StoryObj } from "@storybook/react-native";
+import { View } from "react-native";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
+
+import { SubCalendarList, type SubCalendarListProps } from "./SubCalendarPicker";
+
+const mockSubCalendars = [
+  { id: "primary", label: "Work Calendar", primary: true },
+  { id: "holidays", label: "UK Holidays", primary: false, hint: "Public holidays" },
+  { id: "birthdays", label: "Contacts' Birthdays", primary: false },
+];
+
+const meta = {
+  title: "Calendars/SubCalendarList",
+  component: SubCalendarList,
+  decorators: [
+    (Story) => (
+      <GestureHandlerRootView style={{ flex: 1 }}>
+        <BottomSheetModalProvider>
+          <View style={{ flex: 1, padding: 16, backgroundColor: "#f9f9f9" }}>
+            <Story />
+          </View>
+        </BottomSheetModalProvider>
+      </GestureHandlerRootView>
+    ),
+  ],
+  tags: ["autodocs"],
+  args: {
+    subCalendars: mockSubCalendars,
+    provider: "google" as const,
+    connectionColor: "#6366f1",
+    onConfirm: () => {},
+    onBack: () => {},
+  } satisfies SubCalendarListProps,
+} satisfies Meta<typeof SubCalendarList>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Loading: Story = {
+  args: {
+    subCalendars: undefined,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    subCalendars: [],
+  },
+};
+
+export const GooglePrimaryPreselected: Story = {
+  args: {
+    provider: "google",
+    subCalendars: mockSubCalendars,
+  },
+};
+
+export const MicrosoftPrimaryPreselected: Story = {
+  args: {
+    provider: "microsoft",
+    subCalendars: [
+      { id: "primary", label: "Personal Calendar", primary: true },
+      { id: "ms_holidays", label: "UK Holidays", primary: false },
+    ],
+    connectionColor: "#0078d4",
+  },
+};
+
+export const NativeAllPreselected: Story = {
+  args: {
+    provider: "native",
+    subCalendars: [
+      { id: "cal_personal", label: "Personal", primary: false },
+      { id: "cal_work", label: "Work", primary: false },
+      { id: "cal_family", label: "Family", primary: false },
+    ],
+    connectionColor: "#f59e0b",
+  },
+};
+
+export const ICalAllPreselected: Story = {
+  args: {
+    provider: "ical",
+    subCalendars: [{ id: "default", label: "My iCal Feed", primary: false }],
+    connectionColor: "#22c55e",
+  },
+};
+
+export const WithHints: Story = {
+  args: {
+    subCalendars: [
+      { id: "primary", label: "Primary", primary: true, hint: "Main work calendar" },
+      { id: "team", label: "Team Events", primary: false, hint: "Shared with the whole team" },
+    ],
+  },
+};
+
+export const SingleCalendar: Story = {
+  args: {
+    subCalendars: [{ id: "primary", label: "Primary Calendar", primary: true }],
+  },
+};
+
+export const NoPrimaryFallsBackToAll: Story = {
+  args: {
+    provider: "google",
+    subCalendars: [
+      { id: "work", label: "Work", primary: false },
+      { id: "personal", label: "Personal", primary: false },
+    ],
+  },
+};

--- a/src/components/calendars/SubCalendarPicker.tsx
+++ b/src/components/calendars/SubCalendarPicker.tsx
@@ -135,13 +135,21 @@ export function SubCalendarPicker({
   const listSubCalendarsAction = useAction(api.calendars.actions.listSubCalendars);
 
   useEffect(() => {
+    let cancelled = false;
     setSubCalendars(undefined);
     setError(null);
     listSubCalendarsAction({ connectionId })
-      .then(setSubCalendars)
+      .then((result) => {
+        if (cancelled) return;
+        setSubCalendars(result);
+      })
       .catch((err: unknown) => {
+        if (cancelled) return;
         setError(err instanceof Error ? err.message : "Failed to load calendars");
       });
+    return () => {
+      cancelled = true;
+    };
   }, [connectionId, listSubCalendarsAction]);
 
   if (error !== null) {

--- a/src/components/calendars/SubCalendarPicker.tsx
+++ b/src/components/calendars/SubCalendarPicker.tsx
@@ -1,0 +1,169 @@
+import { api } from "@convex/_generated/api";
+import type { Id } from "@convex/_generated/dataModel";
+import type { SubCalendar } from "@shared/calendars";
+import { useAction } from "convex/react";
+import { Button, Separator, Spinner, Switch } from "heroui-native";
+import { Fragment, useEffect, useState } from "react";
+import { Text, View } from "react-native";
+
+type Provider = "google" | "microsoft" | "ical" | "native";
+
+export type SubCalendarListProps = {
+  subCalendars: SubCalendar[] | undefined;
+  provider: Provider;
+  connectionColor: string;
+  onConfirm: (selected: { externalId: string; label: string }[]) => void;
+  onBack: () => void;
+};
+
+function getInitialSelection(subCalendars: SubCalendar[], provider: Provider): Set<string> {
+  if (provider === "google" || provider === "microsoft") {
+    const primaryIds = subCalendars.filter((c) => c.primary).map((c) => c.id);
+    return new Set(primaryIds.length > 0 ? primaryIds : subCalendars.map((c) => c.id));
+  }
+  return new Set(subCalendars.map((c) => c.id));
+}
+
+export function SubCalendarList({
+  subCalendars,
+  provider,
+  connectionColor,
+  onConfirm,
+  onBack,
+}: SubCalendarListProps) {
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!subCalendars) return;
+    setSelected(getInitialSelection(subCalendars, provider));
+  }, [subCalendars, provider]);
+
+  const toggle = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const handleConfirm = () => {
+    if (!subCalendars) return;
+    onConfirm(
+      subCalendars
+        .filter((c) => selected.has(c.id))
+        .map((c) => ({ externalId: c.id, label: c.label })),
+    );
+  };
+
+  if (subCalendars === undefined) {
+    return (
+      <View className="flex-1 items-center justify-center py-8">
+        <Spinner />
+      </View>
+    );
+  }
+
+  return (
+    <View className="flex-1">
+      {subCalendars.length === 0 ? (
+        <View className="px-1 py-4">
+          <Text className="text-sm text-muted-foreground">
+            Your calendar is ready — tap Confirm to start syncing.
+          </Text>
+        </View>
+      ) : (
+        <View className="rounded-xl bg-default-100/40 px-3 py-2">
+          {subCalendars.map((cal, idx) => (
+            <Fragment key={cal.id}>
+              {idx > 0 && <Separator className="my-1" />}
+              <View className="flex-row items-center gap-3 py-3">
+                <View
+                  className="h-3 w-3 rounded-full"
+                  style={{ backgroundColor: connectionColor }}
+                />
+                <View className="flex-1">
+                  <Text className="text-sm text-foreground" numberOfLines={1}>
+                    {cal.label}
+                  </Text>
+                  {cal.hint != null ? (
+                    <Text className="text-xs text-muted-foreground" numberOfLines={1}>
+                      {cal.hint}
+                    </Text>
+                  ) : null}
+                </View>
+                <Switch
+                  isSelected={selected.has(cal.id)}
+                  onSelectedChange={() => toggle(cal.id)}
+                  accessibilityLabel={cal.label}
+                />
+              </View>
+            </Fragment>
+          ))}
+        </View>
+      )}
+
+      <View className="mt-6 flex-row items-center justify-between">
+        <Button variant="tertiary" size="sm" onPress={onBack}>
+          Back
+        </Button>
+        <Button size="sm" onPress={handleConfirm}>
+          Confirm
+        </Button>
+      </View>
+    </View>
+  );
+}
+
+type SubCalendarPickerProps = {
+  connectionId: Id<"calendarConnections">;
+  provider: Provider;
+  connectionColor: string;
+  onConfirm: (selected: { externalId: string; label: string }[]) => void;
+  onBack: () => void;
+};
+
+export function SubCalendarPicker({
+  connectionId,
+  provider,
+  connectionColor,
+  onConfirm,
+  onBack,
+}: SubCalendarPickerProps) {
+  const [subCalendars, setSubCalendars] = useState<SubCalendar[] | undefined>(undefined);
+  const [error, setError] = useState<string | null>(null);
+  const listSubCalendarsAction = useAction(api.calendars.actions.listSubCalendars);
+
+  useEffect(() => {
+    setSubCalendars(undefined);
+    setError(null);
+    listSubCalendarsAction({ connectionId })
+      .then(setSubCalendars)
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : "Failed to load calendars");
+      });
+  }, [connectionId, listSubCalendarsAction]);
+
+  if (error !== null) {
+    return (
+      <View className="px-1 py-4">
+        <Text className="text-sm text-danger">{error}</Text>
+        <View className="mt-3">
+          <Button variant="tertiary" size="sm" onPress={onBack}>
+            Back
+          </Button>
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <SubCalendarList
+      subCalendars={subCalendars}
+      provider={provider}
+      connectionColor={connectionColor}
+      onConfirm={onConfirm}
+      onBack={onBack}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `listSubCalendars` public Convex action to `convex/calendars/actions.ts`, wrapping the existing service method
- Creates `SubCalendarPicker` connected component (`src/components/calendars/SubCalendarPicker.tsx`) that fetches sub-calendars on mount, shows a `Spinner` while loading, and delegates to `SubCalendarList`
- Creates `SubCalendarList` presentational component (exported for Storybook) with local toggle state — Google/Microsoft default to `primary === true` only; native/iCal default to all
- Creates `SubCalendarPicker.stories.tsx` covering: Default, Loading, Empty, provider-specific preselection, hints, single calendar, no-primary fallback

## Test Plan

- TypeScript compiles with zero errors (`npx tsc --noEmit`)
- Lint passes (`npm run lint`)
- Formatting passes (`npm run fmt:check`)
- All 380 tests pass (`npm run test`)
- Storybook: check all story variants show correct visual states and default selections

## Checklist
- [x] TypeScript compiles with zero errors
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass

Closes #146