### PR TITLE
feat(onboarding): #210 add EnterCodeView

### DIFF
--- a/src/components/onboarding/phone/EnterCodeView.stories.tsx
+++ b/src/components/onboarding/phone/EnterCodeView.stories.tsx
@@ -1,0 +1,219 @@
+import type { Meta, StoryObj } from "@storybook/react-native";
+import { Button, Card, FieldError } from "heroui-native";
+import { useState } from "react";
+import { Text, View } from "react-native";
+
+import { VerificationCodeInput } from "@/components/ui/phone/VerificationCodeInput";
+
+import { EnterCodeView } from "./EnterCodeView";
+
+// Pure display helpers for each visual state — avoid importing live Convex/Clerk hooks
+
+type DisplayProps = {
+  maskedPhone: string;
+  code: string;
+  onCodeChange: (v: string) => void;
+  loading?: boolean;
+  error?: string | null;
+  resendCooldown?: number;
+  onVerify: () => void;
+  onResend: () => void;
+  onEditNumber: () => void;
+};
+
+function EnterCodeDisplay({
+  maskedPhone,
+  code,
+  onCodeChange,
+  loading = false,
+  error = null,
+  resendCooldown = 30,
+  onVerify,
+  onResend,
+  onEditNumber,
+}: DisplayProps) {
+  return (
+    <View className="gap-6">
+      <View className="mx-4">
+        <Text className="text-4xl font-bold leading-none mb-2">Enter the code</Text>
+        <Text className="text-base">Sent to {maskedPhone}</Text>
+      </View>
+
+      <Card className="gap-4 mx-4">
+        <Card.Body className="gap-4">
+          <VerificationCodeInput
+            value={code}
+            onChange={onCodeChange}
+            onComplete={onVerify}
+            disabled={loading}
+            isInvalid={!!error}
+            autoFocus={false}
+          />
+        </Card.Body>
+
+        <Card.Footer className="gap-3 flex-col">
+          {error && <FieldError isInvalid>{error}</FieldError>}
+
+          <Button
+            variant="primary"
+            onPress={onVerify}
+            isDisabled={code.length !== 6 || loading}
+            className="w-full"
+            accessibilityLabel="Verify code"
+          >
+            {loading ? "Verifying..." : "Verify"}
+          </Button>
+        </Card.Footer>
+      </Card>
+
+      <View className="items-center gap-2">
+        <Button
+          variant="ghost"
+          size="sm"
+          isDisabled={resendCooldown > 0}
+          onPress={onResend}
+          accessibilityLabel={
+            resendCooldown > 0
+              ? `Resend code available in ${resendCooldown} seconds`
+              : "Resend code"
+          }
+        >
+          {resendCooldown > 0 ? `Resend code (${resendCooldown}s)` : "Resend code"}
+        </Button>
+
+        <Button
+          variant="ghost"
+          size="sm"
+          isDisabled={loading}
+          onPress={onEditNumber}
+          accessibilityLabel="Edit phone number"
+        >
+          Edit number
+        </Button>
+      </View>
+    </View>
+  );
+}
+
+const meta = {
+  title: "Onboarding/Phone/EnterCodeView",
+  component: EnterCodeView,
+  decorators: [
+    (Story) => (
+      <View style={{ flex: 1, padding: 16, backgroundColor: "#f9f9f9" }}>
+        <Story />
+      </View>
+    ),
+  ],
+  tags: ["autodocs"],
+  args: {
+    phoneE164: "+447700900123",
+    onVerified: () => {},
+    onEditNumber: () => {},
+  },
+} satisfies Meta<typeof EnterCodeView>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => {
+    const [code, setCode] = useState("");
+    return (
+      <EnterCodeDisplay
+        maskedPhone="•••••• 0123"
+        code={code}
+        onCodeChange={setCode}
+        resendCooldown={30}
+        onVerify={() => {}}
+        onResend={() => {}}
+        onEditNumber={args.onEditNumber}
+      />
+    );
+  },
+};
+
+export const WithCodeEntered: Story = {
+  render: (args) => {
+    const [code, setCode] = useState("123456");
+    return (
+      <EnterCodeDisplay
+        maskedPhone="•••••• 0123"
+        code={code}
+        onCodeChange={setCode}
+        resendCooldown={30}
+        onVerify={() => {}}
+        onResend={() => {}}
+        onEditNumber={args.onEditNumber}
+      />
+    );
+  },
+};
+
+export const Loading: Story = {
+  render: (args) => (
+    <EnterCodeDisplay
+      maskedPhone="•••••• 0123"
+      code="123456"
+      onCodeChange={() => {}}
+      loading
+      resendCooldown={30}
+      onVerify={() => {}}
+      onResend={() => {}}
+      onEditNumber={args.onEditNumber}
+    />
+  ),
+};
+
+export const WithError: Story = {
+  render: (args) => {
+    const [code, setCode] = useState("123456");
+    return (
+      <EnterCodeDisplay
+        maskedPhone="•••••• 0123"
+        code={code}
+        onCodeChange={setCode}
+        error="Incorrect code. Please try again."
+        resendCooldown={30}
+        onVerify={() => {}}
+        onResend={() => {}}
+        onEditNumber={args.onEditNumber}
+      />
+    );
+  },
+};
+
+export const ResendAvailable: Story = {
+  render: (args) => {
+    const [code, setCode] = useState("");
+    return (
+      <EnterCodeDisplay
+        maskedPhone="•••••• 0123"
+        code={code}
+        onCodeChange={setCode}
+        resendCooldown={0}
+        onVerify={() => {}}
+        onResend={() => {}}
+        onEditNumber={args.onEditNumber}
+      />
+    );
+  },
+};
+
+export const ResendWithCountdown: Story = {
+  render: (args) => {
+    const [code, setCode] = useState("");
+    return (
+      <EnterCodeDisplay
+        maskedPhone="•••••• 0123"
+        code={code}
+        onCodeChange={setCode}
+        resendCooldown={12}
+        onVerify={() => {}}
+        onResend={() => {}}
+        onEditNumber={args.onEditNumber}
+      />
+    );
+  },
+};

