### PR TITLE
feat(observability): #232 add reportError helper with unit test

### DIFF
--- a/src/lib/observability/reportError.test.ts
+++ b/src/lib/observability/reportError.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@sentry/react-native", () => ({
+  captureException: vi.fn(),
+  withScope: vi.fn(),
+}));
+
+import * as Sentry from "@sentry/react-native";
+
+import { reportError } from "./reportError";
+
+const mockCaptureException = vi.mocked(Sentry.captureException);
+const mockWithScope = vi.mocked(Sentry.withScope);
+
+function makeMockScope() {
+  return {
+    setTag: vi.fn(),
+    setExtra: vi.fn(),
+    setLevel: vi.fn(),
+    setFingerprint: vi.fn(),
+  };
+}
+
+describe("reportError", () => {
+  let scope: ReturnType<typeof makeMockScope>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    scope = makeMockScope();
+    mockWithScope.mockImplementation((cb) => {
+      cb(scope as never);
+    });
+  });
+
+  test("forwards an Error instance unchanged to captureException", () => {
+    const error = new Error("original");
+    reportError(error);
+    expect(mockCaptureException).toHaveBeenCalledWith(error);
+  });
+
+  test("converts a string to an Error with that message", () => {
+    reportError("something went wrong");
+    const captured = mockCaptureException.mock.calls[0]?.[0] as Error;
+    expect(captured).toBeInstanceOf(Error);
+    expect(captured.message).toBe("something went wrong");
+  });
+
+  test("converts null to an Error with message 'Unknown error (null/undefined thrown)'", () => {
+    reportError(null);
+    const captured = mockCaptureException.mock.calls[0]?.[0] as Error;
+    expect(captured).toBeInstanceOf(Error);
+    expect(captured.message).toBe("Unknown error (null/undefined thrown)");
+  });
+
+  test("converts undefined to an Error with message 'Unknown error (null/undefined thrown)'", () => {
+    reportError(undefined);
+    const captured = mockCaptureException.mock.calls[0]?.[0] as Error;
+    expect(captured).toBeInstanceOf(Error);
+    expect(captured.message).toBe("Unknown error (null/undefined thrown)");
+  });
+
+  test("converts a plain object to an Error and attaches it as extra.originalValue", () => {
+    const obj = { code: 42, reason: "timeout" };
+    reportError(obj);
+    const captured = mockCaptureException.mock.calls[0]?.[0] as Error;
+    expect(captured).toBeInstanceOf(Error);
+    expect(scope.setExtra).toHaveBeenCalledWith("originalValue", obj);
+  });
+
+  test("applies tags via scope.setTag", () => {
+    reportError(new Error("test"), { tags: { component: "auth", env: "prod" } });
+    expect(scope.setTag).toHaveBeenCalledWith("component", "auth");
+    expect(scope.setTag).toHaveBeenCalledWith("env", "prod");
+  });
+
+  test("applies extra via scope.setExtra", () => {
+    reportError(new Error("test"), { extra: { userId: "u-123" } });
+    expect(scope.setExtra).toHaveBeenCalledWith("userId", "u-123");
+  });
+
+  test("defaults level to 'error' when not specified", () => {
+    reportError(new Error("test"));
+    expect(scope.setLevel).toHaveBeenCalledWith("error");
+  });
+
+  test("applies the level from context when specified", () => {
+    reportError(new Error("test"), { level: "fatal" });
+    expect(scope.setLevel).toHaveBeenCalledWith("fatal");
+  });
+
+  test("applies fingerprint when specified", () => {
+    reportError(new Error("test"), { fingerprint: ["my-error", "module-a"] });
+    expect(scope.setFingerprint).toHaveBeenCalledWith(["my-error", "module-a"]);
+  });
+
+  test("does not call setFingerprint when fingerprint is not provided", () => {
+    reportError(new Error("test"));
+    expect(scope.setFingerprint).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/observability/reportError.ts
+++ b/src/lib/observability/reportError.ts
@@ -1,0 +1,41 @@
+import * as Sentry from "@sentry/react-native";
+
+type ErrorContext = {
+  tags?: Record<string, string>;
+  extra?: Record<string, unknown>;
+  level?: "fatal" | "error" | "warning";
+  fingerprint?: string[];
+};
+
+function normalise(error: unknown): { error: Error; extra?: Record<string, unknown> } {
+  if (error instanceof Error) return { error };
+  if (typeof error === "string") return { error: new Error(error) };
+  if (error === null || error === undefined)
+    return { error: new Error("Unknown error (null/undefined thrown)") };
+  return { error: new Error("Non-error value thrown"), extra: { originalValue: error } };
+}
+
+export function reportError(error: unknown, context?: ErrorContext): void {
+  const { error: normalisedError, extra: normalisedExtra } = normalise(error);
+
+  Sentry.withScope((scope) => {
+    if (context?.tags) {
+      for (const [k, v] of Object.entries(context.tags)) {
+        scope.setTag(k, v);
+      }
+    }
+
+    const mergedExtra = { ...normalisedExtra, ...context?.extra };
+    for (const [k, v] of Object.entries(mergedExtra)) {
+      scope.setExtra(k, v);
+    }
+
+    scope.setLevel(context?.level ?? "error");
+
+    if (context?.fingerprint) {
+      scope.setFingerprint(context.fingerprint);
+    }
+
+    Sentry.captureException(normalisedError);
+  });
+}


### PR DESCRIPTION
## Summary

- Adds `src/lib/observability/reportError.ts` exporting a single `reportError(error, context?)` function
- Normalises any thrown value into a real `Error` before forwarding to `Sentry.captureException`
- Applies optional `tags`, `extra`, `level` (default `"error"`), and `fingerprint` via `Sentry.withScope`

## Normalisation rules

| Input type | Behaviour |
|---|---|
| `Error` instance | Forwarded unchanged |
| `string` | Wrapped in `new Error(message)` |
| `null` / `undefined` | `new Error("Unknown error (null/undefined thrown)")` |
| Plain object | `new Error("Non-error value thrown")` + `extra.originalValue = obj` |

## Test Plan

- 11 vitest unit tests covering all five normalisation paths and all scope-application paths
- `@sentry/react-native` fully mocked — no real Sentry calls in CI
- All 543 tests pass, lint clean, pre-commit hooks pass

## Checklist

- [x] TypeScript compiles with zero errors (new files only — pre-existing errors in stories unrelated to this change)
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass (543/543)

Closes #232