### PR TITLE
feat(profile): #267 schema, profile queries, and identity mutation

### DIFF
--- a/convex/contacts/queries.ts
+++ b/convex/contacts/queries.ts
@@ -18,7 +18,6 @@ export const listMyContacts = query({
     const enriched: Array<{
       contactId: Id<"contacts">;
       user: Doc<"users">;
-      nickname?: string;
       createdAt: number;
     }> = [];
     for (const row of rows) {
@@ -27,7 +26,6 @@ export const listMyContacts = query({
         enriched.push({
           contactId: row._id,
           user,
-          ...(row.nickname && { nickname: row.nickname }),
           createdAt: row.createdAt,
         });
       }

--- a/convex/contacts/schema.ts
+++ b/convex/contacts/schema.ts
@@ -20,7 +20,6 @@ export const Contact = {
   contactUserId: v.id("users"),
   createdAt: v.number(),
   sourceInviteId: v.optional(v.id("contactInvites")),
-  nickname: v.optional(v.string()),
   circleIds: v.optional(v.array(v.string())),
 };
 

--- a/convex/users/mutations.test.ts
+++ b/convex/users/mutations.test.ts
@@ -172,6 +172,74 @@ describe("updateProfile bio length validation", () => {
   });
 });
 
+describe("updateProfileIdentity", () => {
+  test("sets nickname on crew user", async () => {
+    const t = await makeTestWithUser();
+    await t.withIdentity(identity).mutation(api.users.mutations.updateProfileIdentity, {
+      nickname: "Joey",
+    });
+    const user = await t.run((ctx) =>
+      ctx.db
+        .query("users")
+        .withIndex("byExternalAuthId", (q) => q.eq("externalAuthId", identity.subject))
+        .unique(),
+    );
+    expect(user?.nickname).toBe("Joey");
+  });
+
+  test("rejects nickname longer than 50 characters", async () => {
+    const t = await makeTestWithUser();
+    await expect(
+      t.withIdentity(identity).mutation(api.users.mutations.updateProfileIdentity, {
+        nickname: "A".repeat(51),
+      }),
+    ).rejects.toThrow();
+  });
+
+  test("trims whitespace from nickname", async () => {
+    const t = await makeTestWithUser();
+    await t.withIdentity(identity).mutation(api.users.mutations.updateProfileIdentity, {
+      nickname: "  Joey  ",
+    });
+    const user = await t.run((ctx) =>
+      ctx.db
+        .query("users")
+        .withIndex("byExternalAuthId", (q) => q.eq("externalAuthId", identity.subject))
+        .unique(),
+    );
+    expect(user?.nickname).toBe("Joey");
+  });
+
+  test("throws when unauthenticated", async () => {
+    const t = convexTest(schema, modules);
+    await expect(
+      t.mutation(api.users.mutations.updateProfileIdentity, { nickname: "Joey" }),
+    ).rejects.toThrow("Not authenticated");
+  });
+
+  test("does not mutate other fields", async () => {
+    const t = convexTest(schema, modules);
+    await t.run((ctx) =>
+      ctx.db.insert("users", {
+        externalAuthId: identity.subject,
+        email: "me@example.com",
+        hasCompletedOnboarding: false,
+        firstName: "Existing",
+      }),
+    );
+    await t.withIdentity(identity).mutation(api.users.mutations.updateProfileIdentity, {
+      nickname: "Joey",
+    });
+    const user = await t.run((ctx) =>
+      ctx.db
+        .query("users")
+        .withIndex("byExternalAuthId", (q) => q.eq("externalAuthId", identity.subject))
+        .unique(),
+    );
+    expect(user?.firstName).toBe("Existing");
+  });
+});
+
 describe("updateProfile URL validation", () => {
   test("rejects javascript: protocol as website", async () => {
     const t = await makeTestWithUser();

--- a/convex/users/mutations.test.ts
+++ b/convex/users/mutations.test.ts
@@ -238,6 +238,26 @@ describe("updateProfileIdentity", () => {
     );
     expect(user?.firstName).toBe("Existing");
   });
+
+  test("omitting nickname preserves the stored value", async () => {
+    const t = convexTest(schema, modules);
+    await t.run((ctx) =>
+      ctx.db.insert("users", {
+        externalAuthId: identity.subject,
+        email: "me@example.com",
+        hasCompletedOnboarding: false,
+        nickname: "Joey",
+      }),
+    );
+    await t.withIdentity(identity).mutation(api.users.mutations.updateProfileIdentity, {});
+    const user = await t.run((ctx) =>
+      ctx.db
+        .query("users")
+        .withIndex("byExternalAuthId", (q) => q.eq("externalAuthId", identity.subject))
+        .unique(),
+    );
+    expect(user?.nickname).toBe("Joey");
+  });
 });
 
 describe("updateProfile URL validation", () => {

--- a/convex/users/mutations.ts
+++ b/convex/users/mutations.ts
@@ -8,6 +8,8 @@ import { upsertCurrentUser } from "./domain/upsertCurrentUser";
 
 const httpUrl = z.url({ protocol: /^https?$/, hostname: z.regexes.domain });
 
+const updateProfileIdentitySchema = z.object({ nickname: z.string().trim().max(50).optional() });
+
 const completeOnboardingSchema = z.object({
   firstName: z.string().max(100),
   lastName: z.string().max(100),
@@ -95,5 +97,20 @@ export const updateProfile = mutation({
       ...(args.imdbUrl !== undefined && { imdbUrl: args.imdbUrl }),
       ...(args.cvUrl !== undefined && { cvUrl: args.cvUrl }),
     });
+  },
+});
+
+export const updateProfileIdentity = mutation({
+  args: { nickname: v.optional(v.string()) },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Not authenticated");
+
+    const parsed = parseOrConvexError(updateProfileIdentitySchema, args);
+
+    const user = await getUserByExternalId(ctx, identity.subject);
+    if (!user) throw new Error("User not found");
+
+    await ctx.db.patch(user._id, { nickname: parsed.nickname });
   },
 });

--- a/convex/users/mutations.ts
+++ b/convex/users/mutations.ts
@@ -111,6 +111,7 @@ export const updateProfileIdentity = mutation({
     const user = await getUserByExternalId(ctx, identity.subject);
     if (!user) throw new Error("User not found");
 
+    if (parsed.nickname === undefined) return;
     await ctx.db.patch(user._id, { nickname: parsed.nickname });
   },
 });

--- a/convex/users/queries.test.ts
+++ b/convex/users/queries.test.ts
@@ -1,3 +1,4 @@
+/// <reference types="vite/client" />
 import { convexTest } from "convex-test";
 import { describe, expect, test } from "vitest";
 
@@ -10,6 +11,12 @@ const identity = {
   subject: "clerk_user_42",
   issuer: "https://example.clerk.test",
   tokenIdentifier: "https://example.clerk.test|clerk_user_42",
+};
+
+const identity2 = {
+  subject: "clerk_user_99",
+  issuer: "https://example.clerk.test",
+  tokenIdentifier: "https://example.clerk.test|clerk_user_99",
 };
 
 describe("getCurrentUser", () => {
@@ -37,5 +44,225 @@ describe("getCurrentUser", () => {
     );
     const result = await t.withIdentity(identity).query(api.users.queries.getCurrentUser, {});
     expect(result?.email).toBe("me@example.com");
+  });
+});
+
+describe("getMyProfile", () => {
+  test("returns null when unauthenticated", async () => {
+    const t = convexTest(schema, modules);
+    const result = await t.query(api.users.queries.getMyProfile, {});
+    expect(result).toBeNull();
+  });
+
+  test("returns null when authenticated but no matching users row", async () => {
+    const t = convexTest(schema, modules);
+    const result = await t.withIdentity(identity).query(api.users.queries.getMyProfile, {});
+    expect(result).toBeNull();
+  });
+
+  test("returns null when user row exists but userType is undefined", async () => {
+    const t = convexTest(schema, modules);
+    await t.run((ctx) =>
+      ctx.db.insert("users", {
+        externalAuthId: identity.subject,
+        email: "me@example.com",
+        hasCompletedOnboarding: false,
+      }),
+    );
+    const result = await t.withIdentity(identity).query(api.users.queries.getMyProfile, {});
+    expect(result).toBeNull();
+  });
+
+  test("returns self variant with all identity fields for crew user", async () => {
+    const t = convexTest(schema, modules);
+    await t.run((ctx) =>
+      ctx.db.insert("users", {
+        externalAuthId: identity.subject,
+        email: "me@example.com",
+        hasCompletedOnboarding: true,
+        userType: "crew",
+        firstName: "Alice",
+        lastName: "Smith",
+        nickname: "Ali",
+        profilePictureUrl: "https://example.com/pic.jpg",
+      }),
+    );
+    const result = await t.withIdentity(identity).query(api.users.queries.getMyProfile, {});
+    expect(result).not.toBeNull();
+    expect(result?.mode).toBe("self");
+    expect(result?.userType).toBe("crew");
+    expect(result?.firstName).toBe("Alice");
+    expect(result?.lastName).toBe("Smith");
+    expect(result?.nickname).toBe("Ali");
+    expect(result?.profilePictureUrl).toBe("https://example.com/pic.jpg");
+  });
+
+  test("returns pm-self variant for production-manager user", async () => {
+    const t = convexTest(schema, modules);
+    await t.run((ctx) =>
+      ctx.db.insert("users", {
+        externalAuthId: identity.subject,
+        email: "pm@example.com",
+        hasCompletedOnboarding: true,
+        userType: "production-manager",
+        firstName: "Bob",
+        lastName: "Jones",
+      }),
+    );
+    const result = await t.withIdentity(identity).query(api.users.queries.getMyProfile, {});
+    expect(result?.mode).toBe("pm-self");
+    expect(result?.userType).toBe("production-manager");
+  });
+});
+
+describe("getViewableProfile", () => {
+  test("returns self variant when viewing own user id as crew", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await t.run((ctx) =>
+      ctx.db.insert("users", {
+        externalAuthId: identity.subject,
+        email: "me@example.com",
+        hasCompletedOnboarding: true,
+        userType: "crew",
+        firstName: "Alice",
+        lastName: "Smith",
+      }),
+    );
+    const result = await t
+      .withIdentity(identity)
+      .query(api.users.queries.getViewableProfile, { userId });
+    expect(result?.mode).toBe("self");
+    expect(result?.userType).toBe("crew");
+  });
+
+  test("returns contact variant when viewing a crew user who is in my contacts", async () => {
+    const t = convexTest(schema, modules);
+    const viewerId = await t.run((ctx) =>
+      ctx.db.insert("users", {
+        externalAuthId: identity.subject,
+        email: "viewer@example.com",
+        hasCompletedOnboarding: true,
+        userType: "crew",
+      }),
+    );
+    const subjectId = await t.run((ctx) =>
+      ctx.db.insert("users", {
+        externalAuthId: identity2.subject,
+        email: "subject@example.com",
+        hasCompletedOnboarding: true,
+        userType: "crew",
+        isPublic: false,
+      }),
+    );
+    await t.run((ctx) =>
+      ctx.db.insert("contacts", {
+        ownerId: viewerId,
+        contactUserId: subjectId,
+        createdAt: Date.now(),
+      }),
+    );
+    const result = await t
+      .withIdentity(identity)
+      .query(api.users.queries.getViewableProfile, { userId: subjectId });
+    expect(result?.mode).toBe("contact");
+  });
+
+  test("returns public-card variant for crew with isPublic:true and not in contacts", async () => {
+    const t = convexTest(schema, modules);
+    await t.run((ctx) =>
+      ctx.db.insert("users", {
+        externalAuthId: identity.subject,
+        email: "viewer@example.com",
+        hasCompletedOnboarding: true,
+        userType: "crew",
+      }),
+    );
+    const subjectId = await t.run((ctx) =>
+      ctx.db.insert("users", {
+        externalAuthId: identity2.subject,
+        email: "public@example.com",
+        hasCompletedOnboarding: true,
+        userType: "crew",
+        isPublic: true,
+      }),
+    );
+    const result = await t
+      .withIdentity(identity)
+      .query(api.users.queries.getViewableProfile, { userId: subjectId });
+    expect(result?.mode).toBe("public-card");
+  });
+
+  test("returns null for crew with isPublic:false and not in contacts", async () => {
+    const t = convexTest(schema, modules);
+    await t.run((ctx) =>
+      ctx.db.insert("users", {
+        externalAuthId: identity.subject,
+        email: "viewer@example.com",
+        hasCompletedOnboarding: true,
+        userType: "crew",
+      }),
+    );
+    const subjectId = await t.run((ctx) =>
+      ctx.db.insert("users", {
+        externalAuthId: identity2.subject,
+        email: "private@example.com",
+        hasCompletedOnboarding: true,
+        userType: "crew",
+        isPublic: false,
+      }),
+    );
+    const result = await t
+      .withIdentity(identity)
+      .query(api.users.queries.getViewableProfile, { userId: subjectId });
+    expect(result).toBeNull();
+  });
+
+  test("returns null when viewing a production-manager other than self", async () => {
+    const t = convexTest(schema, modules);
+    await t.run((ctx) =>
+      ctx.db.insert("users", {
+        externalAuthId: identity.subject,
+        email: "viewer@example.com",
+        hasCompletedOnboarding: true,
+        userType: "crew",
+      }),
+    );
+    const pmId = await t.run((ctx) =>
+      ctx.db.insert("users", {
+        externalAuthId: identity2.subject,
+        email: "pm@example.com",
+        hasCompletedOnboarding: true,
+        userType: "production-manager",
+      }),
+    );
+    const result = await t
+      .withIdentity(identity)
+      .query(api.users.queries.getViewableProfile, { userId: pmId });
+    expect(result).toBeNull();
+  });
+
+  test("returns null when viewing a non-existent user id", async () => {
+    const t = convexTest(schema, modules);
+    await t.run((ctx) =>
+      ctx.db.insert("users", {
+        externalAuthId: identity.subject,
+        email: "viewer@example.com",
+        hasCompletedOnboarding: true,
+        userType: "crew",
+      }),
+    );
+    const fakeId = await t.run(async (ctx) => {
+      const id = await ctx.db.insert("users", {
+        externalAuthId: "temp",
+        email: "temp@example.com",
+        hasCompletedOnboarding: false,
+      });
+      await ctx.db.delete(id);
+      return id;
+    });
+    const result = await t
+      .withIdentity(identity)
+      .query(api.users.queries.getViewableProfile, { userId: fakeId });
+    expect(result).toBeNull();
   });
 });