--- a/src/components/onboarding/phone/EnterCodeView.tsx
+++ b/src/components/onboarding/phone/EnterCodeView.tsx
@@ -19,6 +19,7 @@ type Props = {
 export function EnterCodeView({ phoneE164, onVerified, onEditNumber }: Props) {
   const [code, setCode] = useState("");
   const [loading, setLoading] = useState(false);
+  const [resending, setResending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [resendCooldown, startResendCooldown] = useCountdown(30);
 
@@ -57,18 +58,24 @@ export function EnterCodeView({ phoneE164, onVerified, onEditNumber }: Props) {
   }
 
   async function handleResend() {
+    if (resending) return;
     if (!user) {
       setError("You must be signed in.");
       return;
     }
 
+    setResending(true);
     setError(null);
-    const result = await addAndStartVerification({ user, phoneNumber: phoneE164 });
-    if (!result.ok) {
-      setError(result.message);
-      return;
+    try {
+      const result = await addAndStartVerification({ user, phoneNumber: phoneE164 });
+      if (!result.ok) {
+        setError(result.message);
+        return;
+      }
+      startResendCooldown(30);
+    } finally {
+      setResending(false);
     }
-    startResendCooldown(30);
   }
 
   return (
@@ -109,15 +116,21 @@ export function EnterCodeView({ phoneE164, onVerified, onEditNumber }: Props) {
         <Button
           variant="ghost"
           size="sm"
-          isDisabled={resendCooldown > 0}
+          isDisabled={resendCooldown > 0 || resending}
           onPress={handleResend}
           accessibilityLabel={
             resendCooldown > 0
               ? `Resend code available in ${resendCooldown} seconds`
-              : "Resend code"
+              : resending
+                ? "Resending code"
+                : "Resend code"
           }
         >
-          {resendCooldown > 0 ? `Resend code (${resendCooldown}s)` : "Resend code"}
+          {resending
+            ? "Resending..."
+            : resendCooldown > 0
+              ? `Resend code (${resendCooldown}s)`
+              : "Resend code"}
         </Button>
 
         <Button

--- a/src/components/onboarding/phone/EnterCodeView.tsx
+++ b/src/components/onboarding/phone/EnterCodeView.tsx
@@ -1,0 +1,135 @@
+import { useUser } from "@clerk/expo";
+import { api } from "@convex/_generated/api";
+import { useAction } from "convex/react";
+import { Button, Card, FieldError } from "heroui-native";
+import { useState } from "react";
+import { Text, View } from "react-native";
+
+import { VerificationCodeInput } from "@/components/ui/phone/VerificationCodeInput";
+import { useCountdown } from "@/hooks/useCountdown";
+import { addAndStartVerification } from "@/lib/phone/clerk/addAndStartVerification";
+import { confirmVerification } from "@/lib/phone/clerk/confirmVerification";
+
+type Props = {
+  phoneE164: string;
+  onVerified: () => void;
+  onEditNumber: () => void;
+};
+
+export function EnterCodeView({ phoneE164, onVerified, onEditNumber }: Props) {
+  const [code, setCode] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [resendCooldown, startResendCooldown] = useCountdown(30);
+
+  const { user } = useUser();
+  const syncVerifiedPhone = useAction(api.users.syncVerifiedPhone.syncVerifiedPhone);
+
+  const last4 = phoneE164.slice(-4);
+  const maskedPhone = `•••••• ${last4}`;
+
+  async function handleVerify(codeToVerify: string) {
+    if (codeToVerify.length !== 6 || loading) return;
+
+    setLoading(true);
+    setError(null);
+
+    if (!user) {
+      setError("You must be signed in.");
+      setLoading(false);
+      return;
+    }
+
+    const result = await confirmVerification({ user, code: codeToVerify });
+    if (!result.ok) {
+      setError(result.message);
+      setLoading(false);
+      return;
+    }
+
+    try {
+      await syncVerifiedPhone({});
+      onVerified();
+    } catch {
+      setError("Phone verified but failed to sync. Please try again.");
+      setLoading(false);
+    }
+  }
+
+  async function handleResend() {
+    if (!user) {
+      setError("You must be signed in.");
+      return;
+    }
+
+    setError(null);
+    const result = await addAndStartVerification({ user, phoneNumber: phoneE164 });
+    if (!result.ok) {
+      setError(result.message);
+      return;
+    }
+    startResendCooldown(30);
+  }
+
+  return (
+    <View className="gap-6">
+      <View className="mx-4">
+        <Text className="text-4xl font-bold leading-none mb-2">Enter the code</Text>
+        <Text className="text-base">Sent to {maskedPhone}</Text>
+      </View>
+
+      <Card className="gap-4 mx-4">
+        <Card.Body className="gap-4">
+          <VerificationCodeInput
+            value={code}
+            onChange={setCode}
+            onComplete={handleVerify}
+            disabled={loading}
+            isInvalid={!!error}
+            autoFocus
+          />
+        </Card.Body>
+
+        <Card.Footer className="gap-3 flex-col">
+          {error && <FieldError isInvalid>{error}</FieldError>}
+
+          <Button
+            variant="primary"
+            onPress={() => handleVerify(code)}
+            isDisabled={code.length !== 6 || loading}
+            className="w-full"
+            accessibilityLabel="Verify code"
+          >
+            {loading ? "Verifying..." : "Verify"}
+          </Button>
+        </Card.Footer>
+      </Card>
+
+      <View className="items-center gap-2">
+        <Button
+          variant="ghost"
+          size="sm"
+          isDisabled={resendCooldown > 0}
+          onPress={handleResend}
+          accessibilityLabel={
+            resendCooldown > 0
+              ? `Resend code available in ${resendCooldown} seconds`
+              : "Resend code"
+          }
+        >
+          {resendCooldown > 0 ? `Resend code (${resendCooldown}s)` : "Resend code"}
+        </Button>
+
+        <Button
+          variant="ghost"
+          size="sm"
+          isDisabled={loading}
+          onPress={onEditNumber}
+          accessibilityLabel="Edit phone number"
+        >
+          Edit number
+        </Button>
+      </View>
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `EnterCodeView` component at `src/components/onboarding/phone/EnterCodeView.tsx`
- Renders `VerificationCodeInput`, Verify button, Resend button (with 30s cooldown), and Edit number link
- On code complete (6 digits), automatically triggers verification via `confirmVerification` then syncs to Convex via `syncVerifiedPhone` action
- Resend uses `addAndStartVerification` and resets the 30-second cooldown timer
- Shows phone with last 4 digits visible (`•••••• XXXX`) in the subheading
- Includes Storybook story file covering Default, WithCodeEntered, Loading, WithError, ResendAvailable, and ResendWithCountdown states

## Test Plan

- [ ] Open the onboarding phone verification flow
- [ ] Confirm subheading shows masked phone with last 4 digits visible
- [ ] Enter a 6-digit code — Verify button enables; auto-triggers on completion
- [ ] Submit an invalid code — Clerk error message appears inline
- [ ] Verify resend button shows `Resend code (30s)` on mount, counts down, then enables
- [ ] Tap Resend — cooldown resets to 30s
- [ ] Tap Edit number — `onEditNumber` called, navigates back
- [ ] Successful verification — `onVerified` called after syncVerifiedPhone succeeds

## Checklist

- [x] TypeScript compiles with zero errors
- [x] Lint passes (0 warnings, 0 errors)
- [x] Formatting passes
- [x] Tests pass (418/418)

Closes #210