### PR TITLE
refactor(observability): #235 replace AppErrorBoundary with Sentry.ErrorBoundary

### DIFF
--- a/src/components/ui/AppErrorBoundary.tsx
+++ b/src/components/ui/AppErrorBoundary.tsx
@@ -1,14 +1,11 @@
+import * as Sentry from "@sentry/react-native";
 import { Button } from "heroui-native";
 import React from "react";
 import { Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
-type Props = {
+type AppErrorBoundaryProps = {
   children: React.ReactNode;
-};
-
-type State = {
-  hasError: boolean;
 };
 
 export type ErrorFallbackProps = {
@@ -33,21 +30,10 @@ export function ErrorFallback({ onReset }: ErrorFallbackProps) {
   );
 }
 
-export class AppErrorBoundary extends React.Component<Props, State> {
-  state: State = { hasError: false };
-
-  static getDerivedStateFromError(): State {
-    return { hasError: true };
-  }
-
-  componentDidCatch(error: Error, info: React.ErrorInfo): void {
-    console.error("[ErrorBoundary]", error, info);
-  }
-
-  render() {
-    if (this.state.hasError) {
-      return <ErrorFallback onReset={() => this.setState({ hasError: false })} />;
-    }
-    return this.props.children;
-  }
+export function AppErrorBoundary({ children }: AppErrorBoundaryProps) {
+  return (
+    <Sentry.ErrorBoundary fallback={({ resetError }) => <ErrorFallback onReset={resetError} />}>
+      {children}
+    </Sentry.ErrorBoundary>
+  );
 }


### PR DESCRIPTION
## Summary

- Replaces the bespoke `AppErrorBoundary` class component with a thin wrapper around `Sentry.ErrorBoundary` from `@sentry/react-native`
- `ErrorFallback` is passed as the `fallback` render prop; Sentry's `resetError` is wired to the `onReset` handler
- Sentry auto-captures errors with `mechanism: errorboundary` and the React component stack, so the manual `componentDidCatch` plumbing is removed
- Named exports `AppErrorBoundary` and `ErrorFallback` are preserved with unchanged public shapes — no callers change

## Test Plan

- [ ] TypeScript compiles with zero errors in changed file (`npx tsc --noEmit` — pre-existing errors in unrelated files are unchanged)
- [ ] Lint passes (`npm run lint`)
- [ ] All 543 tests pass (`npm run test`)
- [ ] Storybook story renders: `AppErrorBoundary.stories.tsx` uses both `ErrorFallback` and `AppErrorBoundary` exports unchanged
- [ ] Manual smoke test: throw inside a child component → `ErrorFallback` renders, Sentry event arrives tagged `mechanism: errorboundary` with component stack

## Checklist
- [x] TypeScript compiles with zero errors (in changed file)
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass (543/543)

Closes #235