### PR TITLE
feat(observability): #234 bind Clerk user id to Sentry user context

### DIFF
--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -15,6 +15,7 @@ import { AppState } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 
 import { AppErrorBoundary } from "@/components/ui/AppErrorBoundary";
+import { useSentryUser } from "@/hooks/useSentryUser";
 import { registerBackgroundSync } from "@/lib/calendars/backgroundSync";
 import { syncNativeConnections } from "@/lib/calendars/syncNativeConnections";
 import { getDeviceId } from "@/lib/devices/getDeviceId";
@@ -72,6 +73,7 @@ function RootNavigator() {
   const ref = useNavigationContainerRef();
   const { isLoading, isAuthenticated } = useConvexAuth();
   const { isSignedIn, signOut } = useAuth();
+  useSentryUser();
   const upsertUser = useMutation(api.users.mutations.upsertUser);
   const currentUser = useQuery(api.users.queries.getCurrentUser, isAuthenticated ? {} : "skip");
   const syncNativeOnOpenAction = useAction(api.calendars.actions.syncNativeOnOpen);

--- a/src/hooks/useSentryUser.ts
+++ b/src/hooks/useSentryUser.ts
@@ -1,0 +1,15 @@
+import { useAuth } from "@clerk/expo";
+import * as Sentry from "@sentry/react-native";
+import { useEffect } from "react";
+
+export function useSentryUser(): void {
+  const { userId } = useAuth();
+
+  useEffect(() => {
+    if (userId != null) {
+      Sentry.setUser({ id: userId });
+    } else {
+      Sentry.setUser(null);
+    }
+  }, [userId]);
+}


### PR DESCRIPTION
## Summary

- Adds `src/hooks/useSentryUser.ts` — a hook that subscribes to `useAuth()` from `@clerk/expo` and keeps Sentry's user context in sync
- Calls `Sentry.setUser({ id: userId })` when Clerk `userId` is non-null; calls `Sentry.setUser(null)` when it transitions back to null
- Wires `useSentryUser()` once into `RootNavigator` in `src/app/_layout.tsx` alongside existing auth effects
- Only the opaque Clerk user id is attached — no email, name, or other PII fields

## Test Plan

- TypeScript compiles with zero errors (pre-existing unrelated errors excluded)
- Lint passes (0 warnings, 0 errors)
- Formatting passes
- All 543 tests pass across 66 test files

Manual smoke test:
1. Sign in → trigger an error → confirm Sentry event shows `user.id` matching Clerk user id
2. Sign out → trigger an error → confirm Sentry event has no user attached

## Checklist
- [x] TypeScript compiles with zero errors
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass (543/543)

Closes #234