### PR TITLE
feat(phone): #199 add VerificationCodeInput component

### DIFF
--- a/src/app/(auth)/forgot-password.tsx
+++ b/src/app/(auth)/forgot-password.tsx
@@ -198,7 +198,6 @@ export default function Page() {
                 subtitle={subtitleByStrategy[mfaStrategy]}
                 value={field.state.value}
                 onChange={field.handleChange}
-                onBlur={field.handleBlur}
                 onSubmit={() => mfaForm.handleSubmit()}
                 isLoading={!!isSubmitting}
                 isDisabled={!canSubmit || !!isSubmitting || fetchStatus === "fetching"}
@@ -227,7 +226,6 @@ export default function Page() {
                       subtitle="Enter the 6-digit code sent to your email"
                       value={field.state.value}
                       onChange={field.handleChange}
-                      onBlur={field.handleBlur}
                       onSubmit={() => codeForm.handleSubmit()}
                       isLoading={!!isSubmitting}
                       isDisabled={!canSubmit || !!isSubmitting || fetchStatus === "fetching"}

--- a/src/app/(auth)/sign-in.tsx
+++ b/src/app/(auth)/sign-in.tsx
@@ -190,7 +190,6 @@ export default function Page() {
                       subtitle={subtitleByStrategy[secondFactorStrategy]}
                       value={field.state.value}
                       onChange={field.handleChange}
-                      onBlur={field.handleBlur}
                       onSubmit={() => verifyForm.handleSubmit()}
                       isLoading={!!isSubmitting}
                       isDisabled={!canSubmit || !!isSubmitting || fetchStatus === "fetching"}
@@ -235,7 +234,6 @@ export default function Page() {
                       subtitle="Enter the 6-digit code sent to your email"
                       value={field.state.value}
                       onChange={field.handleChange}
-                      onBlur={field.handleBlur}
                       onSubmit={() => verifyForm.handleSubmit()}
                       isLoading={!!isSubmitting}
                       isDisabled={!canSubmit || !!isSubmitting || fetchStatus === "fetching"}

--- a/src/app/(auth)/sign-up.tsx
+++ b/src/app/(auth)/sign-up.tsx
@@ -84,7 +84,6 @@ export default function Page() {
                       subtitle="Enter the 6-digit code sent to your email"
                       value={field.state.value}
                       onChange={field.handleChange}
-                      onBlur={field.handleBlur}
                       onSubmit={() => verifyForm.handleSubmit()}
                       isLoading={!!isSubmitting}
                       isDisabled={!canSubmit || !!isSubmitting || fetchStatus === "fetching"}

--- a/src/components/ui/VerifyCodeScreen.stories.tsx
+++ b/src/components/ui/VerifyCodeScreen.stories.tsx
@@ -8,7 +8,6 @@ const meta = {
   args: {
     value: "",
     onChange: () => {},
-    onBlur: () => {},
     onSubmit: () => {},
     isLoading: false,
     isDisabled: false,

--- a/src/components/ui/VerifyCodeScreen.tsx
+++ b/src/components/ui/VerifyCodeScreen.tsx
@@ -46,6 +46,7 @@ export function VerifyCodeScreen({
             onChange={onChange}
             onComplete={onSubmit}
             disabled={isDisabled}
+            isInvalid={!!error}
             autoFocus
           />
         </Card.Body>

--- a/src/components/ui/VerifyCodeScreen.tsx
+++ b/src/components/ui/VerifyCodeScreen.tsx
@@ -1,7 +1,8 @@
-import { Button, Card, FieldError, InputOTP } from "heroui-native";
+import { Button, Card, FieldError } from "heroui-native";
 import { useState } from "react";
 import { Text, View } from "react-native";
 
+import { VerificationCodeInput } from "@/components/ui/phone/VerificationCodeInput";
 import { useCountdown } from "@/hooks/useCountdown";
 
 type Props = {
@@ -9,7 +10,6 @@ type Props = {
   subtitle: string;
   value: string;
   onChange: (value: string) => void;
-  onBlur: () => void;
   onSubmit: () => void;
   isLoading: boolean;
   isDisabled: boolean;
@@ -23,7 +23,6 @@ export function VerifyCodeScreen({
   subtitle,
   value,
   onChange,
-  onBlur,
   onSubmit,
   isLoading,
   isDisabled,
@@ -41,27 +40,14 @@ export function VerifyCodeScreen({
       </View>
 
       <Card className="gap-4 mx-4">
-        <Card.Body className="gap-4 items-center">
-          <InputOTP
-            maxLength={6}
+        <Card.Body className="gap-4">
+          <VerificationCodeInput
             value={value}
             onChange={onChange}
-            onBlur={onBlur}
-            isInvalid={!!error}
             onComplete={onSubmit}
-          >
-            <InputOTP.Group>
-              <InputOTP.Slot index={0} />
-              <InputOTP.Slot index={1} />
-              <InputOTP.Slot index={2} />
-            </InputOTP.Group>
-            <InputOTP.Separator />
-            <InputOTP.Group>
-              <InputOTP.Slot index={3} />
-              <InputOTP.Slot index={4} />
-              <InputOTP.Slot index={5} />
-            </InputOTP.Group>
-          </InputOTP>
+            disabled={isDisabled}
+            autoFocus
+          />
         </Card.Body>
 
         <Card.Footer className="gap-3 flex-col">

--- a/src/components/ui/phone/VerificationCodeInput.stories.tsx
+++ b/src/components/ui/phone/VerificationCodeInput.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from "@storybook/react-native";
+import { View } from "react-native";
+
+import { VerificationCodeInput } from "./VerificationCodeInput";
+
+const meta = {
+  title: "UI/Phone/VerificationCodeInput",
+  component: VerificationCodeInput,
+  decorators: [
+    (Story) => (
+      <View style={{ flex: 1, justifyContent: "center", padding: 16 }}>
+        <Story />
+      </View>
+    ),
+  ],
+  args: {
+    value: "",
+    onChange: () => {},
+    autoFocus: false,
+    disabled: false,
+  },
+} satisfies Meta<typeof VerificationCodeInput>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const PartiallyFilled: Story = {
+  args: {
+    value: "123",
+  },
+};
+
+export const Filled: Story = {
+  args: {
+    value: "123456",
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    value: "123456",
+    disabled: true,
+  },
+};
+
+export const WithOnComplete: Story = {
+  args: {
+    value: "",
+    onComplete: (code) => {
+      console.log("Code complete:", code);
+    },
+  },
+};

--- a/src/components/ui/phone/VerificationCodeInput.tsx
+++ b/src/components/ui/phone/VerificationCodeInput.tsx
@@ -7,6 +7,7 @@ type Props = {
   onComplete?: (code: string) => void;
   autoFocus?: boolean;
   disabled?: boolean;
+  isInvalid?: boolean;
 };
 
 export function VerificationCodeInput({
@@ -15,16 +16,18 @@ export function VerificationCodeInput({
   onComplete,
   autoFocus = true,
   disabled = false,
+  isInvalid,
 }: Props) {
-  const lastCompleted = useRef<string | null>(null);
+  const wasComplete = useRef(false);
 
   function handleChangeText(text: string) {
     const cleaned = text.replace(/\D/g, "").slice(0, 6);
     onChange(cleaned);
-    if (cleaned.length === 6 && cleaned !== lastCompleted.current) {
-      lastCompleted.current = cleaned;
+    const isComplete = cleaned.length === 6;
+    if (isComplete && !wasComplete.current) {
       onComplete?.(cleaned);
     }
+    wasComplete.current = isComplete;
   }
 
   return (
@@ -37,6 +40,7 @@ export function VerificationCodeInput({
       maxLength={6}
       autoFocus={autoFocus}
       editable={!disabled}
+      isInvalid={isInvalid}
     />
   );
 }

--- a/src/components/ui/phone/VerificationCodeInput.tsx
+++ b/src/components/ui/phone/VerificationCodeInput.tsx
@@ -18,16 +18,15 @@ export function VerificationCodeInput({
   disabled = false,
   isInvalid,
 }: Props) {
-  const wasComplete = useRef(false);
+  const lastCompleted = useRef<string | null>(null);
 
   function handleChangeText(text: string) {
     const cleaned = text.replace(/\D/g, "").slice(0, 6);
     onChange(cleaned);
-    const isComplete = cleaned.length === 6;
-    if (isComplete && !wasComplete.current) {
+    if (cleaned.length === 6 && cleaned !== lastCompleted.current) {
+      lastCompleted.current = cleaned;
       onComplete?.(cleaned);
     }
-    wasComplete.current = isComplete;
   }
 
   return (

--- a/src/components/ui/phone/VerificationCodeInput.tsx
+++ b/src/components/ui/phone/VerificationCodeInput.tsx
@@ -1,0 +1,42 @@
+import { Input } from "heroui-native";
+import { useRef } from "react";
+
+type Props = {
+  value: string;
+  onChange: (next: string) => void;
+  onComplete?: (code: string) => void;
+  autoFocus?: boolean;
+  disabled?: boolean;
+};
+
+export function VerificationCodeInput({
+  value,
+  onChange,
+  onComplete,
+  autoFocus = true,
+  disabled = false,
+}: Props) {
+  const lastCompleted = useRef<string | null>(null);
+
+  function handleChangeText(text: string) {
+    const cleaned = text.replace(/\D/g, "").slice(0, 6);
+    onChange(cleaned);
+    if (cleaned.length === 6 && cleaned !== lastCompleted.current) {
+      lastCompleted.current = cleaned;
+      onComplete?.(cleaned);
+    }
+  }
+
+  return (
+    <Input
+      value={value}
+      onChangeText={handleChangeText}
+      keyboardType="number-pad"
+      textContentType="oneTimeCode"
+      autoComplete="sms-otp"
+      maxLength={6}
+      autoFocus={autoFocus}
+      editable={!disabled}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

- Add `VerificationCodeInput` at `src/components/ui/phone/VerificationCodeInput.tsx` — wraps HeroUI Native `Input` for numeric SMS one-time codes with `keyboardType="number-pad"`, `textContentType="oneTimeCode"`, `autoComplete="sms-otp"`, `maxLength={6}`, strips non-digits, clips to 6 chars, and calls `onComplete` exactly once per distinct 6-digit value
- Refactor `VerifyCodeScreen` to use `VerificationCodeInput` in place of `InputOTP`, removing the `onBlur` prop (not relevant for this input type)
- Update all consumers (`sign-in`, `sign-up`, `forgot-password`) to remove the now-removed `onBlur` prop
- Add Storybook stories covering Default, PartiallyFilled, Filled, Disabled, and WithOnComplete states

## Test Plan

- [ ] TypeScript compiles with zero errors (`npx tsc --noEmit`)
- [ ] Lint passes (`npm run lint`)
- [ ] Formatting passes (`npm run fmt:check`)
- [ ] All 392 tests pass (`npm run test`)
- [ ] Storybook: `UI/Phone/VerificationCodeInput` shows all story variants
- [ ] Auth flows (sign-in, sign-up, forgot-password) still render the code input correctly

## Checklist
- [x] TypeScript compiles with zero errors
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass

Closes #199