### PR TITLE
feat(calendars): #152 diary marked dates — colour-coded dots per connection

### DIFF
--- a/src/app/(home)/diary.tsx
+++ b/src/app/(home)/diary.tsx
@@ -1,4 +1,6 @@
-import { format, startOfMonth } from "date-fns";
+import { api } from "@convex/_generated/api";
+import { useQuery } from "convex/react";
+import { format, endOfMonth, startOfMonth } from "date-fns";
 import { useThemeColor } from "heroui-native";
 import { useState } from "react";
 import { Pressable, Text, View } from "react-native";
@@ -13,9 +15,7 @@ export default function Diary() {
   const today = new Date();
   const todayIso = format(today, "yyyy-MM-dd");
   const [selectedDate, setSelectedDate] = useState<string>(todayIso);
-  const [_visibleMonth, setVisibleMonth] = useState<string>(() => {
-    return format(startOfMonth(new Date()), "yyyy-MM-dd");
-  });
+  const [visibleMonth, setVisibleMonth] = useState<Date>(() => startOfMonth(new Date()));
   const [isManagementSheetOpen, setIsManagementSheetOpen] = useState(false);
   const insets = useSafeAreaInsets();
 
@@ -25,6 +25,47 @@ export default function Diary() {
     "foreground",
     "muted",
   ]);
+
+  const connections = useQuery(api.calendars.queries.getConnections, {});
+
+  const startMs = visibleMonth.getTime();
+  const endMs = endOfMonth(visibleMonth).getTime() + 1;
+
+  const events = useQuery(api.calendars.queries.getEventsForDateRange, { startMs, endMs });
+
+  const eventDots: Record<string, { dots: { key: string; color: string }[] }> = {};
+  if (events) {
+    for (const event of events) {
+      const dateKey = format(new Date(event.startsAt), "yyyy-MM-dd");
+      if (!eventDots[dateKey]) {
+        eventDots[dateKey] = { dots: [] };
+      }
+      const existing = eventDots[dateKey]!;
+      const connectionId = event.connectionId as string;
+      if (!existing.dots.some((d) => d.key === connectionId)) {
+        existing.dots.push({ key: connectionId, color: event.color });
+      }
+    }
+  }
+
+  const selectedMarking = {
+    selected: true,
+    selectedColor: accent,
+  };
+
+  const mergedMarkedDates: Record<string, object> = {};
+  for (const [date, dotData] of Object.entries(eventDots)) {
+    if (date === selectedDate) {
+      mergedMarkedDates[date] = { ...dotData, ...selectedMarking };
+    } else {
+      mergedMarkedDates[date] = dotData;
+    }
+  }
+  if (!mergedMarkedDates[selectedDate]) {
+    mergedMarkedDates[selectedDate] = selectedMarking;
+  }
+
+  const hasNoConnections = connections !== undefined && connections.length === 0;
 
   return (
     <>
@@ -46,7 +87,9 @@ export default function Diary() {
           <Calendar
             current={todayIso}
             onDayPress={(day: DateData) => setSelectedDate(day.dateString)}
-            onMonthChange={(m: DateData) => setVisibleMonth(m.dateString)}
+            onMonthChange={(m: DateData) => setVisibleMonth(startOfMonth(new Date(m.dateString)))}
+            markedDates={mergedMarkedDates}
+            markingType="multi-dot"
             theme={{
               backgroundColor: "transparent",
               calendarBackground: "transparent",
@@ -65,6 +108,19 @@ export default function Diary() {
             }}
             style={{ marginHorizontal: 8 }}
           />
+
+          {hasNoConnections && (
+            <Pressable
+              onPress={() => setIsManagementSheetOpen(true)}
+              accessibilityRole="button"
+              accessibilityLabel="Connect a calendar to see your events"
+              className="mx-4 mt-2 items-center rounded-lg border border-foreground/20 py-3"
+            >
+              <Text className="text-sm text-foreground/60">
+                Connect a calendar to see your events
+              </Text>
+            </Pressable>
+          )}
 
           <View className="mt-4 px-4">
             <Text className="text-sm text-foreground/60">{format(selectedDate, "EEEE")}</Text>

--- a/src/app/(home)/diary.tsx
+++ b/src/app/(home)/diary.tsx
@@ -1,6 +1,6 @@
 import { api } from "@convex/_generated/api";
 import { useQuery } from "convex/react";
-import { format, endOfMonth, startOfMonth } from "date-fns";
+import { format, endOfMonth } from "date-fns";
 import { useThemeColor } from "heroui-native";
 import { useState } from "react";
 import { Pressable, Text, View } from "react-native";
@@ -15,7 +15,10 @@ export default function Diary() {
   const today = new Date();
   const todayIso = format(today, "yyyy-MM-dd");
   const [selectedDate, setSelectedDate] = useState<string>(todayIso);
-  const [visibleMonth, setVisibleMonth] = useState<Date>(() => startOfMonth(new Date()));
+  const [visibleMonth, setVisibleMonth] = useState<Date>(() => {
+    const now = new Date();
+    return new Date(now.getFullYear(), now.getMonth(), 1);
+  });
   const [isManagementSheetOpen, setIsManagementSheetOpen] = useState(false);
   const insets = useSafeAreaInsets();
 
@@ -87,7 +90,7 @@ export default function Diary() {
           <Calendar
             current={todayIso}
             onDayPress={(day: DateData) => setSelectedDate(day.dateString)}
-            onMonthChange={(m: DateData) => setVisibleMonth(startOfMonth(new Date(m.dateString)))}
+            onMonthChange={(m: DateData) => setVisibleMonth(new Date(m.year, m.month - 1, 1))}
             markedDates={mergedMarkedDates}
             markingType="multi-dot"
             theme={{


### PR DESCRIPTION
## Summary

- Queries `getEventsForDateRange` reactively for the visible calendar month, updating when the user navigates months via `onMonthChange`
- Transforms events into `react-native-calendars` multi-dot format: one dot per connection per day (deduplicated by `connectionId`)
- Merges event dots with the existing selected-date highlight so both states coexist correctly
- Shows a tappable "Connect a calendar to see your events" prompt below the calendar when `getConnections` returns an empty array, opening `CalendarManagementSheet` on press

## Test Plan

- [ ] Navigate to the Diary tab — calendar shows colour-coded dots on days with events
- [ ] Each connection contributes at most one dot per day (multiple events from same connection = one dot)
- [ ] Selecting a different date preserves that date's dot markers alongside the selection highlight
- [ ] Navigate to next/previous month — dots update to reflect that month's events
- [ ] Disconnect all calendars — "Connect a calendar to see your events" prompt appears below the calendar
- [ ] Tap the prompt — `CalendarManagementSheet` opens

## Checklist

- [x] TypeScript compiles with zero errors
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass (385/385)

Closes #152