### PR TITLE
feat(phone): #202 add CountrySelect component

### DIFF
--- a/src/components/ui/phone/CountrySelect.stories.tsx
+++ b/src/components/ui/phone/CountrySelect.stories.tsx
@@ -1,0 +1,70 @@
+import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
+import type { Meta, StoryObj } from "@storybook/react-native";
+import { useState } from "react";
+import { View } from "react-native";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
+
+import { CountrySelect } from "./CountrySelect";
+
+const meta = {
+  title: "UI/Phone/CountrySelect",
+  component: CountrySelect,
+  decorators: [
+    (Story) => (
+      <GestureHandlerRootView style={{ flex: 1 }}>
+        <BottomSheetModalProvider>
+          <View style={{ flex: 1, padding: 16, backgroundColor: "#f9f9f9" }}>
+            <Story />
+          </View>
+        </BottomSheetModalProvider>
+      </GestureHandlerRootView>
+    ),
+  ],
+  tags: ["autodocs"],
+  args: {
+    value: "GB",
+    onChange: () => {},
+    disabled: false,
+  },
+} satisfies Meta<typeof CountrySelect>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const InteractiveRender: Story["render"] = (args) => {
+  const [selected, setSelected] = useState(args.value);
+  return <CountrySelect {...args} value={selected} onChange={setSelected} />;
+};
+
+export const Default: Story = {
+  render: InteractiveRender,
+};
+
+export const UnitedStates: Story = {
+  render: InteractiveRender,
+  args: {
+    value: "US",
+  },
+};
+
+export const France: Story = {
+  render: InteractiveRender,
+  args: {
+    value: "FR",
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    value: "GB",
+    disabled: true,
+  },
+};
+
+export const NoSelection: Story = {
+  render: InteractiveRender,
+  args: {
+    value: "XX",
+  },
+};

--- a/src/components/ui/phone/CountrySelect.tsx
+++ b/src/components/ui/phone/CountrySelect.tsx
@@ -1,0 +1,78 @@
+import { BottomSheetScrollView } from "@gorhom/bottom-sheet";
+import { LinearGradient } from "expo-linear-gradient";
+import { ScrollShadow, Select, useThemeColor } from "heroui-native";
+import { Text, View } from "react-native";
+
+import { COUNTRIES } from "@/lib/countries/countries";
+
+import { CountryFlag } from "./CountryFlag";
+
+type SelectOption = {
+  value: string;
+  label: string;
+};
+
+type Props = {
+  value: string;
+  onChange: (iso2: string) => void;
+  disabled?: boolean;
+};
+
+export function CountrySelect({ value, onChange, disabled = false }: Props) {
+  const themeColorOverlay = useThemeColor("overlay");
+
+  const selectedCountry = COUNTRIES.find(({ code }) => code === value);
+
+  const selectedOption: SelectOption | undefined = selectedCountry
+    ? { value: selectedCountry.code, label: selectedCountry.name }
+    : undefined;
+
+  return (
+    <Select
+      value={selectedOption}
+      onValueChange={(option) => {
+        if (option) onChange(option.value);
+      }}
+      isDisabled={disabled}
+      presentation="bottom-sheet"
+      accessibilityLabel="Select country code"
+    >
+      <Select.Trigger>
+        <View className="flex-row items-center gap-2 flex-1">
+          <CountryFlag iso2={value} size={20} />
+          <Text>{selectedCountry?.dialCode ?? ""}</Text>
+        </View>
+        <Select.TriggerIndicator />
+      </Select.Trigger>
+      <Select.Portal>
+        <Select.Overlay className="bg-black/50" />
+        <Select.Content
+          presentation="bottom-sheet"
+          snapPoints={["50%", "90%"]}
+          keyboardBehavior="extend"
+          enableDynamicSizing={false}
+          enableOverDrag={false}
+          contentContainerClassName="flex-1 h-full"
+        >
+          <ScrollShadow LinearGradientComponent={LinearGradient} color={themeColorOverlay}>
+            <BottomSheetScrollView
+              showsVerticalScrollIndicator={true}
+              contentContainerStyle={{ paddingBottom: 16 }}
+            >
+              {COUNTRIES.map(({ code, name, dialCode }) => (
+                <Select.Item key={code} value={code} label={name}>
+                  <View className="flex-row items-center gap-2 flex-1">
+                    <CountryFlag iso2={code} size={20} />
+                    <Select.ItemLabel />
+                  </View>
+                  <Text style={{ color: "#888" }}>{dialCode}</Text>
+                  <Select.ItemIndicator />
+                </Select.Item>
+              ))}
+            </BottomSheetScrollView>
+          </ScrollShadow>
+        </Select.Content>
+      </Select.Portal>
+    </Select>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `src/components/ui/phone/CountrySelect.tsx` — a HeroUI Native `Select`-based country picker
- Trigger displays the selected country's flag (`CountryFlag`) and dial code
- Bottom-sheet dropdown lists all countries with flag, name, and dial code (from `@/lib/countries/countries`)
- Supports `value` (ISO-3166 alpha-2), `onChange`, and `disabled` props
- Adds `src/components/ui/phone/CountrySelect.stories.tsx` with Default, UnitedStates, France, Disabled, and NoSelection stories

**Note:** The spec references `@/lib/phone/countries` (created in #197), but that path was consolidated into `@/lib/countries/countries` in the same PR's follow-up commit. The component imports from the actual existing location.

## Test Plan

- [ ] Open Storybook → `UI/Phone/CountrySelect` — verify all story variants render
- [ ] Default story: tap trigger, bottom sheet opens with full country list
- [ ] Select a country — trigger updates to show new flag + dial code
- [ ] Disabled story: trigger is non-interactive
- [ ] NoSelection story (`XX`): trigger shows no flag, no dial code (unknown code)

## Checklist

- [x] TypeScript compiles with zero errors
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass (44 test files, 401 tests)

Closes #202