### PR TITLE
feat(phone): #207 add confirmVerification Clerk service function

### DIFF
--- a/src/lib/phone/clerk/confirmVerification.test.ts
+++ b/src/lib/phone/clerk/confirmVerification.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const mockIsClerkAPIResponseError = vi.hoisted(() => vi.fn<(err: unknown) => boolean>());
+vi.mock("@clerk/expo", () => ({
+  isClerkAPIResponseError: mockIsClerkAPIResponseError,
+}));
+
+import { confirmVerification } from "./confirmVerification";
+
+type MockPhone = {
+  id: string;
+  verification: { status: string } | null;
+  attemptVerification: ReturnType<typeof vi.fn>;
+  destroy: ReturnType<typeof vi.fn>;
+};
+
+type MockUser = {
+  phoneNumbers: MockPhone[];
+  update: ReturnType<typeof vi.fn>;
+};
+
+function makeClerkError(longMessage?: string, message?: string): unknown {
+  return { errors: [{ longMessage, message }] };
+}
+
+describe("confirmVerification", () => {
+  let user: MockUser;
+  let pendingPhone: MockPhone;
+  let verifiedPhone: MockPhone;
+
+  beforeEach(() => {
+    mockIsClerkAPIResponseError.mockReset();
+    mockIsClerkAPIResponseError.mockReturnValue(false);
+
+    pendingPhone = {
+      id: "phone_pending",
+      verification: { status: "unverified" },
+      attemptVerification: vi.fn().mockResolvedValue(undefined),
+      destroy: vi.fn().mockResolvedValue(undefined),
+    };
+
+    verifiedPhone = {
+      id: "phone_verified_old",
+      verification: { status: "verified" },
+      attemptVerification: vi.fn(),
+      destroy: vi.fn().mockResolvedValue(undefined),
+    };
+
+    user = {
+      phoneNumbers: [verifiedPhone, pendingPhone],
+      update: vi.fn().mockResolvedValue(undefined),
+    };
+  });
+
+  test("returns ok:true, sets pending phone as primary, and destroys other phones", async () => {
+    const result = await confirmVerification({
+      user: user as never,
+      code: "123456",
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(pendingPhone.attemptVerification).toHaveBeenCalledWith({ code: "123456" });
+    expect(user.update).toHaveBeenCalledWith({ primaryPhoneNumberId: "phone_pending" });
+    expect(verifiedPhone.destroy).toHaveBeenCalledOnce();
+    expect(pendingPhone.destroy).not.toHaveBeenCalled();
+  });
+
+  test("returns ok:false when no pending phone exists", async () => {
+    user.phoneNumbers = [{ ...verifiedPhone }];
+
+    const result = await confirmVerification({
+      user: user as never,
+      code: "123456",
+    });
+
+    expect(result).toEqual({ ok: false, message: "No pending phone to verify." });
+  });
+
+  test("returns ok:false with longMessage when attemptVerification rejects with Clerk error", async () => {
+    const clerkError = makeClerkError("Incorrect code", undefined);
+    pendingPhone.attemptVerification.mockRejectedValue(clerkError);
+    mockIsClerkAPIResponseError.mockImplementation((err) => err === clerkError);
+
+    const result = await confirmVerification({
+      user: user as never,
+      code: "000000",
+    });
+
+    expect(result).toEqual({ ok: false, message: "Incorrect code" });
+  });
+
+  test("returns ok:false with message when attemptVerification rejects with Clerk error with only message (no longMessage)", async () => {
+    const clerkError = makeClerkError(undefined, "Code expired");
+    pendingPhone.attemptVerification.mockRejectedValue(clerkError);
+    mockIsClerkAPIResponseError.mockImplementation((err) => err === clerkError);
+
+    const result = await confirmVerification({
+      user: user as never,
+      code: "000000",
+    });
+
+    expect(result).toEqual({ ok: false, message: "Code expired" });
+  });
+
+  test("returns ok:false when user.update rejects with Clerk error after verification succeeds", async () => {
+    const clerkError = makeClerkError("Unable to update primary phone", undefined);
+    user.update.mockRejectedValue(clerkError);
+    mockIsClerkAPIResponseError.mockImplementation((err) => err === clerkError);
+
+    const result = await confirmVerification({
+      user: user as never,
+      code: "123456",
+    });
+
+    expect(result).toEqual({ ok: false, message: "Unable to update primary phone" });
+  });
+});

--- a/src/lib/phone/clerk/confirmVerification.ts
+++ b/src/lib/phone/clerk/confirmVerification.ts
@@ -1,0 +1,34 @@
+import { isClerkAPIResponseError } from "@clerk/expo";
+import type { UserResource } from "@clerk/shared/types";
+
+const FALLBACK_MESSAGE = "Something went wrong. Please try again.";
+
+export async function confirmVerification(params: {
+  user: UserResource;
+  code: string;
+}): Promise<{ ok: true } | { ok: false; message: string }> {
+  try {
+    const { user, code } = params;
+
+    const pending = user.phoneNumbers.filter((p) => p.verification?.status !== "verified");
+    const pendingPhone = pending[pending.length - 1];
+
+    if (!pendingPhone) {
+      return { ok: false, message: "No pending phone to verify." };
+    }
+
+    await pendingPhone.attemptVerification({ code });
+    await user.update({ primaryPhoneNumberId: pendingPhone.id });
+
+    const others = user.phoneNumbers.filter((p) => p.id !== pendingPhone.id);
+    await Promise.all(others.map((p) => p.destroy()));
+
+    return { ok: true };
+  } catch (error) {
+    if (isClerkAPIResponseError(error)) {
+      const message = error.errors[0]?.longMessage ?? error.errors[0]?.message ?? FALLBACK_MESSAGE;
+      return { ok: false, message };
+    }
+    return { ok: false, message: FALLBACK_MESSAGE };
+  }
+}

--- a/src/lib/phone/clerk/confirmVerification.ts
+++ b/src/lib/phone/clerk/confirmVerification.ts
@@ -10,7 +10,7 @@ export async function confirmVerification(params: {
   try {
     const { user, code } = params;
 
-    const pending = user.phoneNumbers.filter((p) => p.verification?.status !== "verified");
+    const pending = user.phoneNumbers.filter((p) => p.verification?.status === "unverified");
     const pendingPhone = pending[pending.length - 1];
 
     if (!pendingPhone) {


### PR DESCRIPTION
## Summary

- Adds `src/lib/phone/clerk/confirmVerification.ts` — finds the pending (unverified) phone on the user, calls `attemptVerification({ code })`, sets it as the primary phone via `user.update`, and destroys any other phone numbers
- Returns `{ ok: true }` on success; surfaces Clerk's verbatim error message (preferring `longMessage`) or falls back to a generic message
- Adds `confirmVerification.test.ts` covering all five specified scenarios

## Test Plan

- [ ] Happy path: pending phone verified, set as primary, old phones destroyed → `{ ok: true }`
- [ ] No pending phone → `{ ok: false, message: "No pending phone to verify." }`
- [ ] `attemptVerification` Clerk error with `longMessage` → returned verbatim
- [ ] `attemptVerification` Clerk error with only `message` (no `longMessage`) → returned verbatim
- [ ] `user.update` Clerk error → `{ ok: false, message }` from Clerk

## Checklist

- [x] TypeScript compiles with zero errors
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass (414/414)

Closes #207