### PR TITLE
feat(profile): #266 visibility resolver and shared types

### DIFF
--- a/convex/users/lib/resolveProfileVisibility.test.ts
+++ b/convex/users/lib/resolveProfileVisibility.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "vitest";
+
+import type { Id } from "../../_generated/dataModel";
+import { resolveProfileVisibility } from "./resolveProfileVisibility";
+
+const userId1 = "userId1" as Id<"users">;
+const userId2 = "userId2" as Id<"users">;
+
+describe("resolveProfileVisibility", () => {
+  test("viewer is same crew user as subject → self", () => {
+    expect(
+      resolveProfileVisibility({
+        viewerUserId: userId1,
+        subject: { _id: userId1, userType: "crew", isPublic: false },
+        isContact: false,
+      }),
+    ).toEqual({ mode: "self" });
+  });
+
+  test("viewer is same PM user as subject → pm-self", () => {
+    expect(
+      resolveProfileVisibility({
+        viewerUserId: userId1,
+        subject: { _id: userId1, userType: "production-manager", isPublic: false },
+        isContact: false,
+      }),
+    ).toEqual({ mode: "pm-self" });
+  });
+
+  test("subject is PM other than viewer → hidden", () => {
+    expect(
+      resolveProfileVisibility({
+        viewerUserId: userId1,
+        subject: { _id: userId2, userType: "production-manager", isPublic: false },
+        isContact: false,
+      }),
+    ).toEqual({ mode: "hidden" });
+  });
+
+  test("subject is crew, viewer is different, isContact true → contact", () => {
+    expect(
+      resolveProfileVisibility({
+        viewerUserId: userId1,
+        subject: { _id: userId2, userType: "crew", isPublic: false },
+        isContact: true,
+      }),
+    ).toEqual({ mode: "contact" });
+  });
+
+  test("subject is crew, viewer is different, isContact false, isPublic true → public-card", () => {
+    expect(
+      resolveProfileVisibility({
+        viewerUserId: userId1,
+        subject: { _id: userId2, userType: "crew", isPublic: true },
+        isContact: false,
+      }),
+    ).toEqual({ mode: "public-card" });
+  });
+
+  test("subject is crew, viewer is different, isContact false, isPublic false → hidden", () => {
+    expect(
+      resolveProfileVisibility({
+        viewerUserId: userId1,
+        subject: { _id: userId2, userType: "crew", isPublic: false },
+        isContact: false,
+      }),
+    ).toEqual({ mode: "hidden" });
+  });
+
+  test("subject has undefined userType → hidden", () => {
+    expect(
+      resolveProfileVisibility({
+        viewerUserId: userId1,
+        subject: { _id: userId2, userType: undefined, isPublic: false },
+        isContact: false,
+      }),
+    ).toEqual({ mode: "hidden" });
+  });
+});

--- a/convex/users/lib/resolveProfileVisibility.ts
+++ b/convex/users/lib/resolveProfileVisibility.ts
@@ -1,0 +1,43 @@
+import type { ProfileVisibility } from "@shared/profile/visibilityMode";
+
+import type { Id } from "../../_generated/dataModel";
+
+type Args = {
+  viewerUserId: Id<"users"> | null;
+  subject: {
+    _id: Id<"users">;
+    userType: "crew" | "production-manager" | undefined;
+    isPublic: boolean | undefined;
+  };
+  isContact: boolean;
+};
+
+export function resolveProfileVisibility(args: Args): ProfileVisibility {
+  const { viewerUserId, subject, isContact } = args;
+
+  if (subject.userType === undefined) {
+    return { mode: "hidden" };
+  }
+
+  if (viewerUserId === subject._id && subject.userType === "crew") {
+    return { mode: "self" };
+  }
+
+  if (viewerUserId === subject._id && subject.userType === "production-manager") {
+    return { mode: "pm-self" };
+  }
+
+  if (subject.userType === "production-manager") {
+    return { mode: "hidden" };
+  }
+
+  if (isContact === true) {
+    return { mode: "contact" };
+  }
+
+  if (subject.isPublic === true) {
+    return { mode: "public-card" };
+  }
+
+  return { mode: "hidden" };
+}

