### PR TITLE
feat(convex): #204 forward verified primary phone in Clerk webhook handler

### DIFF
--- a/convex/webhooks/clerk/handler.test.ts
+++ b/convex/webhooks/clerk/handler.test.ts
@@ -104,6 +104,7 @@ describe("handleClerkWebhook", () => {
         firstName: "Alice",
         lastName: "Smith",
         profilePictureUrl: "https://example.com/pic.jpg",
+        phone: "",
       });
     });
 
@@ -120,6 +121,26 @@ describe("handleClerkWebhook", () => {
       );
       expect(response.status).toBe(200);
       expect(ctx.runMutation).not.toHaveBeenCalled();
+    });
+
+    test("calls userCreated with verified primary phone as E.164 string", async () => {
+      const withPhonePayload = {
+        ...userPayload,
+        phone_numbers: [
+          { id: "phone_1", phone_number: "+447700900000", verification: { status: "verified" } },
+        ],
+        primary_phone_number_id: "phone_1",
+      };
+      mockVerifyWebhook.mockResolvedValue({ type: "user.created", data: withPhonePayload });
+      const response = await handler(
+        ctx,
+        makeRequest(JSON.stringify({ type: "user.created", data: withPhonePayload })),
+      );
+      expect(response.status).toBe(200);
+      expect(ctx.runMutation).toHaveBeenCalledWith(
+        "users:webhooks:userCreated",
+        expect.objectContaining({ phone: "+447700900000" }),
+      );
     });
   });
 
@@ -157,6 +178,64 @@ describe("handleClerkWebhook", () => {
       expect(ctx.runMutation).toHaveBeenCalledWith(
         "users:webhooks:userUpdated",
         expect.objectContaining({ externalAuthId: "user_abc", email: undefined }),
+      );
+    });
+
+    test("calls userUpdated with verified primary phone as E.164 string", async () => {
+      const withPhonePayload = {
+        ...userPayload,
+        phone_numbers: [
+          { id: "phone_1", phone_number: "+447700900001", verification: { status: "verified" } },
+        ],
+        primary_phone_number_id: "phone_1",
+      };
+      mockVerifyWebhook.mockResolvedValue({ type: "user.updated", data: withPhonePayload });
+      const response = await handler(
+        ctx,
+        makeRequest(JSON.stringify({ type: "user.updated", data: withPhonePayload })),
+      );
+      expect(response.status).toBe(200);
+      expect(ctx.runMutation).toHaveBeenCalledWith(
+        "users:webhooks:userUpdated",
+        expect.objectContaining({ phone: "+447700900001" }),
+      );
+    });
+
+    test("calls userUpdated with phone '' when primary_phone_number_id is null", async () => {
+      const noPhonePayload = {
+        ...userPayload,
+        phone_numbers: [],
+        primary_phone_number_id: null,
+      };
+      mockVerifyWebhook.mockResolvedValue({ type: "user.updated", data: noPhonePayload });
+      const response = await handler(
+        ctx,
+        makeRequest(JSON.stringify({ type: "user.updated", data: noPhonePayload })),
+      );
+      expect(response.status).toBe(200);
+      expect(ctx.runMutation).toHaveBeenCalledWith(
+        "users:webhooks:userUpdated",
+        expect.objectContaining({ phone: "" }),
+      );
+    });
+
+    test("calls userUpdated with phone '' when primary phone verification is not verified", async () => {
+      const unverifiedPhonePayload = {
+        ...userPayload,
+        phone_numbers: [
+          { id: "phone_1", phone_number: "+447700900002", verification: { status: "unverified" } },
+        ],
+        primary_phone_number_id: "phone_1",
+      };
+      mockVerifyWebhook.mockResolvedValue({ type: "user.updated", data: unverifiedPhonePayload });
+      const response = await handler(
+        ctx,
+        makeRequest(JSON.stringify({ type: "user.updated", data: unverifiedPhonePayload })),
+      );
+      expect(response.status).toBe(200);
+      expect(ctx.runMutation).toHaveBeenCalledWith(
+        "users:webhooks:userUpdated",
+        expect.objectContaining({ phone: "" }),
       );
     });
   });