--- a/convex/users/queries.ts
+++ b/convex/users/queries.ts
@@ -1,5 +1,9 @@
+import type { ViewableProfile } from "@shared/profile/viewableProfile";
+import { v } from "convex/values";
+
 import { query } from "../_generated/server";
 import { getUserByExternalId } from "./db/getUser";
+import { resolveProfileVisibility } from "./lib/resolveProfileVisibility";
 
 export const getCurrentUser = query({
   args: {},
@@ -7,5 +11,70 @@ export const getCurrentUser = query({
     const identity = await ctx.auth.getUserIdentity();
     if (!identity) return null;
     return getUserByExternalId(ctx, identity.subject);
+  },
+});
+
+export const getMyProfile = query({
+  args: {},
+  handler: async (ctx): Promise<ViewableProfile | null> => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) return null;
+
+    const viewer = await getUserByExternalId(ctx, identity.subject);
+    if (!viewer) return null;
+
+    if (viewer.userType === undefined) return null;
+
+    return {
+      mode: viewer.userType === "crew" ? "self" : "pm-self",
+      userId: viewer._id,
+      firstName: viewer.firstName,
+      lastName: viewer.lastName,
+      nickname: viewer.nickname,
+      profilePictureUrl: viewer.profilePictureUrl,
+      userType: viewer.userType,
+    } as ViewableProfile;
+  },
+});
+
+export const getViewableProfile = query({
+  args: { userId: v.id("users") },
+  handler: async (ctx, args): Promise<ViewableProfile | null> => {
+    const identity = await ctx.auth.getUserIdentity();
+    const viewer = identity ? await getUserByExternalId(ctx, identity.subject) : null;
+
+    const subject = await ctx.db.get(args.userId);
+    if (!subject) return null;
+
+    let isContact = false;
+    if (viewer !== null) {
+      const result = await ctx.db
+        .query("contacts")
+        .withIndex("byOwnerAndContact", (q) =>
+          q.eq("ownerId", viewer._id).eq("contactUserId", subject._id),
+        )
+        .unique();
+      isContact = result !== null;
+    }
+
+    const visibility = resolveProfileVisibility({
+      viewerUserId: viewer?._id ?? null,
+      subject: { _id: subject._id, userType: subject.userType, isPublic: subject.isPublic },
+      isContact,
+    });
+
+    if (visibility.mode === "hidden") return null;
+
+    const userType = subject.userType as "crew" | "production-manager";
+
+    return {
+      mode: visibility.mode,
+      userId: subject._id,
+      firstName: subject.firstName,
+      lastName: subject.lastName,
+      nickname: subject.nickname,
+      profilePictureUrl: subject.profilePictureUrl,
+      userType,
+    } as ViewableProfile;
   },
 });

