### PR TITLE
feat(profile): Production Types section

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -94,6 +94,7 @@ import type * as users_mutations from "../users/mutations.js";
 import type * as users_mutations_updateDepartmentAndRoles from "../users/mutations/updateDepartmentAndRoles.js";
 import type * as users_mutations_updateProfileBioLinks from "../users/mutations/updateProfileBioLinks.js";
 import type * as users_mutations_updateProfileLocation from "../users/mutations/updateProfileLocation.js";
+import type * as users_mutations_updateProfileProductionTypes from "../users/mutations/updateProfileProductionTypes.js";
 import type * as users_queries from "../users/queries.js";
 import type * as users_syncVerifiedPhone from "../users/syncVerifiedPhone.js";
 import type * as users_webhooks from "../users/webhooks.js";
@@ -192,6 +193,7 @@ declare const fullApi: ApiFromModules<{
   "users/mutations/updateDepartmentAndRoles": typeof users_mutations_updateDepartmentAndRoles;
   "users/mutations/updateProfileBioLinks": typeof users_mutations_updateProfileBioLinks;
   "users/mutations/updateProfileLocation": typeof users_mutations_updateProfileLocation;
+  "users/mutations/updateProfileProductionTypes": typeof users_mutations_updateProfileProductionTypes;
   "users/queries": typeof users_queries;
   "users/syncVerifiedPhone": typeof users_syncVerifiedPhone;
   "users/webhooks": typeof users_webhooks;

--- a/convex/users/mutations/updateProfileProductionTypes.test.ts
+++ b/convex/users/mutations/updateProfileProductionTypes.test.ts
@@ -1,0 +1,89 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+
+import { api } from "../../_generated/api";
+import schema from "../../schema";
+
+const modules = import.meta.glob("/convex/**/*.ts");
+
+const identity = {
+  subject: "clerk_user_42",
+  issuer: "https://example.clerk.test",
+  tokenIdentifier: "https://example.clerk.test|clerk_user_42",
+};
+
+async function makeTestWithCrewUser() {
+  const t = convexTest(schema, modules);
+  await t.run((ctx) =>
+    ctx.db.insert("users", {
+      externalAuthId: identity.subject,
+      email: "me@example.com",
+      hasCompletedOnboarding: true,
+      userType: "crew",
+    }),
+  );
+  return t;
+}
+
+const mut = api.users.mutations.updateProfileProductionTypes.updateProfileProductionTypes;
+
+describe("updateProfileProductionTypes", () => {
+  test("happy path: sets production types", async () => {
+    const t = await makeTestWithCrewUser();
+    await t.withIdentity(identity).mutation(mut, {
+      productionTypes: ["Feature Film", "Documentary", "Commercial"],
+    });
+    const user = await t.run((ctx) =>
+      ctx.db
+        .query("users")
+        .withIndex("byExternalAuthId", (q) => q.eq("externalAuthId", identity.subject))
+        .unique(),
+    );
+    expect(user?.productionTypes).toEqual(["Feature Film", "Documentary", "Commercial"]);
+  });
+
+  test("rejects unknown production type", async () => {
+    const t = await makeTestWithCrewUser();
+    await expect(
+      t.withIdentity(identity).mutation(mut, {
+        productionTypes: ["Feature Film", "Podcast"],
+      }),
+    ).rejects.toThrow('Unknown production type: "Podcast"');
+  });
+
+  test("rejects duplicate production type", async () => {
+    const t = await makeTestWithCrewUser();
+    await expect(
+      t.withIdentity(identity).mutation(mut, {
+        productionTypes: ["Documentary", "Documentary"],
+      }),
+    ).rejects.toThrow('Duplicate production type: "Documentary"');
+  });
+
+  test("accepts empty array", async () => {
+    const t = await makeTestWithCrewUser();
+    await t.withIdentity(identity).mutation(mut, {
+      productionTypes: ["Feature Film"],
+    });
+    await t.withIdentity(identity).mutation(mut, {
+      productionTypes: [],
+    });
+    const user = await t.run((ctx) =>
+      ctx.db
+        .query("users")
+        .withIndex("byExternalAuthId", (q) => q.eq("externalAuthId", identity.subject))
+        .unique(),
+    );
+    expect(user?.productionTypes).toEqual([]);
+  });
+
+  test("rejects when unauthenticated", async () => {
+    const t = convexTest(schema, modules);
+    await expect(
+      t.mutation(mut, {
+        productionTypes: ["Feature Film"],
+      }),
+    ).rejects.toThrow("Not authenticated");
+  });
+});

--- a/convex/users/mutations/updateProfileProductionTypes.ts
+++ b/convex/users/mutations/updateProfileProductionTypes.ts
@@ -1,0 +1,33 @@
+import { PRODUCTION_TYPES } from "@shared/profile/productionTypes";
+import { ConvexError, v } from "convex/values";
+
+import { mutation } from "../../_generated/server";
+import { getUserByExternalId } from "../db/getUser";
+
+export const updateProfileProductionTypes = mutation({
+  args: {
+    productionTypes: v.array(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new ConvexError("Not authenticated");
+
+    const user = await getUserByExternalId(ctx, identity.subject);
+    if (!user) throw new ConvexError("User not found");
+
+    const seen = new Set<string>();
+    for (const entry of args.productionTypes) {
+      if (!(PRODUCTION_TYPES as readonly string[]).includes(entry)) {
+        throw new ConvexError(`Unknown production type: "${entry}"`);
+      }
+      if (seen.has(entry)) {
+        throw new ConvexError(`Duplicate production type: "${entry}"`);
+      }
+      seen.add(entry);
+    }
+
+    await ctx.db.patch(user._id, {
+      productionTypes: args.productionTypes,
+    });
+  },
+});

--- a/convex/users/queries.ts
+++ b/convex/users/queries.ts
@@ -41,6 +41,7 @@ export const getMyProfile = query({
         imdbId: viewer.imdbId,
         city: viewer.city,
         country: viewer.country,
+        productionTypes: viewer.productionTypes,
       };
     }
 
@@ -107,6 +108,7 @@ export const getViewableProfile = query({
         bio: subject.bio,
         website: subject.website,
         imdbId: subject.imdbId,
+        productionTypes: subject.productionTypes,
       };
     }
 

--- a/convex/users/schema.ts
+++ b/convex/users/schema.ts
@@ -40,6 +40,7 @@ export const User = {
   spokenLanguages: v.optional(v.array(v.object({ language: v.string(), fluency: v.string() }))),
   passports: v.optional(v.array(v.string())),
   kit: v.optional(v.array(v.string())),
+  productionTypes: v.optional(v.array(v.string())),
 
   hasCompletedOnboarding: v.boolean(),
   isPublic: v.optional(v.boolean()),

--- a/src/app/profile/edit/index.tsx
+++ b/src/app/profile/edit/index.tsx
@@ -5,6 +5,7 @@ import { ListGroup, PressableFeedback, Spinner } from "heroui-native";
 import {
   BriefcaseIcon,
   ChevronRightIcon,
+  ClapperboardIcon,
   FileTextIcon,
   MapPinIcon,
   UserIcon,
@@ -37,6 +38,11 @@ export default function EditProfileHubScreen() {
 
   const deptRolesPreview =
     profile.userType === "crew" && profile.department ? profile.department : "Not added";
+
+  const productionTypesPreview =
+    profile.mode === "self" && profile.productionTypes && profile.productionTypes.length > 0
+      ? `${profile.productionTypes.length} selected`
+      : "Not added";
 
   const locationPreview = "city" in profile && profile.city ? profile.city : "Not added";
 
@@ -76,6 +82,28 @@ export default function EditProfileHubScreen() {
                 <ListGroup.ItemContent>
                   <ListGroup.ItemTitle>Department & Roles</ListGroup.ItemTitle>
                   <ListGroup.ItemDescription>{deptRolesPreview}</ListGroup.ItemDescription>
+                </ListGroup.ItemContent>
+                <ListGroup.ItemSuffix>
+                  <ChevronRightIcon size={16} />
+                </ListGroup.ItemSuffix>
+              </ListGroup.Item>
+            </PressableFeedback.Scale>
+          </PressableFeedback>
+        ) : null}
+
+        {profile.userType === "crew" ? (
+          <PressableFeedback
+            animation={false}
+            onPress={() => router.push("/profile/edit/production-types")}
+          >
+            <PressableFeedback.Scale>
+              <ListGroup.Item>
+                <ListGroup.ItemPrefix>
+                  <ClapperboardIcon size={20} />
+                </ListGroup.ItemPrefix>
+                <ListGroup.ItemContent>
+                  <ListGroup.ItemTitle>Production Types</ListGroup.ItemTitle>
+                  <ListGroup.ItemDescription>{productionTypesPreview}</ListGroup.ItemDescription>
                 </ListGroup.ItemContent>
                 <ListGroup.ItemSuffix>
                   <ChevronRightIcon size={16} />

--- a/src/app/profile/edit/production-types.tsx
+++ b/src/app/profile/edit/production-types.tsx
@@ -1,0 +1,108 @@
+import { api } from "@convex/_generated/api";
+import { PRODUCTION_TYPES } from "@shared/profile/productionTypes";
+import { useForm } from "@tanstack/react-form";
+import { useMutation, useQuery } from "convex/react";
+import { useRouter } from "expo-router";
+import { Button, Checkbox, ControlField, Label, Spinner } from "heroui-native";
+import { ScrollView, View } from "react-native";
+
+import { Title } from "@/components/ui/Title";
+
+export default function EditProductionTypesScreen() {
+  const router = useRouter();
+  const profile = useQuery(api.users.queries.getMyProfile);
+  const updateProductionTypes = useMutation(
+    api.users.mutations.updateProfileProductionTypes.updateProfileProductionTypes,
+  );
+
+  if (profile === undefined) {
+    return (
+      <View className="flex-1 items-center justify-center">
+        <Spinner />
+      </View>
+    );
+  }
+
+  if (profile === null || profile.userType !== "crew") {
+    return (
+      <View className="flex-1 items-center justify-center px-4">
+        <Title title="Sign in to edit your profile" />
+      </View>
+    );
+  }
+
+  const current =
+    profile.mode === "self" || profile.mode === "contact" ? (profile.productionTypes ?? []) : [];
+
+  return (
+    <EditProductionTypesForm
+      initialTypes={current}
+      onDone={() => router.back()}
+      onSubmit={updateProductionTypes}
+    />
+  );
+}
+
+type FormProps = {
+  initialTypes: string[];
+  onDone: () => void;
+  onSubmit: (args: { productionTypes: string[] }) => Promise<unknown>;
+};
+
+function EditProductionTypesForm({ initialTypes, onDone, onSubmit }: FormProps) {
+  const form = useForm({
+    defaultValues: {
+      productionTypes: initialTypes,
+    },
+    onSubmit: async ({ value }) => {
+      await onSubmit({ productionTypes: value.productionTypes });
+      onDone();
+    },
+  });
+
+  return (
+    <ScrollView className="flex-1" contentContainerClassName="p-4 gap-6">
+      <form.Field name="productionTypes">
+        {(field) => (
+          <View className="gap-3">
+            {PRODUCTION_TYPES.map((type) => {
+              const isSelected = field.state.value.includes(type);
+              return (
+                <ControlField
+                  key={type}
+                  isSelected={isSelected}
+                  onSelectedChange={() => {
+                    const next = isSelected
+                      ? field.state.value.filter((t) => t !== type)
+                      : [...field.state.value, type];
+                    field.handleChange(next);
+                  }}
+                >
+                  <ControlField.Indicator>
+                    <Checkbox />
+                  </ControlField.Indicator>
+                  <Label>{type}</Label>
+                </ControlField>
+              );
+            })}
+          </View>
+        )}
+      </form.Field>
+
+      <form.Subscribe
+        selector={(state) => ({ canSubmit: state.canSubmit, isSubmitting: state.isSubmitting })}
+      >
+        {({ canSubmit, isSubmitting }) => (
+          <Button
+            variant="primary"
+            onPress={() => form.handleSubmit()}
+            isDisabled={!canSubmit || isSubmitting}
+            className="w-full"
+          >
+            {isSubmitting ? "Saving..." : "Save"}
+          </Button>
+        )}
+      </form.Subscribe>
+    </ScrollView>
+  );
+}

--- a/src/components/profile/Profile.stories.tsx
+++ b/src/components/profile/Profile.stories.tsx
@@ -31,6 +31,7 @@ const selfWithNicknameProfile: ViewableProfile = {
   bio: undefined,
   website: undefined,
   imdbId: undefined,
+  productionTypes: undefined,
 };
 
 const selfWithoutNicknameProfile: ViewableProfile = {
@@ -40,6 +41,7 @@ const selfWithoutNicknameProfile: ViewableProfile = {
   bio: undefined,
   website: undefined,
   imdbId: undefined,
+  productionTypes: undefined,
 };
 
 const contactProfile: ViewableProfile = {
@@ -49,6 +51,7 @@ const contactProfile: ViewableProfile = {
   bio: undefined,
   website: undefined,
   imdbId: undefined,
+  productionTypes: undefined,
 };
 
 const publicCardProfile: ViewableProfile = {

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -6,6 +6,7 @@ import { DepartmentRolesSection } from "./sections/DepartmentRolesSection";
 import { IdentitySection } from "./sections/IdentitySection";
 import { LinksSection } from "./sections/LinksSection";
 import { LocationSection } from "./sections/LocationSection";
+import { ProductionTypesSection } from "./sections/ProductionTypesSection";
 
 type Props = {
   profile: ViewableProfile;
@@ -16,6 +17,7 @@ export function Profile({ profile }: Props) {
     <ScrollView contentContainerClassName="gap-4 p-4">
       <IdentitySection profile={profile} />
       <DepartmentRolesSection profile={profile} />
+      <ProductionTypesSection profile={profile} />
       <LocationSection profile={profile} />
       <BioSection profile={profile} />
       <LinksSection profile={profile} />

--- a/src/components/profile/sections/BioSection.stories.tsx
+++ b/src/components/profile/sections/BioSection.stories.tsx
@@ -24,18 +24,21 @@ const selfWithBio: ViewableProfile = {
   mode: "self",
   ...baseCrew,
   bio: "Camera operator with 15 years experience in film and television.",
+  productionTypes: undefined,
 };
 
 const selfEmpty: ViewableProfile = {
   mode: "self",
   ...baseCrew,
   bio: undefined,
+  productionTypes: undefined,
 };
 
 const contactWithBio: ViewableProfile = {
   mode: "contact",
   ...baseCrew,
   bio: "Camera operator with 15 years experience in film and television.",
+  productionTypes: undefined,
 };
 
 const meta = {

--- a/src/components/profile/sections/IdentitySection.stories.tsx
+++ b/src/components/profile/sections/IdentitySection.stories.tsx
@@ -32,6 +32,7 @@ const selfWithNicknameProfile: ViewableProfile = {
   bio: undefined,
   website: undefined,
   imdbId: undefined,
+  productionTypes: undefined,
 };
 
 const selfWithoutNicknameProfile: ViewableProfile = {
@@ -41,6 +42,7 @@ const selfWithoutNicknameProfile: ViewableProfile = {
   bio: undefined,
   website: undefined,
   imdbId: undefined,
+  productionTypes: undefined,
 };
 
 const contactProfile: ViewableProfile = {
@@ -50,6 +52,7 @@ const contactProfile: ViewableProfile = {
   bio: undefined,
   website: undefined,
   imdbId: undefined,
+  productionTypes: undefined,
 };
 
 const publicCardProfile: ViewableProfile = {

--- a/src/components/profile/sections/LinksSection.stories.tsx
+++ b/src/components/profile/sections/LinksSection.stories.tsx
@@ -41,6 +41,7 @@ export const Default: Story = {
       ...baseCrew,
       website: "https://adalovelace.com",
       imdbId: "nm0000123",
+      productionTypes: undefined,
     },
   },
 };
@@ -52,6 +53,7 @@ export const WebsiteOnly: Story = {
       ...baseCrew,
       website: "https://adalovelace.com",
       imdbId: undefined,
+      productionTypes: undefined,
     },
   },
 };
@@ -63,6 +65,7 @@ export const IMDBOnly: Story = {
       ...baseCrew,
       website: undefined,
       imdbId: "nm0000100",
+      productionTypes: undefined,
     },
   },
 };
@@ -74,6 +77,7 @@ export const Empty: Story = {
       ...baseCrew,
       website: undefined,
       imdbId: undefined,
+      productionTypes: undefined,
     },
   },
 };

--- a/src/components/profile/sections/LocationSection.stories.tsx
+++ b/src/components/profile/sections/LocationSection.stories.tsx
@@ -24,6 +24,7 @@ const selfWithData: ViewableProfile = {
   ...baseCrew,
   city: "London",
   country: "GB",
+  productionTypes: undefined,
 };
 
 const selfEmpty: ViewableProfile = {
@@ -31,6 +32,7 @@ const selfEmpty: ViewableProfile = {
   ...baseCrew,
   city: undefined,
   country: undefined,
+  productionTypes: undefined,
 };
 
 const contactWithData: ViewableProfile = {
@@ -38,6 +40,7 @@ const contactWithData: ViewableProfile = {
   ...baseCrew,
   city: "Los Angeles",
   country: "US",
+  productionTypes: undefined,
 };
 
 const publicCard: ViewableProfile = {

--- a/src/components/profile/sections/ProductionTypesSection.stories.tsx
+++ b/src/components/profile/sections/ProductionTypesSection.stories.tsx
@@ -3,7 +3,7 @@ import type { ViewableProfile } from "@shared/profile/viewableProfile";
 import type { Meta, StoryObj } from "@storybook/react-native";
 import { View } from "react-native";
 
-import { DepartmentRolesSection } from "./DepartmentRolesSection";
+import { ProductionTypesSection } from "./ProductionTypesSection";
 
 const baseCrew = {
   userId: "user_1" as Id<"users">,
@@ -12,6 +12,8 @@ const baseCrew = {
   profilePictureUrl: undefined,
   userType: "crew" as const,
   nickname: undefined,
+  department: "Camera" as const,
+  roles: ["Director of Photography"],
   city: undefined,
   country: undefined,
 };
@@ -19,46 +21,33 @@ const baseCrew = {
 const selfWithData: ViewableProfile = {
   mode: "self",
   ...baseCrew,
-  department: "Camera",
-  roles: ["Director of Photography", "1st AC"],
   bio: undefined,
   website: undefined,
   imdbId: undefined,
-  productionTypes: undefined,
+  productionTypes: ["Feature Film", "TV Drama", "Documentary", "Commercial"],
 };
 
 const selfEmpty: ViewableProfile = {
   mode: "self",
   ...baseCrew,
-  department: undefined,
-  roles: undefined,
   bio: undefined,
   website: undefined,
   imdbId: undefined,
   productionTypes: undefined,
 };
 
-const contact: ViewableProfile = {
+const contactWithData: ViewableProfile = {
   mode: "contact",
   ...baseCrew,
-  department: "Sound",
-  roles: ["Production Sound Mixer", "Sound Assistant"],
   bio: undefined,
   website: undefined,
   imdbId: undefined,
-  productionTypes: undefined,
-};
-
-const publicCard: ViewableProfile = {
-  mode: "public-card",
-  ...baseCrew,
-  department: "Electrical",
-  roles: ["Gaffer"],
+  productionTypes: ["Music Video", "Short Film", "Streaming Series"],
 };
 
 const meta = {
-  title: "Profile/DepartmentRolesSection",
-  component: DepartmentRolesSection,
+  title: "Profile/ProductionTypesSection",
+  component: ProductionTypesSection,
   decorators: [
     (Story) => (
       <View style={{ flex: 1, padding: 16 }}>
@@ -68,12 +57,11 @@ const meta = {
   ],
   tags: ["autodocs"],
   args: { profile: selfWithData },
-} satisfies Meta<typeof DepartmentRolesSection>;
+} satisfies Meta<typeof ProductionTypesSection>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const SelfWithData: Story = { args: { profile: selfWithData } };
 export const SelfEmpty: Story = { args: { profile: selfEmpty } };
-export const Contact: Story = { args: { profile: contact } };
-export const PublicCard: Story = { args: { profile: publicCard } };
+export const ContactWithData: Story = { args: { profile: contactWithData } };

--- a/src/components/profile/sections/ProductionTypesSection.tsx
+++ b/src/components/profile/sections/ProductionTypesSection.tsx
@@ -1,0 +1,49 @@
+import type { ViewableProfile } from "@shared/profile/viewableProfile";
+import { Card, Chip } from "heroui-native";
+import { Text, View } from "react-native";
+
+type Props = {
+  profile: ViewableProfile;
+};
+
+function hasProductionTypes(profile: ViewableProfile): profile is Extract<
+  ViewableProfile,
+  { productionTypes: string[] | undefined }
+> & {
+  productionTypes: string[];
+} {
+  return (
+    "productionTypes" in profile &&
+    Array.isArray(profile.productionTypes) &&
+    profile.productionTypes.length > 0
+  );
+}
+
+export function ProductionTypesSection({ profile }: Props) {
+  if (hasProductionTypes(profile)) {
+    return (
+      <View className="gap-2">
+        <Text className="text-sm font-medium text-muted">Production Types</Text>
+        <View className="flex-row flex-wrap gap-2">
+          {profile.productionTypes.map((type) => (
+            <Chip key={type} variant="secondary" size="sm">
+              {type}
+            </Chip>
+          ))}
+        </View>
+      </View>
+    );
+  }
+
+  if (profile.mode === "self") {
+    return (
+      <Card variant="secondary">
+        <Card.Body>
+          <Text className="text-sm text-muted">Add the types of productions you work on</Text>
+        </Card.Body>
+      </Card>
+    );
+  }
+
+  return null;
+}

--- a/types/profile/productionTypes.ts
+++ b/types/profile/productionTypes.ts
@@ -1,0 +1,15 @@
+export const PRODUCTION_TYPES = [
+  "Feature Film",
+  "TV Drama",
+  "TV Comedy",
+  "Documentary",
+  "Commercial",
+  "Music Video",
+  "Corporate",
+  "Short Film",
+  "Streaming Series",
+  "Reality TV",
+  "Other",
+] as const;
+
+export type ProductionType = (typeof PRODUCTION_TYPES)[number];

--- a/types/profile/viewableProfile.ts
+++ b/types/profile/viewableProfile.ts
@@ -21,6 +21,10 @@ type BioLinks = {
   imdbId: string | undefined;
 };
 
+type CrewExtras = {
+  productionTypes: string[] | undefined;
+};
+
 type CrewProfile = ProfileIdentity & {
   userType: "crew";
   department: Department | undefined;
@@ -32,8 +36,8 @@ type ProductionManagerProfile = ProfileIdentity & {
 };
 
 export type ViewableProfile =
-  | ({ mode: "self" } & CrewProfile & BioLinks & Location)
-  | ({ mode: "contact" } & CrewProfile & BioLinks & Location)
+  | ({ mode: "self" } & CrewProfile & BioLinks & Location & CrewExtras)
+  | ({ mode: "contact" } & CrewProfile & BioLinks & Location & CrewExtras)
   | ({ mode: "public-card" } & CrewProfile & Location)
   | ({ mode: "pm-self" } & ProductionManagerProfile)
   | ({ mode: "pm-job-linked" } & ProductionManagerProfile);


### PR DESCRIPTION
Closes #256

## Summary

- Adds Production Types multi-select section to the Crew Member Profile (Feature Film, TV Drama, TV Comedy, Documentary, Commercial, Music Video, Corporate, Short Film, Streaming Series, Reality TV, Other)
- New mutation validates against canonical taxonomy, rejecting unknown entries and duplicates
- Section visible in Self and Contact modes only (not Public Card); chips rendered in insertion order

## Test plan

- [x] `updateProfileProductionTypes` mutation: happy path, unknown rejection, duplicate rejection, empty array, unauthenticated rejection (5 tests)
- [x] Full test suite passes (603 tests across 73 files)
- [x] TypeScript type checking passes (no new errors)
- [x] Lint and format pass
- [x] Stories: SelfWithData, SelfEmpty, ContactWithData

🤖 Generated with [Claude Code](https://claude.com/claude-code)