--- a/types/profile/viewableProfile.ts
+++ b/types/profile/viewableProfile.ts
@@ -1,0 +1,17 @@
+import type { Id } from "@convex/_generated/dataModel";
+
+type ProfileBase = {
+  userId: Id<"users">;
+  firstName: string | undefined;
+  lastName: string | undefined;
+  nickname: string | undefined;
+  profilePictureUrl: string | undefined;
+  userType: "crew" | "production-manager";
+};
+
+export type ViewableProfile =
+  | ({ mode: "self" } & ProfileBase)
+  | ({ mode: "contact" } & ProfileBase)
+  | ({ mode: "public-card" } & ProfileBase)
+  | ({ mode: "pm-self" } & ProfileBase)
+  | ({ mode: "pm-job-linked" } & ProfileBase);

--- a/types/profile/viewableProfile.ts
+++ b/types/profile/viewableProfile.ts
@@ -1,17 +1,21 @@
 import type { Id } from "@convex/_generated/dataModel";
 
-type ProfileBase = {
+type ProfileIdentity = {
   userId: Id<"users">;
   firstName: string | undefined;
   lastName: string | undefined;
   nickname: string | undefined;
   profilePictureUrl: string | undefined;
-  userType: "crew" | "production-manager";
+};
+
+type CrewProfile = ProfileIdentity & { userType: "crew" };
+type ProductionManagerProfile = ProfileIdentity & {
+  userType: "production-manager";
 };
 
 export type ViewableProfile =
-  | ({ mode: "self" } & ProfileBase)
-  | ({ mode: "contact" } & ProfileBase)
-  | ({ mode: "public-card" } & ProfileBase)
-  | ({ mode: "pm-self" } & ProfileBase)
-  | ({ mode: "pm-job-linked" } & ProfileBase);
+  | ({ mode: "self" } & CrewProfile)
+  | ({ mode: "contact" } & CrewProfile)
+  | ({ mode: "public-card" } & CrewProfile)
+  | ({ mode: "pm-self" } & ProductionManagerProfile)
+  | ({ mode: "pm-job-linked" } & ProductionManagerProfile);

--- a/types/profile/visibilityMode.ts
+++ b/types/profile/visibilityMode.ts
@@ -1,0 +1,15 @@
+export type VisibilityMode =
+  | "self"
+  | "contact"
+  | "public-card"
+  | "pm-self"
+  | "pm-job-linked"
+  | "hidden";
+
+export type ProfileVisibility =
+  | { mode: "self" }
+  | { mode: "contact" }
+  | { mode: "public-card" }
+  | { mode: "pm-self" }
+  | { mode: "pm-job-linked" }
+  | { mode: "hidden" };


### PR DESCRIPTION
## Summary

- Adds `VisibilityMode` (string-literal union) and `ProfileVisibility` (discriminated union) to `types/profile/visibilityMode.ts`
- Adds `ViewableProfile` discriminated union to `types/profile/viewableProfile.ts` — one variant per non-hidden visibility mode
- Adds pure `resolveProfileVisibility` function in `convex/users/lib/` — no Convex ctx, no DB reads, evaluates seven ordered branches
- Full vitest coverage (7 tests, one per branch)

## Test Plan

- `npx vitest run convex/users/lib/resolveProfileVisibility.test.ts` — all 7 scenarios pass
- `npm run test` — 550 tests pass across 67 files

## Checklist
- [x] TypeScript compiles with zero errors (pre-existing errors in src/ are unrelated)
- [x] Lint passes
- [x] Formatting passes
- [x] All 7 test scenarios pass

Closes #266