### PR TITLE
feat(convex): #205 add syncVerifiedPhone action

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -57,6 +57,7 @@ import type * as users_domain_syncUser from "../users/domain/syncUser.js";
 import type * as users_domain_upsertCurrentUser from "../users/domain/upsertCurrentUser.js";
 import type * as users_mutations from "../users/mutations.js";
 import type * as users_queries from "../users/queries.js";
+import type * as users_syncVerifiedPhone from "../users/syncVerifiedPhone.js";
 import type * as users_webhooks from "../users/webhooks.js";
 import type * as webhooks_clerk_handler from "../webhooks/clerk/handler.js";
 
@@ -116,6 +117,7 @@ declare const fullApi: ApiFromModules<{
   "users/domain/upsertCurrentUser": typeof users_domain_upsertCurrentUser;
   "users/mutations": typeof users_mutations;
   "users/queries": typeof users_queries;
+  "users/syncVerifiedPhone": typeof users_syncVerifiedPhone;
   "users/webhooks": typeof users_webhooks;
   "webhooks/clerk/handler": typeof webhooks_clerk_handler;
 }>;

--- a/convex/users/syncVerifiedPhone.test.ts
+++ b/convex/users/syncVerifiedPhone.test.ts
@@ -1,0 +1,117 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { api, internal } from "../_generated/api";
+import schema from "../schema";
+
+const mockGetUser = vi.hoisted(() => vi.fn());
+
+vi.mock("@clerk/backend", () => ({
+  createClerkClient: vi.fn().mockReturnValue({
+    users: { getUser: mockGetUser },
+  }),
+}));
+
+const modules = import.meta.glob("/convex/**/*.ts");
+
+const identity = {
+  subject: "user_clerk_sync_1",
+  issuer: "https://example.clerk.test",
+  tokenIdentifier: "https://example.clerk.test|user_clerk_sync_1",
+};
+
+const baseClerkUser = {
+  id: "user_clerk_sync_1",
+  primaryPhoneNumberId: "phone_1",
+  phoneNumbers: [
+    { id: "phone_1", phoneNumber: "+447700900123", verification: { status: "verified" } },
+  ],
+  emailAddresses: [{ id: "email_1", emailAddress: "alice@example.com" }],
+  primaryEmailAddressId: "email_1",
+  firstName: "Alice",
+  lastName: "Smith",
+  imageUrl: "https://example.com/pic.jpg",
+};
+
+async function makeTestWithUser() {
+  const t = convexTest(schema, modules);
+  await t.run((ctx) =>
+    ctx.db.insert("users", {
+      externalAuthId: identity.subject,
+      email: "alice@example.com",
+      hasCompletedOnboarding: false,
+    }),
+  );
+  return t;
+}
+
+describe("syncVerifiedPhone", () => {
+  beforeEach(() => {
+    mockGetUser.mockReset();
+  });
+
+  test("verified primary phone: calls userUpdated and updates user document", async () => {
+    mockGetUser.mockResolvedValue(baseClerkUser);
+    const t = await makeTestWithUser();
+
+    await t.withIdentity(identity).action(api.users.syncVerifiedPhone.syncVerifiedPhone, {});
+
+    const user = await t.run((ctx) =>
+      ctx.db
+        .query("users")
+        .withIndex("byExternalAuthId", (q) => q.eq("externalAuthId", identity.subject))
+        .unique(),
+    );
+    expect(user?.phone).toBe("+447700900123");
+  });
+
+  test("no verified primary phone: throws and leaves user document unchanged", async () => {
+    mockGetUser.mockResolvedValue({
+      ...baseClerkUser,
+      phoneNumbers: [
+        { id: "phone_1", phoneNumber: "+447700900123", verification: { status: "unverified" } },
+      ],
+    });
+    const t = await makeTestWithUser();
+
+    await expect(
+      t.withIdentity(identity).action(api.users.syncVerifiedPhone.syncVerifiedPhone, {}),
+    ).rejects.toThrow("No verified primary phone on Clerk user.");
+
+    const user = await t.run((ctx) =>
+      ctx.db
+        .query("users")
+        .withIndex("byExternalAuthId", (q) => q.eq("externalAuthId", identity.subject))
+        .unique(),
+    );
+    expect(user?.phone).toBeUndefined();
+  });
+
+  test("unauthenticated caller: throws and makes no Clerk request", async () => {
+    const t = convexTest(schema, modules);
+
+    await expect(t.action(api.users.syncVerifiedPhone.syncVerifiedPhone, {})).rejects.toThrow();
+
+    expect(mockGetUser).not.toHaveBeenCalled();
+  });
+
+  test("race: action and webhook both write same phone — result is idempotent", async () => {
+    mockGetUser.mockResolvedValue(baseClerkUser);
+    const t = await makeTestWithUser();
+
+    await t.withIdentity(identity).action(api.users.syncVerifiedPhone.syncVerifiedPhone, {});
+    await t.mutation(internal.users.webhooks.userUpdated, {
+      externalAuthId: identity.subject,
+      phone: "+447700900123",
+    });
+
+    const user = await t.run((ctx) =>
+      ctx.db
+        .query("users")
+        .withIndex("byExternalAuthId", (q) => q.eq("externalAuthId", identity.subject))
+        .unique(),
+    );
+    expect(user?.phone).toBe("+447700900123");
+  });
+});

