### PR TITLE
feat(settings): #213 add change-phone-number flow

### DIFF
--- a/src/app/(home)/profile.tsx
+++ b/src/app/(home)/profile.tsx
@@ -39,7 +39,9 @@ export default function Profile() {
         <View className="flex-row items-center justify-between px-4 py-4">
           <Text className="text-base">Phone number</Text>
           <View className="flex-row items-center gap-1">
-            <Text className="text-base text-default-500">{formatPhone(currentUser?.phone)}</Text>
+            <Text className="text-base text-default-500">
+              {currentUser === undefined ? "" : formatPhone(currentUser?.phone)}
+            </Text>
             <Text className="text-default-400 text-lg">›</Text>
           </View>
         </View>

--- a/src/app/(home)/profile.tsx
+++ b/src/app/(home)/profile.tsx
@@ -1,18 +1,57 @@
 import { useClerk, useUser } from "@clerk/expo";
-import { Button } from "heroui-native";
+import { api } from "@convex/_generated/api";
+import { useQuery } from "convex/react";
+import { useRouter } from "expo-router";
+import { Button, PressableFeedback, Separator } from "heroui-native";
+import { parsePhoneNumberFromString } from "libphonenumber-js";
 import { Text, View } from "react-native";
+
+function formatPhone(phone: string | undefined | null): string {
+  if (!phone) return "Not set";
+  try {
+    const parsed = parsePhoneNumberFromString(phone);
+    return parsed?.formatNational() ?? phone;
+  } catch {
+    return phone;
+  }
+}
 
 export default function Profile() {
   const { user } = useUser();
   const { signOut } = useClerk();
+  const router = useRouter();
+  const currentUser = useQuery(api.users.queries.getCurrentUser);
 
   return (
-    <View className="flex-1 items-center justify-center gap-4">
-      <Text className="text-2xl font-bold">Profile</Text>
-      <Text className="text-base text-default-500">{user?.emailAddresses[0]?.emailAddress}</Text>
-      <Button variant="danger-soft" onPress={() => signOut()}>
-        Sign out
-      </Button>
+    <View className="flex-1 pt-8">
+      <View className="items-center gap-2 py-6">
+        <Text className="text-2xl font-bold">Profile</Text>
+        <Text className="text-base text-default-500">{user?.emailAddresses[0]?.emailAddress}</Text>
+      </View>
+
+      <Separator />
+
+      <PressableFeedback
+        onPress={() => router.push("/settings/phone")}
+        accessibilityRole="button"
+        accessibilityLabel="Change phone number"
+      >
+        <View className="flex-row items-center justify-between px-4 py-4">
+          <Text className="text-base">Phone number</Text>
+          <View className="flex-row items-center gap-1">
+            <Text className="text-base text-default-500">{formatPhone(currentUser?.phone)}</Text>
+            <Text className="text-default-400 text-lg">›</Text>
+          </View>
+        </View>
+      </PressableFeedback>
+
+      <Separator />
+
+      <View className="items-center mt-8">
+        <Button variant="danger-soft" onPress={() => signOut()}>
+          Sign out
+        </Button>
+      </View>
     </View>
   );
 }

--- a/src/app/settings/phone.tsx
+++ b/src/app/settings/phone.tsx
@@ -1,0 +1,56 @@
+import { useUser } from "@clerk/expo";
+import { useRouter } from "expo-router";
+import { useEffect, useRef, useState } from "react";
+import { View } from "react-native";
+import { ScrollView } from "react-native-gesture-handler";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { withUniwind } from "uniwind";
+
+import { EnterCodeView } from "@/components/onboarding/phone/EnterCodeView";
+import { EnterNumberView } from "@/components/onboarding/phone/EnterNumberView";
+import { BackButton } from "@/components/ui/BackButton";
+import { cancelPendingPhone } from "@/lib/phone/clerk/cancelPendingPhone";
+
+const StyledSafeAreaView = withUniwind(SafeAreaView);
+
+export default function ChangePhoneNumber() {
+  const [view, setView] = useState<"enter-number" | "enter-code">("enter-number");
+  const [pendingE164, setPendingE164] = useState("");
+  const { user } = useUser();
+  const router = useRouter();
+  const hasCleanedUp = useRef(false);
+
+  useEffect(() => {
+    if (user && !hasCleanedUp.current) {
+      hasCleanedUp.current = true;
+      void cancelPendingPhone({ user });
+    }
+  }, [user]);
+
+  return (
+    <StyledSafeAreaView className="flex-1">
+      <BackButton onPress={() => router.back()} />
+      <ScrollView contentContainerStyle={{ flexGrow: 1 }} keyboardShouldPersistTaps="handled">
+        <View className="flex-1 gap-6 py-2">
+          {view === "enter-number" ? (
+            <EnterNumberView
+              onCodeSent={(e164) => {
+                setPendingE164(e164);
+                setView("enter-code");
+              }}
+            />
+          ) : (
+            <EnterCodeView
+              phoneE164={pendingE164}
+              onVerified={() => router.back()}
+              onEditNumber={() => {
+                if (user) void cancelPendingPhone({ user });
+                setView("enter-number");
+              }}
+            />
+          )}
+        </View>
+      </ScrollView>
+    </StyledSafeAreaView>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a **Phone number** row to the Profile/Settings screen (`src/app/(home)/profile.tsx`) showing the user's verified number formatted in national style, with a tap target that navigates to the edit screen
- Creates `src/app/settings/phone.tsx` — a new screen that reuses `EnterNumberView` and `EnterCodeView` from the onboarding flow to guide the user through an OTP-verified phone change
- Reads the current phone from the existing `api.users.queries.getCurrentUser` Convex query; live query updates automatically reflect the new number on the Settings row after verification succeeds

## Test Plan

- [ ] Tap "Phone number" row in Profile → opens the Change phone number screen
- [ ] Enter a new UK/US number and submit → receive SMS → enter code → returns to Profile with new number shown in national format
- [ ] Abandon mid-flow (press Back during OTP entry) → Profile still shows the original number
- [ ] TypeScript compiles with zero errors
- [ ] Lint passes
- [ ] Formatting passes
- [ ] All 421 tests pass

Closes #213