### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Potential fix for [https://github.com/ChazUK/crewcircle-app/security/code-scanning/1](https://github.com/ChazUK/crewcircle-app/security/code-scanning/1)

Add an explicit `permissions` block for the `lint` job in `.github/workflows/ci.yml` so the job follows least privilege.  
Best minimal fix without changing behavior: set:

```yml
permissions:
  contents: read
```

under `jobs.lint` (at the same level as `runs-on` and `steps`).  
No imports, methods, or extra definitions are needed since this is YAML workflow configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
