### PR TITLE
refactor(observability): #238 migrate console.error sites in src/ to reportError

### DIFF
--- a/src/app/(auth)/forgot-password.tsx
+++ b/src/app/(auth)/forgot-password.tsx
@@ -10,6 +10,7 @@ import { withUniwind } from "uniwind";
 
 import { BackButton } from "@/components/ui/BackButton";
 import { VerifyCodeScreen } from "@/components/ui/VerifyCodeScreen";
+import { reportError } from "@/lib/observability/reportError";
 import { getClerkErrorMessage } from "@/utils/clerkErrors";
 
 type Step = "email" | "code" | "new-password" | "mfa";
@@ -122,8 +123,9 @@ export default function Page() {
           setStep("mfa");
         }
       } else {
-        console.error(
-          `[forgot-password] Unexpected sign-in status after password reset: "${signIn.status}".`,
+        reportError(
+          new Error(`Unexpected sign-in status after password reset: "${signIn.status}"`),
+          { tags: { area: "auth.forgotPassword" } },
         );
       }
     },
@@ -165,7 +167,9 @@ export default function Page() {
           },
         });
       } else {
-        console.error("Sign-in attempt not complete after MFA:", signIn);
+        reportError(new Error(`Sign-in attempt not complete after MFA: status=${signIn.status}`), {
+          tags: { area: "auth.forgotPassword" },
+        });
       }
     },
   });

--- a/src/app/(auth)/sign-in.tsx
+++ b/src/app/(auth)/sign-in.tsx
@@ -21,6 +21,7 @@ import { SignInWithAppleButton } from "@/components/auth/SignInWithAppleButton";
 import { SignInWithGoogleButton } from "@/components/auth/SignInWithGoogleButton";
 import { BackButton } from "@/components/ui/BackButton";
 import { VerifyCodeScreen } from "@/components/ui/VerifyCodeScreen";
+import { reportError } from "@/lib/observability/reportError";
 import { getClerkErrorMessage } from "@/utils/clerkErrors";
 
 const StyledSafeAreaView = withUniwind(SafeAreaView);
@@ -92,7 +93,9 @@ export default function Page() {
           await signIn.mfa.sendEmailCode();
         }
       } else {
-        console.error("Sign-in attempt not complete:", signIn);
+        reportError(new Error(`Sign-in attempt not complete: status=${signIn.status}`), {
+          tags: { area: "auth.signIn" },
+        });
       }
     },
   });
@@ -121,7 +124,9 @@ export default function Page() {
           throw e;
         }
       } else {
-        console.error("Sign-in attempt not complete:", signIn);
+        reportError(new Error(`Sign-in attempt not complete: status=${signIn.status}`), {
+          tags: { area: "auth.signIn" },
+        });
       }
     },
   });

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -20,6 +20,7 @@ import { useSentryUser } from "@/hooks/useSentryUser";
 import { registerBackgroundSync } from "@/lib/calendars/backgroundSync";
 import { syncNativeConnections } from "@/lib/calendars/syncNativeConnections";
 import { getDeviceId } from "@/lib/devices/getDeviceId";
+import { reportError } from "@/lib/observability/reportError";
 
 const sentryDsn = process.env.EXPO_PUBLIC_SENTRY_DSN!;
 if (!sentryDsn) throw new Error("Add EXPO_PUBLIC_SENTRY_DSN to the .env file");
@@ -102,7 +103,7 @@ function RootNavigator() {
       initialDesyncCheckDone.current = true;
 
       if (isSignedIn && !isAuthenticated)
-        signOut().catch((err) => console.error("Failed to sign out stale Clerk session:", err));
+        signOut().catch((err) => reportError(err, { tags: { area: "auth.signOut" } }));
     }
   }, [isLoading, isSignedIn, isAuthenticated, signOut]);
 
@@ -114,7 +115,7 @@ function RootNavigator() {
 
     upsertUser()
       .then(() => setIsUserReady(true))
-      .catch((err) => console.error("Failed to upsert user:", err));
+      .catch((err) => reportError(err, { tags: { area: "users.upsert" } }));
   }, [isAuthenticated]);
 
   // Keep the splash visible until auth has resolved AND (if authenticated)
