### PR TITLE
feat(calendars): #147 useSubCalendarConfirm — wire SubCalendarPicker confirmation

### DIFF
--- a/convex/calendars/actions.ts
+++ b/convex/calendars/actions.ts
@@ -5,6 +5,7 @@ import { v } from "convex/values";
 import { action } from "../_generated/server";
 import { requireOwnedConnection } from "./auth/requireOwnedConnection";
 import { calendarService } from "./service/registry";
+import { syncAfterConnect } from "./syncAfterConnect";
 import { runSyncWithRetry } from "./syncWithRetry";
 
 export const disconnect = action({
@@ -29,5 +30,21 @@ export const listSubCalendars = action({
   args: { connectionId: v.id("calendarConnections") },
   handler: async (ctx, args) => {
     return await calendarService.listSubCalendars(ctx, args.connectionId);
+  },
+});
+
+export const setEnabledSubCalendars = action({
+  args: {
+    connectionId: v.id("calendarConnections"),
+    selections: v.array(
+      v.object({
+        externalId: v.string(),
+        label: v.string(),
+      }),
+    ),
+  },
+  handler: async (ctx, args) => {
+    await calendarService.setEnabledSubCalendars(ctx, args.connectionId, args.selections);
+    await syncAfterConnect(ctx, args.connectionId);
   },
 });

--- a/convex/calendars/actions.ts
+++ b/convex/calendars/actions.ts
@@ -44,7 +44,13 @@ export const setEnabledSubCalendars = action({
     ),
   },
   handler: async (ctx, args) => {
+    const { connection } = await requireOwnedConnection(ctx, args.connectionId);
     await calendarService.setEnabledSubCalendars(ctx, args.connectionId, args.selections);
-    await syncAfterConnect(ctx, args.connectionId);
+    // Native connections sync from the device, not the server — scheduling
+    // a server-side sync would just hit sync.ts's native guard and burn
+    // through the retry budget.
+    if (connection.provider !== "native") {
+      await syncAfterConnect(ctx, args.connectionId);
+    }
   },
 });

--- a/src/hooks/useSubCalendarConfirm.ts
+++ b/src/hooks/useSubCalendarConfirm.ts
@@ -1,0 +1,32 @@
+import { api } from "@convex/_generated/api";
+import type { Id } from "@convex/_generated/dataModel";
+import { useAction } from "convex/react";
+import { useCallback, useState } from "react";
+
+type SubCalendarSelection = { externalId: string; label: string };
+
+export function useSubCalendarConfirm(connectionId: Id<"calendarConnections">) {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const setEnabledSubCalendars = useAction(api.calendars.actions.setEnabledSubCalendars);
+
+  const confirmSelection = useCallback(
+    async (selected: SubCalendarSelection[]) => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        await setEnabledSubCalendars({ connectionId, selections: selected });
+      } catch (e) {
+        const err = e instanceof Error ? e : new Error(String(e));
+        setError(err);
+        throw err;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [connectionId, setEnabledSubCalendars],
+  );
+
+  return { confirmSelection, isLoading, error };
+}

--- a/src/hooks/useSubCalendarConfirm.ts
+++ b/src/hooks/useSubCalendarConfirm.ts
@@ -1,18 +1,20 @@
 import { api } from "@convex/_generated/api";
 import type { Id } from "@convex/_generated/dataModel";
 import { useAction } from "convex/react";
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 
 type SubCalendarSelection = { externalId: string; label: string };
 
 export function useSubCalendarConfirm(connectionId: Id<"calendarConnections">) {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
+  const inFlight = useRef(0);
 
   const setEnabledSubCalendars = useAction(api.calendars.actions.setEnabledSubCalendars);
 
   const confirmSelection = useCallback(
     async (selected: SubCalendarSelection[]) => {
+      inFlight.current += 1;
       setIsLoading(true);
       setError(null);
       try {
@@ -22,7 +24,8 @@ export function useSubCalendarConfirm(connectionId: Id<"calendarConnections">) {
         setError(err);
         throw err;
       } finally {
-        setIsLoading(false);
+        inFlight.current -= 1;
+        if (inFlight.current === 0) setIsLoading(false);
       }
     },
     [connectionId, setEnabledSubCalendars],


### PR DESCRIPTION
## Summary

- Add `setEnabledSubCalendars` public Convex action in `convex/calendars/actions.ts` — persists sub-calendar selections via the service layer then schedules an immediate post-connect sync via `syncAfterConnect`
- Add `useSubCalendarConfirm(connectionId)` hook at `src/hooks/useSubCalendarConfirm.ts` — returns `{ confirmSelection, isLoading, error }` for use across all four connect-flow components

The sequencing guarantee (save → sync) is enforced server-side within the single action so there is no race condition possible from two separate client calls.

## Test Plan

- TypeScript compiles with zero errors
- Lint passes
- Formatting passes
- All 380 tests pass

## Checklist
- [x] TypeScript compiles with zero errors
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass

Closes #147