--- a/convex/users/schema.ts
+++ b/convex/users/schema.ts
@@ -9,6 +9,7 @@ export const User = {
   profilePictureUrl: v.optional(v.string()),
   firstName: v.optional(v.string()),
   lastName: v.optional(v.string()),
+  nickname: v.optional(v.string()),
 
   userType: v.optional(v.union(v.literal("crew"), v.literal("production-manager"))),
   department: v.optional(v.string()),


### PR DESCRIPTION
## Summary

- Adds `nickname` field to the `User` validator (`convex/users/schema.ts`)
- Removes `nickname` from the `Contact` validator (`convex/contacts/schema.ts`) — folded from the planned follow-up PR per @ChazUK comment, since dev data is disposable
- Updates `listMyContacts` to remove the now-dropped contact nickname field from its return shape
- Adds `getMyProfile` query — returns the `self`/`pm-self` variant of `ViewableProfile` for the authenticated user
- Adds `getViewableProfile` query — resolves visibility via `resolveProfileVisibility` and returns the appropriate `ViewableProfile` variant (or null if hidden)
- Adds `updateProfileIdentity` mutation — validates and patches only `nickname` on the caller's user row
- Full test coverage appended to `convex/users/queries.test.ts` and `convex/users/mutations.test.ts` (75 tests in the users/migrations suites, 301 total)

## Test Plan

- `npx vitest run convex/users convex/migrations` — 75 tests pass
- `npx tsc --noEmit` — zero new errors (14 pre-existing errors unchanged)
- `npm run lint` — 0 errors
- Pre-commit hooks ran all 301 tests green

## Checklist

- [x] TypeScript compiles with zero new errors
- [x] Lint passes
- [x] Formatting passes
- [x] Tests pass

Closes #267