### PR TITLE
feat(phone): #203 add addAndStartVerification Clerk service function

### DIFF
--- a/src/lib/phone/clerk/addAndStartVerification.test.ts
+++ b/src/lib/phone/clerk/addAndStartVerification.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const mockIsClerkAPIResponseError = vi.hoisted(() => vi.fn<(err: unknown) => boolean>());
+vi.mock("@clerk/expo", () => ({
+  isClerkAPIResponseError: mockIsClerkAPIResponseError,
+}));
+
+import { addAndStartVerification } from "./addAndStartVerification";
+
+type MockUser = {
+  createPhoneNumber: ReturnType<typeof vi.fn>;
+};
+
+function makeClerkError(longMessage?: string, message?: string): unknown {
+  return { errors: [{ longMessage, message }] };
+}
+
+describe("addAndStartVerification", () => {
+  let mockPrepareVerification: ReturnType<typeof vi.fn>;
+  let mockCreatePhoneNumber: ReturnType<typeof vi.fn>;
+  let user: MockUser;
+
+  beforeEach(() => {
+    mockIsClerkAPIResponseError.mockReset();
+    mockIsClerkAPIResponseError.mockReturnValue(false);
+    mockPrepareVerification = vi.fn().mockResolvedValue(undefined);
+    mockCreatePhoneNumber = vi.fn().mockResolvedValue({
+      prepareVerification: mockPrepareVerification,
+    });
+    user = { createPhoneNumber: mockCreatePhoneNumber };
+  });
+
+  test("returns ok:true when createPhoneNumber and prepareVerification both succeed", async () => {
+    const result = await addAndStartVerification({
+      user: user as never,
+      phoneNumber: "+447700900000",
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(mockCreatePhoneNumber).toHaveBeenCalledWith({
+      phoneNumber: "+447700900000",
+    });
+    expect(mockPrepareVerification).toHaveBeenCalledOnce();
+  });
+
+  test("returns ok:false with longMessage when createPhoneNumber rejects with Clerk error", async () => {
+    const clerkError = makeClerkError("This phone number is taken.", undefined);
+    mockCreatePhoneNumber.mockRejectedValue(clerkError);
+    mockIsClerkAPIResponseError.mockImplementation((err) => err === clerkError);
+
+    const result = await addAndStartVerification({
+      user: user as never,
+      phoneNumber: "+447700900000",
+    });
+
+    expect(result).toEqual({ ok: false, message: "This phone number is taken." });
+  });
+
+  test("returns ok:false with message when prepareVerification rejects with Clerk error that has only message", async () => {
+    const clerkError = makeClerkError(undefined, "Phone number is invalid.");
+    mockPrepareVerification.mockRejectedValue(clerkError);
+    mockIsClerkAPIResponseError.mockImplementation((err) => err === clerkError);
+
+    const result = await addAndStartVerification({
+      user: user as never,
+      phoneNumber: "+447700900000",
+    });
+
+    expect(result).toEqual({ ok: false, message: "Phone number is invalid." });
+  });
+
+  test("returns ok:false with fallback message when createPhoneNumber rejects with a non-Clerk error", async () => {
+    mockCreatePhoneNumber.mockRejectedValue(new Error("Network error"));
+
+    const result = await addAndStartVerification({
+      user: user as never,
+      phoneNumber: "+447700900000",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      message: "Something went wrong. Please try again.",
+    });
+  });
+});

--- a/src/lib/phone/clerk/addAndStartVerification.ts
+++ b/src/lib/phone/clerk/addAndStartVerification.ts
@@ -1,0 +1,23 @@
+import { isClerkAPIResponseError } from "@clerk/expo";
+import type { UserResource } from "@clerk/shared/types";
+
+const FALLBACK_MESSAGE = "Something went wrong. Please try again.";
+
+export async function addAndStartVerification(params: {
+  user: UserResource;
+  phoneNumber: string;
+}): Promise<{ ok: true } | { ok: false; message: string }> {
+  try {
+    const phoneNumberResource = await params.user.createPhoneNumber({
+      phoneNumber: params.phoneNumber,
+    });
+    await phoneNumberResource.prepareVerification();
+    return { ok: true };
+  } catch (error) {
+    if (isClerkAPIResponseError(error)) {
+      const message = error.errors[0]?.longMessage ?? error.errors[0]?.message ?? FALLBACK_MESSAGE;
+      return { ok: false, message };
+    }
+    return { ok: false, message: FALLBACK_MESSAGE };
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `src/lib/phone/clerk/addAndStartVerification.ts` — a client-side function that calls `user.createPhoneNumber()` then `prepareVerification()` to register a phone number and send the SMS verification code
- Surfaces Clerk's first error message verbatim (`longMessage` then `message`), falling back to a generic string for unexpected errors
- Covers all four scenarios from the issue with mocked Clerk types

## Test Plan

- All 4 unit test scenarios pass (happy path, `createPhoneNumber` Clerk error, `prepareVerification` Clerk error with only `message`, generic non-Clerk error)
- Full test suite: 401 tests pass across 44 files
- TypeScript strict mode: zero errors
- Lint and formatting: clean

## Checklist

- [x] TypeScript compiles with zero errors
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass

Closes #203