### PR TITLE
feat(calendars): #153 diary day event list — scrollable event list for selected date

### DIFF
--- a/convex/calendars/actions.ts
+++ b/convex/calendars/actions.ts
@@ -111,23 +111,22 @@ export const listSubCalendars = action({
   },
 });
 
-<<<<<<< feat/150-feat-calendars---ical-connect-flow-ui
+export const syncNativeOnOpen = action({
+  args: {},
+  handler: async (
+    ctx,
+  ): Promise<{ connectionId: Id<"calendarConnections">; nativeCalendarIds: string[] }[]> => {
+    return await calendarService.syncNativeOnOpen(ctx);
+  },
+});
+
 export const setEnabledSubCalendars = action({
   args: {
     connectionId: v.id("calendarConnections"),
-    selections: v.array(
-      v.object({
-        externalId: v.string(),
-        label: v.string(),
-      }),
-    ),
+    selections: v.array(v.object({ externalId: v.string(), label: v.string() })),
   },
-  handler: async (ctx, args): Promise<void> => {
-    await requireOwnedConnection(ctx, args.connectionId);
-    await ctx.runMutation(internal.calendars.db.setEnabledSubCalendars.setEnabledSubCalendars, {
-      connectionId: args.connectionId,
-      selections: args.selections,
-    });
+  handler: async (ctx, args) => {
+    await calendarService.setEnabledSubCalendars(ctx, args.connectionId, args.selections);
   },
 });
 
@@ -154,23 +153,5 @@ export const connectIcal = action({
       label: args.label,
     });
     return { connectionId };
-=======
-export const syncNativeOnOpen = action({
-  args: {},
-  handler: async (
-    ctx,
-  ): Promise<{ connectionId: Id<"calendarConnections">; nativeCalendarIds: string[] }[]> => {
-    return await calendarService.syncNativeOnOpen(ctx);
-  },
-});
-
-export const setEnabledSubCalendars = action({
-  args: {
-    connectionId: v.id("calendarConnections"),
-    selections: v.array(v.object({ externalId: v.string(), label: v.string() })),
-  },
-  handler: async (ctx, args) => {
-    await calendarService.setEnabledSubCalendars(ctx, args.connectionId, args.selections);
->>>>>>> main
   },
 });

--- a/src/app/(home)/diary.tsx
+++ b/src/app/(home)/diary.tsx
@@ -9,6 +9,7 @@ import { ScrollView } from "react-native-gesture-handler";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { CalendarManagementSheet } from "@/components/calendars/CalendarManagementSheet";
+import { DiaryEventList } from "@/components/calendars/DiaryEventList";
 import { GearIcon } from "@/components/ui/icons/GearIcon";
 
 export default function Diary() {
@@ -125,9 +126,8 @@ export default function Diary() {
             </Pressable>
           )}
 
-          <View className="mt-4 px-4">
-            <Text className="text-sm text-foreground/60">{format(selectedDate, "EEEE")}</Text>
-            <Text className="text-sm text-foreground/60">{format(selectedDate, "d MMMM")}</Text>
+          <View className="mt-4">
+            <DiaryEventList selectedDate={selectedDate} />
           </View>
         </View>
       </ScrollView>

--- a/src/components/calendars/DiaryEventList.stories.tsx
+++ b/src/components/calendars/DiaryEventList.stories.tsx
@@ -1,0 +1,114 @@
+import type { Meta, StoryObj } from "@storybook/react-native";
+import { View } from "react-native";
+
+import { DiaryEventListContent, type DiaryEvent } from "./DiaryEventList";
+
+const now = Date.now();
+const todayNoon = new Date();
+todayNoon.setHours(12, 0, 0, 0);
+const todayNoonMs = todayNoon.getTime();
+
+const allDayEvent: DiaryEvent = {
+  _id: "evt_allday_1",
+  title: "Company Away Day",
+  startsAt: todayNoonMs,
+  endsAt: todayNoonMs + 86_400_000,
+  isAllDay: true,
+  color: "#6366f1",
+};
+
+const morningEvent: DiaryEvent = {
+  _id: "evt_timed_1",
+  title: "Crew Call — Set Dressing",
+  startsAt: todayNoonMs - 3 * 3600_000, // 9:00 AM
+  endsAt: todayNoonMs - 3 * 3600_000 + 90 * 60_000, // 10:30 AM
+  isAllDay: false,
+  color: "#22c55e",
+};
+
+const afternoonEvent: DiaryEvent = {
+  _id: "evt_timed_2",
+  title: "Director's Prep Meeting",
+  startsAt: todayNoonMs + 2 * 3600_000, // 2:00 PM
+  endsAt: todayNoonMs + 3 * 3600_000, // 3:00 PM
+  isAllDay: false,
+  color: "#f59e0b",
+};
+
+const eveningEvent: DiaryEvent = {
+  _id: "evt_timed_3",
+  title: "Wrap Party",
+  startsAt: todayNoonMs + 6 * 3600_000, // 6:00 PM
+  endsAt: todayNoonMs + 9 * 3600_000, // 9:00 PM
+  isAllDay: false,
+  color: "#ef4444",
+};
+
+const decorator = (Story: React.ComponentType) => (
+  <View style={{ flex: 1, padding: 16, backgroundColor: "#ffffff" }}>
+    <Story />
+  </View>
+);
+
+const meta = {
+  title: "Calendars/DiaryEventList",
+  component: DiaryEventListContent,
+  decorators: [decorator],
+  tags: ["autodocs"],
+} satisfies Meta<typeof DiaryEventListContent>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Loading: Story = {
+  args: {
+    events: undefined,
+  },
+};
+
+export const NoEvents: Story = {
+  args: {
+    events: [],
+  },
+};
+
+export const AllDayOnly: Story = {
+  args: {
+    events: [allDayEvent],
+  },
+};
+
+export const TimedOnly: Story = {
+  args: {
+    events: [morningEvent, afternoonEvent],
+  },
+};
+
+export const Mixed: Story = {
+  args: {
+    events: [allDayEvent, morningEvent, afternoonEvent, eveningEvent],
+  },
+};
+
+export const SingleTimedEvent: Story = {
+  args: {
+    events: [morningEvent],
+  },
+};
+
+export const MultipleAllDay: Story = {
+  args: {
+    events: [
+      allDayEvent,
+      {
+        _id: "evt_allday_2",
+        title: "Bank Holiday",
+        startsAt: now,
+        endsAt: now + 86_400_000,
+        isAllDay: true,
+        color: "#8b5cf6",
+      },
+    ],
+  },
+};

--- a/src/components/calendars/DiaryEventList.tsx
+++ b/src/components/calendars/DiaryEventList.tsx
@@ -1,0 +1,86 @@
+import { api } from "@convex/_generated/api";
+import { useQuery } from "convex/react";
+import { addDays, format, parseISO, startOfDay } from "date-fns";
+import { Spinner } from "heroui-native";
+import { Text, View } from "react-native";
+
+export type DiaryEvent = {
+  _id: string;
+  title: string;
+  startsAt: number;
+  endsAt: number;
+  isAllDay: boolean;
+  color: string;
+};
+
+type ContentProps = {
+  events: DiaryEvent[] | undefined;
+};
+
+export function DiaryEventListContent({ events }: ContentProps) {
+  if (events === undefined) {
+    return (
+      <View className="items-center py-8">
+        <Spinner />
+      </View>
+    );
+  }
+
+  if (events.length === 0) {
+    return (
+      <View className="items-center py-8">
+        <Text className="text-sm text-foreground/60">No events</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View className="gap-1">
+      {events.map((event) => (
+        <View key={event._id} className="flex-row items-start gap-3 px-4 py-2">
+          <View
+            style={{
+              backgroundColor: event.color,
+              width: 8,
+              height: 8,
+              borderRadius: 4,
+              marginTop: 5,
+              flexShrink: 0,
+            }}
+            accessibilityLabel={`Calendar colour indicator`}
+          />
+          <View className="flex-1">
+            {event.isAllDay ? (
+              <>
+                <Text className="text-xs text-foreground/60">All day</Text>
+                <Text className="text-sm text-foreground">{event.title}</Text>
+              </>
+            ) : (
+              <>
+                <Text className="text-xs text-foreground/60">
+                  {format(new Date(event.startsAt), "h:mm a")} –{" "}
+                  {format(new Date(event.endsAt), "h:mm a")}
+                </Text>
+                <Text className="text-sm text-foreground">{event.title}</Text>
+              </>
+            )}
+          </View>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+type Props = {
+  selectedDate: string;
+};
+
+export function DiaryEventList({ selectedDate }: Props) {
+  const dayStart = startOfDay(parseISO(selectedDate));
+  const startMs = dayStart.getTime();
+  const endMs = addDays(dayStart, 1).getTime();
+
+  const events = useQuery(api.calendars.queries.getEventsForDate, { startMs, endMs });
+
+  return <DiaryEventListContent events={events} />;
+}


### PR DESCRIPTION
## Summary

- Adds `DiaryEventList` component that queries `getEventsForDate` for the selected date with DST-correct `addDays` bounds
- Replaces the static day/date text in `diary.tsx` with the live event list below the calendar
- All-day events show an "All day" label (pinned first, per query sort order); timed events show a local time range formatted as `h:mm a – h:mm a`
- HeroUI `Spinner` shown while the query loads; centred "No events" text for empty days
- Resolves an accidental committed merge conflict in `convex/calendars/actions.ts` (conflict markers were committed in e90da85) — preserves `syncNativeOnOpen`, `connectIcal`, and `setEnabledSubCalendars` via the service layer
- Adds Storybook stories for all visual states: Loading, NoEvents, AllDayOnly, TimedOnly, Mixed, SingleTimedEvent, MultipleAllDay

## Test Plan

- [ ] Tap a date with events → list renders below calendar with colour dots, time ranges, and titles
- [ ] All-day events appear first with "All day" label
- [ ] Timed events show formatted local time range (e.g. "9:00 AM – 10:30 AM")
- [ ] Tap a date with no events → "No events" centred text
- [ ] While query is loading → HeroUI Spinner shown
- [ ] `endMs` is computed with `addDays`, not `+ 86_400_000`

## Checklist

- [x] TypeScript compiles with zero errors
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass (392 passed)

Closes #153