--- a/convex/webhooks/clerk/handler.ts
+++ b/convex/webhooks/clerk/handler.ts
@@ -18,8 +18,16 @@ export const handleClerkWebhook = httpAction(async (ctx, request) => {
   try {
     switch (event.type) {
       case "user.created": {
-        const { id, email_addresses, primary_email_address_id, first_name, last_name, image_url } =
-          event.data;
+        const {
+          id,
+          email_addresses,
+          primary_email_address_id,
+          first_name,
+          last_name,
+          image_url,
+          phone_numbers,
+          primary_phone_number_id,
+        } = event.data;
 
         const email = resolvePrimaryEmail(email_addresses, primary_email_address_id);
         if (!email) {
@@ -35,12 +43,21 @@ export const handleClerkWebhook = httpAction(async (ctx, request) => {
           firstName: first_name ?? undefined,
           lastName: last_name ?? undefined,
           profilePictureUrl: image_url ?? undefined,
+          phone: resolvePrimaryPhone(phone_numbers ?? [], primary_phone_number_id ?? null),
         });
         break;
       }
       case "user.updated": {
-        const { id, email_addresses, primary_email_address_id, first_name, last_name, image_url } =
-          event.data;
+        const {
+          id,
+          email_addresses,
+          primary_email_address_id,
+          first_name,
+          last_name,
+          image_url,
+          phone_numbers,
+          primary_phone_number_id,
+        } = event.data;
 
         await ctx.runMutation(internal.users.webhooks.userUpdated, {
           externalAuthId: id,
@@ -48,6 +65,7 @@ export const handleClerkWebhook = httpAction(async (ctx, request) => {
           firstName: first_name ?? undefined,
           lastName: last_name ?? undefined,
           profilePictureUrl: image_url ?? undefined,
+          phone: resolvePrimaryPhone(phone_numbers ?? [], primary_phone_number_id ?? null),
         });
         break;
       }
@@ -74,4 +92,15 @@ function resolvePrimaryEmail(
   primary_email_address_id: string | null,
 ): string | undefined {
   return email_addresses.find((e) => e.id === primary_email_address_id)?.email_address;
+}
+
+function resolvePrimaryPhone(
+  phone_numbers: { id: string; phone_number: string; verification: { status: string } | null }[],
+  primary_phone_number_id: string | null,
+): string {
+  const primary = phone_numbers.find((p) => p.id === primary_phone_number_id);
+  if (primary?.verification?.status === "verified") {
+    return primary.phone_number;
+  }
+  return "";
 }


### PR DESCRIPTION
## Summary

- Adds a `resolvePrimaryPhone` helper alongside the existing `resolvePrimaryEmail` in the Clerk webhook handler
- Extracts `phone_numbers` and `primary_phone_number_id` from `user.created` and `user.updated` Clerk webhook payloads
- Resolves the verified primary phone: returns the E.164 `phone_number` when `verification.status === "verified"`, otherwise `""` (clears the field)
- Passes the resolved value as the `phone` argument to the existing `userCreated` / `userUpdated` internal Convex mutations (added in #201)

## Test Plan

Four new test scenarios added to `convex/webhooks/clerk/handler.test.ts`:
- `user.created` with verified primary phone → mutation called with the E.164 string
- `user.updated` with verified primary phone → mutation called with the E.164 string
- `user.updated` with `primary_phone_number_id: null` and empty `phone_numbers` → mutation called with `phone: ""`
- `user.updated` with unverified phone (`verification.status !== "verified"`) → mutation called with `phone: ""`

## Checklist
- [x] TypeScript compiles with zero errors
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass (405/405)

Closes #204