### PR TITLE
feat(calendars): #145 CalendarManagementSheet — Add Calendar section with provider buttons

### DIFF
--- a/src/components/calendars/CalendarManagementSheet.stories.tsx
+++ b/src/components/calendars/CalendarManagementSheet.stories.tsx
@@ -4,7 +4,11 @@ import type { Meta, StoryObj } from "@storybook/react-native";
 import { View } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 
-import { CalendarConnectionList, type ConnectionRow } from "./CalendarManagementSheet";
+import {
+  CalendarAddSection,
+  CalendarConnectionList,
+  type ConnectionRow,
+} from "./CalendarManagementSheet";
 
 const now = Date.now();
 
@@ -50,20 +54,22 @@ const errorConnection: ConnectionRow = {
   subCalendarCount: 0,
 };
 
-const meta = {
+const decorator = (Story: React.ComponentType) => (
+  <GestureHandlerRootView style={{ flex: 1 }}>
+    <BottomSheetModalProvider>
+      <View style={{ flex: 1, padding: 16, backgroundColor: "#f9f9f9" }}>
+        <Story />
+      </View>
+    </BottomSheetModalProvider>
+  </GestureHandlerRootView>
+);
+
+// ── CalendarConnectionList stories ──────────────────────────────────────────
+
+const connectionListMeta = {
   title: "Calendars/CalendarConnectionList",
   component: CalendarConnectionList,
-  decorators: [
-    (Story) => (
-      <GestureHandlerRootView style={{ flex: 1 }}>
-        <BottomSheetModalProvider>
-          <View style={{ flex: 1, padding: 16, backgroundColor: "#f9f9f9" }}>
-            <Story />
-          </View>
-        </BottomSheetModalProvider>
-      </GestureHandlerRootView>
-    ),
-  ],
+  decorators: [decorator],
   tags: ["autodocs"],
   args: {
     connections: mockConnections,
@@ -73,37 +79,37 @@ const meta = {
   },
 } satisfies Meta<typeof CalendarConnectionList>;
 
-export default meta;
+export default connectionListMeta;
 
-type Story = StoryObj<typeof meta>;
+type ConnectionListStory = StoryObj<typeof connectionListMeta>;
 
-export const Default: Story = {};
+export const Default: ConnectionListStory = {};
 
-export const Loading: Story = {
+export const Loading: ConnectionListStory = {
   args: {
     connections: undefined,
   },
 };
 
-export const Empty: Story = {
+export const Empty: ConnectionListStory = {
   args: {
     connections: [],
   },
 };
 
-export const WithError: Story = {
+export const WithError: ConnectionListStory = {
   args: {
     connections: [errorConnection, ...mockConnections],
   },
 };
 
-export const SingleConnection: Story = {
+export const SingleConnection: ConnectionListStory = {
   args: {
     connections: [mockConnections[0]!],
   },
 };
 
-export const NeverSynced: Story = {
+export const NeverSynced: ConnectionListStory = {
   args: {
     connections: [
       {
@@ -119,23 +125,38 @@ export const NeverSynced: Story = {
   },
 };
 
-export const Syncing: Story = {
+export const Syncing: ConnectionListStory = {
   args: {
     connections: mockConnections,
     syncingIds: new Set(["conn_ical_1"]),
   },
 };
 
-export const SyncingNative: Story = {
+export const SyncingNative: ConnectionListStory = {
   args: {
     connections: mockConnections,
     syncingIds: new Set(["conn_native_1"]),
   },
 };
 
-export const SyncingMultiple: Story = {
+export const SyncingMultiple: ConnectionListStory = {
   args: {
     connections: mockConnections,
     syncingIds: new Set(["conn_google_1", "conn_native_1"]),
   },
+};
+
+// ── CalendarAddSection stories ───────────────────────────────────────────────
+
+export const AddSectionDefault: StoryObj<typeof CalendarAddSection> = {
+  name: "AddSection/Default",
+  render: () => (
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <BottomSheetModalProvider>
+        <View style={{ flex: 1, padding: 16, backgroundColor: "#f9f9f9" }}>
+          <CalendarAddSection onSelectProvider={() => {}} />
+        </View>
+      </BottomSheetModalProvider>
+    </GestureHandlerRootView>
+  ),
 };

--- a/src/components/calendars/CalendarManagementSheet.tsx
+++ b/src/components/calendars/CalendarManagementSheet.tsx
@@ -9,6 +9,11 @@ import { Text, View } from "react-native";
 
 import { fetchNativeEvents } from "@/lib/calendars/fetchNativeEvents";
 
+import { GoogleCalendarConnectFlow } from "./GoogleCalendarConnectFlow";
+import { ICalConnectFlow } from "./ICalConnectFlow";
+import { MicrosoftCalendarConnectFlow } from "./MicrosoftCalendarConnectFlow";
+import { NativeCalendarConnectFlow } from "./NativeCalendarConnectFlow";
+
 export type ConnectionRow = {
   _id: Id<"calendarConnections">;
   provider: string;
@@ -20,6 +25,8 @@ export type ConnectionRow = {
   subCalendarCount: number;
   nativeCalendarIds?: string[];
 };
+
+export type ActiveStep = "google" | "microsoft" | "ical" | "native";
 
 type Props = {
   isOpen: boolean;
@@ -135,6 +142,66 @@ export function CalendarConnectionList({
   );
 }
 
+type CalendarAddSectionProps = {
+  onSelectProvider: (step: ActiveStep) => void;
+};
+
+// Exported for Storybook — renders provider buttons without Convex
+export function CalendarAddSection({ onSelectProvider }: CalendarAddSectionProps) {
+  return (
+    <View className="mt-6 gap-3">
+      <Text className="px-1 text-sm font-semibold text-foreground">Add Calendar</Text>
+      <View className="gap-2">
+        <Button
+          variant="secondary"
+          onPress={() => onSelectProvider("google")}
+          accessibilityLabel="Connect Google Calendar"
+          className="w-full"
+        >
+          Google Calendar
+        </Button>
+        <Button
+          variant="secondary"
+          onPress={() => onSelectProvider("microsoft")}
+          accessibilityLabel="Connect Microsoft Calendar"
+          className="w-full"
+        >
+          Microsoft Calendar
+        </Button>
+        <Button
+          variant="secondary"
+          onPress={() => onSelectProvider("ical")}
+          accessibilityLabel="Connect iCal or Webcal calendar"
+          className="w-full"
+        >
+          iCal / Webcal
+        </Button>
+        <Button
+          variant="secondary"
+          onPress={() => onSelectProvider("native")}
+          accessibilityLabel="Connect device calendar"
+          className="w-full"
+        >
+          Device Calendar
+        </Button>
+      </View>
+    </View>
+  );
+}
+
+function renderConnectFlow(step: ActiveStep, onBack: () => void) {
+  switch (step) {
+    case "google":
+      return <GoogleCalendarConnectFlow onBack={onBack} />;
+    case "microsoft":
+      return <MicrosoftCalendarConnectFlow onBack={onBack} />;
+    case "ical":
+      return <ICalConnectFlow onBack={onBack} />;
+    case "native":
+      return <NativeCalendarConnectFlow onBack={onBack} />;
+  }
+}
+
 export function CalendarManagementSheet({ isOpen, onClose }: Props) {
   const connections = useQuery(api.calendars.queries.getConnections);
   const [pendingDisconnect, setPendingDisconnect] = useState<Id<"calendarConnections"> | null>(
@@ -143,10 +210,13 @@ export function CalendarManagementSheet({ isOpen, onClose }: Props) {
   const [isDisconnecting, setIsDisconnecting] = useState(false);
   const [disconnectError, setDisconnectError] = useState<string | null>(null);
   const [syncingIds, setSyncingIds] = useState<Set<string>>(new Set());
+  const [activeStep, setActiveStep] = useState<ActiveStep | null>(null);
 
   const disconnectAction = useAction(api.calendars.actions.disconnect);
   const syncNowAction = useAction(api.calendars.actions.syncNow);
   const uploadNativeEventsAction = useAction(api.calendars.uploadNativeEvents);
+
+  const handleBack = () => setActiveStep(null);
 
   const handleSync = async (connection: ConnectionRow) => {
     setSyncingIds((prev) => new Set([...prev, connection._id]));
@@ -192,25 +262,46 @@ export function CalendarManagementSheet({ isOpen, onClose }: Props) {
     setDisconnectError(null);
   };
 
+  const handleSheetOpenChange = (open: boolean) => {
+    if (!open) {
+      if (activeStep !== null) {
+        // During a connect flow, closing gesture navigates back rather than dismissing the sheet
+        setActiveStep(null);
+      } else {
+        onClose();
+      }
+    }
+  };
+
   return (
     <>
-      <BottomSheet isOpen={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <BottomSheet isOpen={isOpen} onOpenChange={handleSheetOpenChange}>
         <BottomSheet.Portal disableFullWindowOverlay>
           <BottomSheet.Overlay />
-          <BottomSheet.Content snapPoints={["55%", "85%"]}>
+          <BottomSheet.Content
+            snapPoints={["55%", "85%"]}
+            enablePanDownToClose={activeStep === null}
+          >
             <BottomSheetScrollView contentContainerStyle={{ paddingBottom: 16 }}>
-              <View className="mb-4 gap-1.5 px-1">
-                <BottomSheet.Title>Connected Calendars</BottomSheet.Title>
-              </View>
-              <CalendarConnectionList
-                connections={connections}
-                syncingIds={syncingIds}
-                onSync={handleSync}
-                onDisconnect={(id) => {
-                  setDisconnectError(null);
-                  setPendingDisconnect(id);
-                }}
-              />
+              {activeStep !== null ? (
+                renderConnectFlow(activeStep, handleBack)
+              ) : (
+                <>
+                  <View className="mb-4 gap-1.5 px-1">
+                    <BottomSheet.Title>Connected Calendars</BottomSheet.Title>
+                  </View>
+                  <CalendarConnectionList
+                    connections={connections}
+                    syncingIds={syncingIds}
+                    onSync={handleSync}
+                    onDisconnect={(id) => {
+                      setDisconnectError(null);
+                      setPendingDisconnect(id);
+                    }}
+                  />
+                  <CalendarAddSection onSelectProvider={setActiveStep} />
+                </>
+              )}
             </BottomSheetScrollView>
           </BottomSheet.Content>
         </BottomSheet.Portal>

--- a/src/components/calendars/GoogleCalendarConnectFlow.stories.tsx
+++ b/src/components/calendars/GoogleCalendarConnectFlow.stories.tsx
@@ -1,0 +1,32 @@
+import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
+import type { Meta, StoryObj } from "@storybook/react-native";
+import { View } from "react-native";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
+
+import { GoogleCalendarConnectFlow } from "./GoogleCalendarConnectFlow";
+
+const meta = {
+  title: "Calendars/GoogleCalendarConnectFlow",
+  component: GoogleCalendarConnectFlow,
+  decorators: [
+    (Story) => (
+      <GestureHandlerRootView style={{ flex: 1 }}>
+        <BottomSheetModalProvider>
+          <View style={{ flex: 1, padding: 16, backgroundColor: "#f9f9f9" }}>
+            <Story />
+          </View>
+        </BottomSheetModalProvider>
+      </GestureHandlerRootView>
+    ),
+  ],
+  tags: ["autodocs"],
+  args: {
+    onBack: () => {},
+  },
+} satisfies Meta<typeof GoogleCalendarConnectFlow>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/components/calendars/GoogleCalendarConnectFlow.tsx
+++ b/src/components/calendars/GoogleCalendarConnectFlow.tsx
@@ -1,0 +1,31 @@
+import { Button } from "heroui-native";
+import { Text, View } from "react-native";
+
+type Props = {
+  onBack: () => void;
+};
+
+export function GoogleCalendarConnectFlow({ onBack }: Props) {
+  return (
+    <View className="flex-1 gap-6 py-4">
+      <View className="flex-row items-center gap-2 px-1">
+        <Button
+          variant="tertiary"
+          size="sm"
+          onPress={onBack}
+          accessibilityLabel="Back to calendars"
+        >
+          ← Back
+        </Button>
+        <Text className="text-base font-semibold text-foreground">Google Calendar</Text>
+      </View>
+
+      <View className="items-center gap-3 py-8">
+        <View className="h-16 w-16 items-center justify-center rounded-full bg-default-100">
+          <Text className="text-2xl font-bold text-foreground">G</Text>
+        </View>
+        <Text className="text-sm text-muted-foreground">Connect your Google Calendar account</Text>
+      </View>
+    </View>
+  );
+}

--- a/src/components/calendars/ICalConnectFlow.stories.tsx
+++ b/src/components/calendars/ICalConnectFlow.stories.tsx
@@ -1,0 +1,32 @@
+import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
+import type { Meta, StoryObj } from "@storybook/react-native";
+import { View } from "react-native";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
+
+import { ICalConnectFlow } from "./ICalConnectFlow";
+
+const meta = {
+  title: "Calendars/ICalConnectFlow",
+  component: ICalConnectFlow,
+  decorators: [
+    (Story) => (
+      <GestureHandlerRootView style={{ flex: 1 }}>
+        <BottomSheetModalProvider>
+          <View style={{ flex: 1, padding: 16, backgroundColor: "#f9f9f9" }}>
+            <Story />
+          </View>
+        </BottomSheetModalProvider>
+      </GestureHandlerRootView>
+    ),
+  ],
+  tags: ["autodocs"],
+  args: {
+    onBack: () => {},
+  },
+} satisfies Meta<typeof ICalConnectFlow>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/components/calendars/ICalConnectFlow.tsx
+++ b/src/components/calendars/ICalConnectFlow.tsx
@@ -1,0 +1,33 @@
+import { Button } from "heroui-native";
+import { Text, View } from "react-native";
+
+type Props = {
+  onBack: () => void;
+};
+
+export function ICalConnectFlow({ onBack }: Props) {
+  return (
+    <View className="flex-1 gap-6 py-4">
+      <View className="flex-row items-center gap-2 px-1">
+        <Button
+          variant="tertiary"
+          size="sm"
+          onPress={onBack}
+          accessibilityLabel="Back to calendars"
+        >
+          ← Back
+        </Button>
+        <Text className="text-base font-semibold text-foreground">iCal / Webcal</Text>
+      </View>
+
+      <View className="items-center gap-3 py-8">
+        <View className="h-16 w-16 items-center justify-center rounded-full bg-default-100">
+          <Text className="text-2xl">📅</Text>
+        </View>
+        <Text className="text-sm text-muted-foreground">
+          Subscribe to a calendar via iCal or Webcal feed URL
+        </Text>
+      </View>
+    </View>
+  );
+}

--- a/src/components/calendars/MicrosoftCalendarConnectFlow.stories.tsx
+++ b/src/components/calendars/MicrosoftCalendarConnectFlow.stories.tsx
@@ -1,0 +1,32 @@
+import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
+import type { Meta, StoryObj } from "@storybook/react-native";
+import { View } from "react-native";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
+
+import { MicrosoftCalendarConnectFlow } from "./MicrosoftCalendarConnectFlow";
+
+const meta = {
+  title: "Calendars/MicrosoftCalendarConnectFlow",
+  component: MicrosoftCalendarConnectFlow,
+  decorators: [
+    (Story) => (
+      <GestureHandlerRootView style={{ flex: 1 }}>
+        <BottomSheetModalProvider>
+          <View style={{ flex: 1, padding: 16, backgroundColor: "#f9f9f9" }}>
+            <Story />
+          </View>
+        </BottomSheetModalProvider>
+      </GestureHandlerRootView>
+    ),
+  ],
+  tags: ["autodocs"],
+  args: {
+    onBack: () => {},
+  },
+} satisfies Meta<typeof MicrosoftCalendarConnectFlow>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/components/calendars/MicrosoftCalendarConnectFlow.tsx
+++ b/src/components/calendars/MicrosoftCalendarConnectFlow.tsx
@@ -1,0 +1,33 @@
+import { Button } from "heroui-native";
+import { Text, View } from "react-native";
+
+type Props = {
+  onBack: () => void;
+};
+
+export function MicrosoftCalendarConnectFlow({ onBack }: Props) {
+  return (
+    <View className="flex-1 gap-6 py-4">
+      <View className="flex-row items-center gap-2 px-1">
+        <Button
+          variant="tertiary"
+          size="sm"
+          onPress={onBack}
+          accessibilityLabel="Back to calendars"
+        >
+          ← Back
+        </Button>
+        <Text className="text-base font-semibold text-foreground">Microsoft Calendar</Text>
+      </View>
+
+      <View className="items-center gap-3 py-8">
+        <View className="h-16 w-16 items-center justify-center rounded-full bg-default-100">
+          <Text className="text-2xl font-bold text-foreground">M</Text>
+        </View>
+        <Text className="text-sm text-muted-foreground">
+          Connect your Microsoft Outlook or Office 365 calendar
+        </Text>
+      </View>
+    </View>
+  );
+}

--- a/src/components/calendars/NativeCalendarConnectFlow.stories.tsx
+++ b/src/components/calendars/NativeCalendarConnectFlow.stories.tsx
@@ -1,0 +1,32 @@
+import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
+import type { Meta, StoryObj } from "@storybook/react-native";
+import { View } from "react-native";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
+
+import { NativeCalendarConnectFlow } from "./NativeCalendarConnectFlow";
+
+const meta = {
+  title: "Calendars/NativeCalendarConnectFlow",
+  component: NativeCalendarConnectFlow,
+  decorators: [
+    (Story) => (
+      <GestureHandlerRootView style={{ flex: 1 }}>
+        <BottomSheetModalProvider>
+          <View style={{ flex: 1, padding: 16, backgroundColor: "#f9f9f9" }}>
+            <Story />
+          </View>
+        </BottomSheetModalProvider>
+      </GestureHandlerRootView>
+    ),
+  ],
+  tags: ["autodocs"],
+  args: {
+    onBack: () => {},
+  },
+} satisfies Meta<typeof NativeCalendarConnectFlow>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/components/calendars/NativeCalendarConnectFlow.tsx
+++ b/src/components/calendars/NativeCalendarConnectFlow.tsx
@@ -1,0 +1,31 @@
+import { Button } from "heroui-native";
+import { Text, View } from "react-native";
+
+type Props = {
+  onBack: () => void;
+};
+
+export function NativeCalendarConnectFlow({ onBack }: Props) {
+  return (
+    <View className="flex-1 gap-6 py-4">
+      <View className="flex-row items-center gap-2 px-1">
+        <Button
+          variant="tertiary"
+          size="sm"
+          onPress={onBack}
+          accessibilityLabel="Back to calendars"
+        >
+          ← Back
+        </Button>
+        <Text className="text-base font-semibold text-foreground">Device Calendar</Text>
+      </View>
+
+      <View className="items-center gap-3 py-8">
+        <View className="h-16 w-16 items-center justify-center rounded-full bg-default-100">
+          <Text className="text-2xl">📱</Text>
+        </View>
+        <Text className="text-sm text-muted-foreground">Sync calendars stored on this device</Text>
+      </View>
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds an **Add Calendar** section below the connected calendars list with four `secondary` HeroUI Native `Button` components (Google Calendar, Microsoft Calendar, iCal / Webcal, Device Calendar)
- Introduces `activeStep` local state (`null | "google" | "microsoft" | "ical" | "native"`) in `CalendarManagementSheet` to track which connect flow is open
- Tapping a provider button renders the corresponding connect flow component in place of the main sheet content; a back button (or swipe down) returns to the main view
- Sets `enablePanDownToClose={activeStep === null}` so the sheet cannot be accidentally dismissed during a connect flow
- Creates stub connect flow components for each provider (`GoogleCalendarConnectFlow`, `MicrosoftCalendarConnectFlow`, `ICalConnectFlow`, `NativeCalendarConnectFlow`) to be fleshed out by #146–#149
- Exports `CalendarAddSection` for Storybook; adds stories for all four stubs

## Test Plan

- [ ] Open the CalendarManagementSheet — four provider buttons render below the connected calendars list
- [ ] Tap **Google Calendar** → Google connect flow renders with a back button; sheet title changes
- [ ] Tap **← Back** → returns to the main connected calendars view
- [ ] Repeat for Microsoft Calendar, iCal / Webcal, and Device Calendar
- [ ] Verify the sheet cannot be swiped down to close while a connect flow is active
- [ ] Verify the sheet can be swiped down to close from the main view

## Checklist

- [x] TypeScript compiles with zero errors
- [x] Lint passes (oxlint)
- [x] Formatting passes (oxfmt)
- [x] Tests pass (380/380)

Closes #145