--- a/convex/users/syncVerifiedPhone.ts
+++ b/convex/users/syncVerifiedPhone.ts
@@ -1,0 +1,38 @@
+import { createClerkClient } from "@clerk/backend";
+
+import { internal } from "../_generated/api";
+import { action } from "../_generated/server";
+
+export const syncVerifiedPhone = action({
+  args: {},
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Not authenticated");
+
+    const clerk = createClerkClient({ secretKey: process.env.CLERK_SECRET_KEY });
+    const clerkUser = await clerk.users.getUser(identity.subject);
+
+    const { primaryPhoneNumberId, phoneNumbers } = clerkUser;
+
+    const primaryPhone = phoneNumbers.find(
+      (p) => p.id === primaryPhoneNumberId && p.verification?.status === "verified",
+    );
+
+    if (!primaryPhone) throw new Error("No verified primary phone on Clerk user.");
+
+    const primaryEmail = clerkUser.emailAddresses.find(
+      (e) => e.id === clerkUser.primaryEmailAddressId,
+    );
+
+    await ctx.runMutation(internal.users.webhooks.userUpdated, {
+      externalAuthId: clerkUser.id,
+      email: primaryEmail?.emailAddress,
+      firstName: clerkUser.firstName ?? undefined,
+      lastName: clerkUser.lastName ?? undefined,
+      profilePictureUrl: clerkUser.imageUrl,
+      phone: primaryPhone.phoneNumber,
+    });
+
+    return null;
+  },
+});


### PR DESCRIPTION
## Summary

- Adds `convex/users/syncVerifiedPhone.ts` exporting a public `action` with no arguments
- Action resolves caller identity via `ctx.auth.getUserIdentity()`, fetches the Clerk user using `createClerkClient` from `@clerk/backend`, finds the verified primary phone, and calls the internal `userUpdated` mutation from #201 with the resolved E.164 phone string
- Returns `null`; throws if unauthenticated or if no verified primary phone exists on the Clerk user

## Test Plan

- All 4 specified scenarios covered in `convex/users/syncVerifiedPhone.test.ts` with `@clerk/backend` mocked via `vi.mock`
- Test 1: verified primary phone → mutation called, `users.phone` updated
- Test 2: no verified primary phone → throws, document unchanged
- Test 3: unauthenticated caller → throws, no Clerk request made
- Test 4: action + webhook both write same phone → idempotent result

## Checklist
- [x] TypeScript compiles with zero errors
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass (409 tests, 45 files)

Closes #205