### PR TITLE
refactor(convex): #212 remove phone arg from completeOnboarding and add server guard

### DIFF
--- a/convex/users/mutations.test.ts
+++ b/convex/users/mutations.test.ts
@@ -19,8 +19,23 @@ async function makeTestWithUser() {
     ctx.db.insert("users", {
       externalAuthId: identity.subject,
       email: "me@example.com",
-      hasCompletedOnboarding: true,
+      hasCompletedOnboarding: false,
       isPublic: false,
+      phone: "+447700000000",
+    }),
+  );
+  return t;
+}
+
+async function makeTestUserWithPhone(phone: string | undefined) {
+  const t = convexTest(schema, modules);
+  await t.run((ctx) =>
+    ctx.db.insert("users", {
+      externalAuthId: identity.subject,
+      email: "me@example.com",
+      hasCompletedOnboarding: false,
+      isPublic: false,
+      ...(phone !== undefined && { phone }),
     }),
   );
   return t;
@@ -65,6 +80,46 @@ describe("completeOnboarding string length validation", () => {
       lastName: "Smith",
       userType: "crew",
     });
+  });
+});
+
+describe("completeOnboarding phone guard", () => {
+  test("throws when user has no phone set", async () => {
+    const t = await makeTestUserWithPhone(undefined);
+    await expect(
+      t.withIdentity(identity).mutation(api.users.mutations.completeOnboarding, {
+        firstName: "Alice",
+        lastName: "Smith",
+        userType: "crew",
+      }),
+    ).rejects.toThrow("Cannot complete onboarding: phone is not set.");
+  });
+
+  test("throws when user phone is empty string", async () => {
+    const t = await makeTestUserWithPhone("");
+    await expect(
+      t.withIdentity(identity).mutation(api.users.mutations.completeOnboarding, {
+        firstName: "Alice",
+        lastName: "Smith",
+        userType: "crew",
+      }),
+    ).rejects.toThrow("Cannot complete onboarding: phone is not set.");
+  });
+
+  test("succeeds when user has a phone set", async () => {
+    const t = await makeTestUserWithPhone("+447700000000");
+    await t.withIdentity(identity).mutation(api.users.mutations.completeOnboarding, {
+      firstName: "Alice",
+      lastName: "Smith",
+      userType: "crew",
+    });
+    const user = await t.run((ctx) =>
+      ctx.db
+        .query("users")
+        .withIndex("byExternalAuthId", (q) => q.eq("externalAuthId", identity.subject))
+        .unique(),
+    );
+    expect(user?.hasCompletedOnboarding).toBe(true);
   });
 });
 

--- a/convex/users/mutations.ts
+++ b/convex/users/mutations.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { ConvexError, v } from "convex/values";
 import { z } from "zod";
 
 import { mutation } from "../_generated/server";
@@ -35,7 +35,6 @@ export const completeOnboarding = mutation({
   args: {
     firstName: v.string(),
     lastName: v.string(),
-    phone: v.optional(v.string()),
     city: v.optional(v.string()),
     userType: v.union(v.literal("crew"), v.literal("production-manager")),
     departments: v.optional(v.array(v.string())),
@@ -47,12 +46,15 @@ export const completeOnboarding = mutation({
     const user = await getUserByExternalId(ctx, identity.subject);
     if (!user) throw new Error("User not found");
 
+    if (!user.phone || user.phone === "") {
+      throw new ConvexError("Cannot complete onboarding: phone is not set.");
+    }
+
     parseOrConvexError(completeOnboardingSchema, args);
 
     await ctx.db.patch(user._id, {
       firstName: args.firstName,
       lastName: args.lastName,
-      ...(args.phone && { phone: args.phone }),
       ...(args.city && { city: args.city }),
       userType: args.userType,
       ...(args.departments?.[0] && { department: args.departments[0] }),


### PR DESCRIPTION
## Summary

- Removes `phone` from `completeOnboarding` mutation args — phone is now written exclusively via the internal mutations triggered by the Clerk webhook / `syncVerifiedPhone` action
- Adds a defensive server-side guard: throws `ConvexError` if the resolved user document has no phone or an empty phone string
- Adds three new test scenarios covering the guard (no phone, empty phone, valid phone)
- Updates existing test helper to include a phone so prior success tests continue to pass

## Test Plan

- `npm run test` — all 421 tests pass
- `npx tsc --noEmit` — zero errors
- `npm run lint` — zero warnings/errors
- `npm run fmt:check` — all files correctly formatted

## Checklist

- [x] TypeScript compiles with zero errors
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass

Closes #212