@@ -167,10 +168,10 @@ function RootNavigator() {
           return;
         } catch (err) {
           if (!isConnectionLost(err) || attempt === delays.length) {
-            console.error(
-              `[RootNavigator] native sync failed (trigger=${trigger}, attempt=${attempt + 1})`,
-              err,
-            );
+            reportError(err, {
+              tags: { area: "calendar.nativeSync" },
+              extra: { trigger, attempt },
+            });
             return;
           }
           console.warn(
@@ -203,7 +204,7 @@ function RootNavigator() {
     if (!isUserReady) return;
     if (process.env.EXPO_PUBLIC_ENABLE_NATIVE_BACKGROUND_SYNC !== "true") return;
     registerBackgroundSync().catch((err) =>
-      console.error("[RootNavigator] failed to register background sync", err),
+      reportError(err, { tags: { area: "calendar.backgroundSync" } }),
     );
   }, [isUserReady]);
 

--- a/src/components/auth/SignInWithAppleButton.tsx
+++ b/src/components/auth/SignInWithAppleButton.tsx
@@ -3,6 +3,8 @@ import * as AppleAuthentication from "expo-apple-authentication";
 import { useRouter } from "expo-router";
 import { Alert, Platform } from "react-native";
 
+import { reportError } from "@/lib/observability/reportError";
+
 type Props = {
   onSignInComplete?: () => void;
 };
@@ -33,7 +35,7 @@ export function SignInWithAppleButton({ onSignInComplete }: Props) {
 
       const message = err instanceof Error ? err.message : "An error occurred during Apple sign-in";
       Alert.alert("Error", message);
-      console.error("Sign in with Apple error:", JSON.stringify(err, null, 2));
+      reportError(err, { tags: { area: "auth.apple" } });
     }
   };
 

--- a/src/components/auth/SignInWithGoogleButton.tsx
+++ b/src/components/auth/SignInWithGoogleButton.tsx
@@ -3,6 +3,8 @@ import { useRouter } from "expo-router";
 import { Button } from "heroui-native";
 import { Alert, Platform } from "react-native";
 
+import { reportError } from "@/lib/observability/reportError";
+
 import { GoogleIcon } from "../ui/icons/Google";
 
 type Props = {
@@ -36,7 +38,7 @@ export function SignInWithGoogleButton({ onSignInComplete }: Props) {
       const message =
         err instanceof Error ? err.message : "An error occurred during Google sign-in";
       Alert.alert("Error", message);
-      console.error("Sign in with Google error:", JSON.stringify(err, null, 2));
+      reportError(err, { tags: { area: "auth.google" } });
     }
   };
 

--- a/src/components/calendars/hooks/useCalendarSync.ts
+++ b/src/components/calendars/hooks/useCalendarSync.ts
@@ -4,6 +4,7 @@ import { useAction } from "convex/react";
 import { useState } from "react";
 
 import { fetchNativeEvents } from "@/lib/calendars/fetchNativeEvents";
+import { reportError } from "@/lib/observability/reportError";
 
 import type { ConnectionRow } from "../CalendarConnectionList";
 
@@ -28,7 +29,7 @@ export function useCalendarSync() {
       const events = await fetchNativeEvents(nativeCalendarIds, syncWindow);
       await uploadNativeEventsAction({ connectionId, events });
     } catch (err) {
-      console.error("[useCalendarSync] native sync failed", err);
+      reportError(err, { tags: { area: "calendar.nativeSync" } });
     } finally {
       setSyncingIds((prev) => {
         const next = new Set(prev);
@@ -47,7 +48,7 @@ export function useCalendarSync() {
     try {
       await syncNowAction({ connectionId: connection._id });
     } catch (err) {
-      console.error("[useCalendarSync] sync failed", err);
+      reportError(err, { tags: { area: "calendar.sync" } });
     } finally {
       setSyncingIds((prev) => {
         const next = new Set(prev);

--- a/src/components/contacts/IncomingInvitesList.tsx
+++ b/src/components/contacts/IncomingInvitesList.tsx
@@ -7,6 +7,7 @@ import { Text, View } from "react-native";
 
 import { useAcceptContactInvite } from "@/hooks/contacts/useAcceptContactInvite";
 import { useDeclineContactInvite } from "@/hooks/contacts/useDeclineContactInvite";
+import { reportError } from "@/lib/observability/reportError";
 
 import { IncomingInviteRow } from "./IncomingInviteRow";
 
@@ -26,7 +27,7 @@ export function IncomingInvitesList() {
       if (action === "accept") await acceptInvite(inviteId);
       else await declineInvite(inviteId);
     } catch (err) {
-      console.error(`[IncomingInvitesList] ${action} failed`, err);
+      reportError(err, { tags: { area: "contacts.invite" }, extra: { action } });
     } finally {
       setBusyIds((prev) => {
         const next = new Set(prev);

--- a/src/components/ui/AppErrorBoundary.tsx
+++ b/src/components/ui/AppErrorBoundary.tsx
@@ -3,6 +3,8 @@ import React from "react";
 import { Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
+import { reportError } from "@/lib/observability/reportError";
+
 type Props = {
   children: React.ReactNode;
 };
@@ -41,7 +43,10 @@ export class AppErrorBoundary extends React.Component<Props, State> {
   }
 
   componentDidCatch(error: Error, info: React.ErrorInfo): void {
-    console.error("[ErrorBoundary]", error, info);
+    reportError(error, {
+      tags: { area: "ui.errorBoundary" },
+      extra: { componentStack: info.componentStack },
+    });
   }
 
   render() {

--- a/src/lib/calendars/syncNativeConnections.ts
+++ b/src/lib/calendars/syncNativeConnections.ts
@@ -1,6 +1,7 @@
 import type { Id } from "@convex/_generated/dataModel";
 import type { IncomingEvent, SyncWindow } from "@shared/calendars";
 
+import { reportError } from "../observability/reportError";
 import { fetchNativeEvents } from "./fetchNativeEvents";
 
 export type NativeConnectionToSync = {
@@ -39,7 +40,7 @@ export async function syncNativeConnections(
       // and rethrow at the end so the caller (background-fetch) can
       // signal Failed to the OS scheduler instead of NewData.
       const error = err instanceof Error ? err : new Error(String(err));
-      console.error("[syncNativeConnections] sync failed for connection", connectionId, error);
+      reportError(error, { tags: { area: "calendar.nativeConnection" }, extra: { connectionId } });
       errors.push(error);
     }
   }


### PR DESCRIPTION
## Summary

- Replaces all caught-error `console.error` call sites in `src/` with `reportError` from `src/lib/observability/reportError.ts`, tagging each with an `area` label for Sentry grouping
- Migrates 4 target sites in `src/app/_layout.tsx` (auth.signOut, users.upsert, calendar.nativeSync with trigger+attempt extra, calendar.backgroundSync)
- Also migrates catch-block sites in: `IncomingInvitesList`, `SignInWithAppleButton`, `SignInWithGoogleButton`, `AppErrorBoundary.componentDidCatch`, `useCalendarSync`, and `syncNativeConnections`
- Migrates unexpected-state branches in auth flows (sign-in MFA not complete, forgot-password unexpected status) as application logic errors
- Leaves Clerk-returned user input errors (`if (error)` blocks in auth forms) as `console.error` — these are expected user-facing auth failures that would create Sentry noise

## Test Plan

- [ ] TypeScript compiles with zero errors (pre-existing story file errors only, unrelated to this change)
- [ ] Lint passes (oxlint: 0 warnings, 0 errors)
- [ ] Formatting passes for all modified files
- [ ] All 543 tests pass
- [ ] Manual smoke test: temporarily break the Convex URL → `users.upsert` error arrives in Sentry with `area: "users.upsert"` tag

## Checklist
- [x] TypeScript compiles with zero errors (in modified files)
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass (543/543)

Closes #238