### PR TITLE
feat(profile): #255 Spoken Languages section

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -94,6 +94,7 @@ import type * as users_mutations from "../users/mutations.js";
 import type * as users_mutations_updateDepartmentAndRoles from "../users/mutations/updateDepartmentAndRoles.js";
 import type * as users_mutations_updateProfileBioLinks from "../users/mutations/updateProfileBioLinks.js";
 import type * as users_mutations_updateProfileLocation from "../users/mutations/updateProfileLocation.js";
+import type * as users_mutations_updateProfileLanguages from "../users/mutations/updateProfileLanguages.js";
 import type * as users_mutations_updateProfileProductionTypes from "../users/mutations/updateProfileProductionTypes.js";
 import type * as users_mutations_updateProfileYears from "../users/mutations/updateProfileYears.js";
 import type * as migrations_dropLegacyYearsFields from "../migrations/dropLegacyYearsFields.js";
@@ -195,6 +196,7 @@ declare const fullApi: ApiFromModules<{
   "users/mutations/updateDepartmentAndRoles": typeof users_mutations_updateDepartmentAndRoles;
   "users/mutations/updateProfileBioLinks": typeof users_mutations_updateProfileBioLinks;
   "users/mutations/updateProfileLocation": typeof users_mutations_updateProfileLocation;
+  "users/mutations/updateProfileLanguages": typeof users_mutations_updateProfileLanguages;
   "users/mutations/updateProfileProductionTypes": typeof users_mutations_updateProfileProductionTypes;
   "users/mutations/updateProfileYears": typeof users_mutations_updateProfileYears;
   "migrations/dropLegacyYearsFields": typeof migrations_dropLegacyYearsFields;

--- a/convex/users/mutations/updateProfileLanguages.test.ts
+++ b/convex/users/mutations/updateProfileLanguages.test.ts
@@ -1,0 +1,109 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+
+import { api } from "../../_generated/api";
+import schema from "../../schema";
+
+const modules = import.meta.glob("/convex/**/*.ts");
+
+const identity = {
+  subject: "clerk_user_42",
+  issuer: "https://example.clerk.test",
+  tokenIdentifier: "https://example.clerk.test|clerk_user_42",
+};
+
+async function makeTestWithCrewUser() {
+  const t = convexTest(schema, modules);
+  await t.run((ctx) =>
+    ctx.db.insert("users", {
+      externalAuthId: identity.subject,
+      email: "me@example.com",
+      hasCompletedOnboarding: true,
+      userType: "crew",
+    }),
+  );
+  return t;
+}
+
+const mut = api.users.mutations.updateProfileLanguages.updateProfileLanguages;
+
+describe("updateProfileLanguages", () => {
+  test("happy path: sets spoken languages", async () => {
+    const t = await makeTestWithCrewUser();
+    await t.withIdentity(identity).mutation(mut, {
+      spokenLanguages: [
+        { code: "en", fluency: "native" },
+        { code: "fr", fluency: "fluent" },
+        { code: "de", fluency: "basic" },
+      ],
+    });
+    const user = await t.run((ctx) =>
+      ctx.db
+        .query("users")
+        .withIndex("byExternalAuthId", (q) => q.eq("externalAuthId", identity.subject))
+        .unique(),
+    );
+    expect(user?.spokenLanguages).toEqual([
+      { code: "en", fluency: "native" },
+      { code: "fr", fluency: "fluent" },
+      { code: "de", fluency: "basic" },
+    ]);
+  });
+
+  test("rejects unknown language code", async () => {
+    const t = await makeTestWithCrewUser();
+    await expect(
+      t.withIdentity(identity).mutation(mut, {
+        spokenLanguages: [{ code: "xx", fluency: "native" }],
+      }),
+    ).rejects.toThrow('Unknown language code: "xx"');
+  });
+
+  test("rejects unknown fluency level", async () => {
+    const t = await makeTestWithCrewUser();
+    await expect(
+      t.withIdentity(identity).mutation(mut, {
+        spokenLanguages: [{ code: "en", fluency: "expert" }],
+      }),
+    ).rejects.toThrow('Unknown fluency level: "expert"');
+  });
+
+  test("rejects duplicate language code", async () => {
+    const t = await makeTestWithCrewUser();
+    await expect(
+      t.withIdentity(identity).mutation(mut, {
+        spokenLanguages: [
+          { code: "en", fluency: "native" },
+          { code: "en", fluency: "fluent" },
+        ],
+      }),
+    ).rejects.toThrow('Duplicate language code: "en"');
+  });
+
+  test("accepts empty array", async () => {
+    const t = await makeTestWithCrewUser();
+    await t.withIdentity(identity).mutation(mut, {
+      spokenLanguages: [{ code: "en", fluency: "native" }],
+    });
+    await t.withIdentity(identity).mutation(mut, {
+      spokenLanguages: [],
+    });
+    const user = await t.run((ctx) =>
+      ctx.db
+        .query("users")
+        .withIndex("byExternalAuthId", (q) => q.eq("externalAuthId", identity.subject))
+        .unique(),
+    );
+    expect(user?.spokenLanguages).toEqual([]);
+  });
+
+  test("rejects when unauthenticated", async () => {
+    const t = convexTest(schema, modules);
+    await expect(
+      t.mutation(mut, {
+        spokenLanguages: [{ code: "en", fluency: "native" }],
+      }),
+    ).rejects.toThrow("Not authenticated");
+  });
+});

--- a/convex/users/mutations/updateProfileLanguages.ts
+++ b/convex/users/mutations/updateProfileLanguages.ts
@@ -1,0 +1,42 @@
+import { FLUENCY_LEVELS } from "@shared/profile/languages";
+import { LANGUAGE_CODES } from "@shared/profile/languages";
+import { ConvexError, v } from "convex/values";
+
+import { mutation } from "../../_generated/server";
+import { getUserByExternalId } from "../db/getUser";
+
+export const updateProfileLanguages = mutation({
+  args: {
+    spokenLanguages: v.array(
+      v.object({
+        code: v.string(),
+        fluency: v.string(),
+      }),
+    ),
+  },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new ConvexError("Not authenticated");
+
+    const user = await getUserByExternalId(ctx, identity.subject);
+    if (!user) throw new ConvexError("User not found");
+
+    const seenCodes = new Set<string>();
+    for (const entry of args.spokenLanguages) {
+      if (!(LANGUAGE_CODES as readonly string[]).includes(entry.code)) {
+        throw new ConvexError(`Unknown language code: "${entry.code}"`);
+      }
+      if (!(FLUENCY_LEVELS as readonly string[]).includes(entry.fluency)) {
+        throw new ConvexError(`Unknown fluency level: "${entry.fluency}"`);
+      }
+      if (seenCodes.has(entry.code)) {
+        throw new ConvexError(`Duplicate language code: "${entry.code}"`);
+      }
+      seenCodes.add(entry.code);
+    }
+
+    await ctx.db.patch(user._id, {
+      spokenLanguages: args.spokenLanguages,
+    });
+  },
+});

--- a/convex/users/queries.ts
+++ b/convex/users/queries.ts
@@ -43,6 +43,7 @@ export const getMyProfile = query({
         country: viewer.country,
         startYearInDepartment: viewer.startYearInDepartment,
         productionTypes: viewer.productionTypes,
+        spokenLanguages: viewer.spokenLanguages,
       };
     }
 
@@ -111,6 +112,7 @@ export const getViewableProfile = query({
         imdbId: subject.imdbId,
         startYearInDepartment: subject.startYearInDepartment,
         productionTypes: subject.productionTypes,
+        spokenLanguages: subject.spokenLanguages,
       };
     }
 

--- a/convex/users/schema.ts
+++ b/convex/users/schema.ts
@@ -38,7 +38,7 @@ export const User = {
   imdbId: v.optional(v.string()),
   cvUrl: v.optional(v.string()),
   specialSkills: v.optional(v.array(v.string())),
-  spokenLanguages: v.optional(v.array(v.object({ language: v.string(), fluency: v.string() }))),
+  spokenLanguages: v.optional(v.array(v.object({ code: v.string(), fluency: v.string() }))),
   passports: v.optional(v.array(v.string())),
   kit: v.optional(v.array(v.string())),
   productionTypes: v.optional(v.array(v.string())),

--- a/src/app/profile/edit/index.tsx
+++ b/src/app/profile/edit/index.tsx
@@ -8,6 +8,7 @@ import {
   ChevronRightIcon,
   ClapperboardIcon,
   FileTextIcon,
+  LanguagesIcon,
   MapPinIcon,
   UserIcon,
 } from "lucide-react-native";
@@ -48,6 +49,11 @@ export default function EditProfileHubScreen() {
   const productionTypesPreview =
     profile.mode === "self" && profile.productionTypes && profile.productionTypes.length > 0
       ? `${profile.productionTypes.length} selected`
+      : "Not added";
+
+  const languagesPreview =
+    profile.mode === "self" && profile.spokenLanguages && profile.spokenLanguages.length > 0
+      ? `${profile.spokenLanguages.length} added`
       : "Not added";
 
   const locationPreview = "city" in profile && profile.city ? profile.city : "Not added";
@@ -129,6 +135,28 @@ export default function EditProfileHubScreen() {
                 <ListGroup.ItemContent>
                   <ListGroup.ItemTitle>Production Types</ListGroup.ItemTitle>
                   <ListGroup.ItemDescription>{productionTypesPreview}</ListGroup.ItemDescription>
+                </ListGroup.ItemContent>
+                <ListGroup.ItemSuffix>
+                  <ChevronRightIcon size={16} />
+                </ListGroup.ItemSuffix>
+              </ListGroup.Item>
+            </PressableFeedback.Scale>
+          </PressableFeedback>
+        ) : null}
+
+        {profile.userType === "crew" ? (
+          <PressableFeedback
+            animation={false}
+            onPress={() => router.push("/profile/edit/languages")}
+          >
+            <PressableFeedback.Scale>
+              <ListGroup.Item>
+                <ListGroup.ItemPrefix>
+                  <LanguagesIcon size={20} />
+                </ListGroup.ItemPrefix>
+                <ListGroup.ItemContent>
+                  <ListGroup.ItemTitle>Spoken Languages</ListGroup.ItemTitle>
+                  <ListGroup.ItemDescription>{languagesPreview}</ListGroup.ItemDescription>
                 </ListGroup.ItemContent>
                 <ListGroup.ItemSuffix>
                   <ChevronRightIcon size={16} />

--- a/src/app/profile/edit/languages.tsx
+++ b/src/app/profile/edit/languages.tsx
@@ -1,0 +1,173 @@
+import { api } from "@convex/_generated/api";
+import {
+  FLUENCY_LABELS,
+  FLUENCY_LEVELS,
+  LANGUAGE_CODES,
+  LANGUAGE_NAMES,
+  type Fluency,
+  type LanguageCode,
+} from "@shared/profile/languages";
+import { useForm } from "@tanstack/react-form";
+import { useMutation, useQuery } from "convex/react";
+import { useRouter } from "expo-router";
+import { Button, Spinner } from "heroui-native";
+import { TrashIcon } from "lucide-react-native";
+import { useState } from "react";
+import { Pressable, ScrollView, Text, View } from "react-native";
+
+import { BottomSheetSelect, type SelectOption } from "@/components/form/BottomSheetSelect";
+import { Title } from "@/components/ui/Title";
+
+type SpokenLanguageEntry = { code: string; fluency: string };
+
+const languageOptions: SelectOption[] = LANGUAGE_CODES.map((code) => ({
+  value: code,
+  label: LANGUAGE_NAMES[code],
+}));
+
+const fluencyOptions: SelectOption[] = FLUENCY_LEVELS.map((level) => ({
+  value: level,
+  label: FLUENCY_LABELS[level],
+}));
+
+export default function EditLanguagesScreen() {
+  const router = useRouter();
+  const profile = useQuery(api.users.queries.getMyProfile);
+  const updateLanguages = useMutation(
+    api.users.mutations.updateProfileLanguages.updateProfileLanguages,
+  );
+
+  if (profile === undefined) {
+    return (
+      <View className="flex-1 items-center justify-center">
+        <Spinner />
+      </View>
+    );
+  }
+
+  if (profile === null || profile.userType !== "crew") {
+    return (
+      <View className="flex-1 items-center justify-center px-4">
+        <Title title="Sign in to edit your profile" />
+      </View>
+    );
+  }
+
+  const current =
+    profile.mode === "self" || profile.mode === "contact" ? (profile.spokenLanguages ?? []) : [];
+
+  return (
+    <EditLanguagesForm
+      initialLanguages={current}
+      onDone={() => router.back()}
+      onSubmit={updateLanguages}
+    />
+  );
+}
+
+type FormProps = {
+  initialLanguages: SpokenLanguageEntry[];
+  onDone: () => void;
+  onSubmit: (args: { spokenLanguages: SpokenLanguageEntry[] }) => Promise<unknown>;
+};
+
+function EditLanguagesForm({ initialLanguages, onDone, onSubmit }: FormProps) {
+  const form = useForm({
+    defaultValues: {
+      spokenLanguages: initialLanguages,
+    },
+    onSubmit: async ({ value }) => {
+      await onSubmit({ spokenLanguages: value.spokenLanguages });
+      onDone();
+    },
+  });
+
+  const [pendingCode, setPendingCode] = useState<string | undefined>(undefined);
+  const [pendingFluency, setPendingFluency] = useState<string | undefined>(undefined);
+
+  return (
+    <ScrollView className="flex-1" contentContainerClassName="p-4 gap-6">
+      <form.Field name="spokenLanguages">
+        {(field) => {
+          const usedCodes = new Set(field.state.value.map((e) => e.code));
+          const availableLanguages = languageOptions.filter((o) => !usedCodes.has(o.value));
+
+          const addEntry = () => {
+            if (pendingCode && pendingFluency) {
+              field.handleChange([
+                ...field.state.value,
+                { code: pendingCode, fluency: pendingFluency },
+              ]);
+              setPendingCode(undefined);
+              setPendingFluency(undefined);
+            }
+          };
+
+          const removeEntry = (code: string) => {
+            field.handleChange(field.state.value.filter((e) => e.code !== code));
+          };
+
+          return (
+            <View className="gap-4">
+              {field.state.value.map((entry) => (
+                <View key={entry.code} className="flex-row items-center gap-2">
+                  <Text className="flex-1 text-sm text-foreground">
+                    {LANGUAGE_NAMES[entry.code as LanguageCode] ?? entry.code}
+                  </Text>
+                  <Text className="text-sm text-muted">
+                    {FLUENCY_LABELS[entry.fluency as Fluency] ?? entry.fluency}
+                  </Text>
+                  <Pressable onPress={() => removeEntry(entry.code)} hitSlop={8}>
+                    <TrashIcon size={16} className="text-danger" />
+                  </Pressable>
+                </View>
+              ))}
+
+              {availableLanguages.length > 0 ? (
+                <View className="border-divider gap-3 rounded-lg border p-3">
+                  <BottomSheetSelect
+                    options={availableLanguages}
+                    value={pendingCode}
+                    placeholder="Select language"
+                    searchable
+                    searchPlaceholder="Search languages..."
+                    onChange={setPendingCode}
+                  />
+                  <BottomSheetSelect
+                    options={fluencyOptions}
+                    value={pendingFluency}
+                    placeholder="Select fluency"
+                    onChange={setPendingFluency}
+                  />
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onPress={addEntry}
+                    isDisabled={!pendingCode || !pendingFluency}
+                  >
+                    Add Language
+                  </Button>
+                </View>
+              ) : null}
+            </View>
+          );
+        }}
+      </form.Field>
+
+      <form.Subscribe
+        selector={(state) => ({ canSubmit: state.canSubmit, isSubmitting: state.isSubmitting })}
+      >
+        {({ canSubmit, isSubmitting }) => (
+          <Button
+            variant="primary"
+            onPress={() => form.handleSubmit()}
+            isDisabled={!canSubmit || isSubmitting}
+            className="w-full"
+          >
+            {isSubmitting ? "Saving..." : "Save"}
+          </Button>
+        )}
+      </form.Subscribe>
+    </ScrollView>
+  );
+}

--- a/src/components/profile/Profile.stories.tsx
+++ b/src/components/profile/Profile.stories.tsx
@@ -33,6 +33,7 @@ const selfWithNicknameProfile: ViewableProfile = {
   imdbId: undefined,
   startYearInDepartment: undefined,
   productionTypes: undefined,
+  spokenLanguages: undefined,
 };
 
 const selfWithoutNicknameProfile: ViewableProfile = {
@@ -44,6 +45,7 @@ const selfWithoutNicknameProfile: ViewableProfile = {
   imdbId: undefined,
   startYearInDepartment: undefined,
   productionTypes: undefined,
+  spokenLanguages: undefined,
 };
 
 const contactProfile: ViewableProfile = {
@@ -55,6 +57,7 @@ const contactProfile: ViewableProfile = {
   imdbId: undefined,
   startYearInDepartment: undefined,
   productionTypes: undefined,
+  spokenLanguages: undefined,
 };
 
 const publicCardProfile: ViewableProfile = {

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -4,6 +4,7 @@ import { ScrollView } from "react-native";
 import { BioSection } from "./sections/BioSection";
 import { DepartmentRolesSection } from "./sections/DepartmentRolesSection";
 import { IdentitySection } from "./sections/IdentitySection";
+import { LanguagesSection } from "./sections/LanguagesSection";
 import { LinksSection } from "./sections/LinksSection";
 import { LocationSection } from "./sections/LocationSection";
 import { ProductionTypesSection } from "./sections/ProductionTypesSection";
@@ -20,6 +21,7 @@ export function Profile({ profile }: Props) {
       <DepartmentRolesSection profile={profile} />
       <YearsSection profile={profile} />
       <ProductionTypesSection profile={profile} />
+      <LanguagesSection profile={profile} />
       <LocationSection profile={profile} />
       <BioSection profile={profile} />
       <LinksSection profile={profile} />

--- a/src/components/profile/sections/BioSection.stories.tsx
+++ b/src/components/profile/sections/BioSection.stories.tsx
@@ -26,6 +26,7 @@ const selfWithBio: ViewableProfile = {
   bio: "Camera operator with 15 years experience in film and television.",
   startYearInDepartment: undefined,
   productionTypes: undefined,
+  spokenLanguages: undefined,
 };
 
 const selfEmpty: ViewableProfile = {
@@ -34,6 +35,7 @@ const selfEmpty: ViewableProfile = {
   bio: undefined,
   startYearInDepartment: undefined,
   productionTypes: undefined,
+  spokenLanguages: undefined,
 };
 
 const contactWithBio: ViewableProfile = {
@@ -42,6 +44,7 @@ const contactWithBio: ViewableProfile = {
   bio: "Camera operator with 15 years experience in film and television.",
   startYearInDepartment: undefined,
   productionTypes: undefined,
+  spokenLanguages: undefined,
 };
 
 const meta = {

--- a/src/components/profile/sections/DepartmentRolesSection.stories.tsx
+++ b/src/components/profile/sections/DepartmentRolesSection.stories.tsx
@@ -26,6 +26,7 @@ const selfWithData: ViewableProfile = {
   imdbId: undefined,
   startYearInDepartment: undefined,
   productionTypes: undefined,
+  spokenLanguages: undefined,
 };
 
 const selfEmpty: ViewableProfile = {
@@ -38,6 +39,7 @@ const selfEmpty: ViewableProfile = {
   imdbId: undefined,
   startYearInDepartment: undefined,
   productionTypes: undefined,
+  spokenLanguages: undefined,
 };
 
 const contact: ViewableProfile = {
@@ -50,6 +52,7 @@ const contact: ViewableProfile = {
   imdbId: undefined,
   startYearInDepartment: undefined,
   productionTypes: undefined,
+  spokenLanguages: undefined,
 };
 
 const publicCard: ViewableProfile = {

--- a/src/components/profile/sections/IdentitySection.stories.tsx
+++ b/src/components/profile/sections/IdentitySection.stories.tsx
@@ -34,6 +34,7 @@ const selfWithNicknameProfile: ViewableProfile = {
   imdbId: undefined,
   startYearInDepartment: undefined,
   productionTypes: undefined,
+  spokenLanguages: undefined,
 };
 
 const selfWithoutNicknameProfile: ViewableProfile = {
@@ -45,6 +46,7 @@ const selfWithoutNicknameProfile: ViewableProfile = {
   imdbId: undefined,
   startYearInDepartment: undefined,
   productionTypes: undefined,
+  spokenLanguages: undefined,
 };
 
 const contactProfile: ViewableProfile = {
@@ -56,6 +58,7 @@ const contactProfile: ViewableProfile = {
   imdbId: undefined,
   startYearInDepartment: undefined,
   productionTypes: undefined,
+  spokenLanguages: undefined,
 };
 
 const publicCardProfile: ViewableProfile = {

--- a/src/components/profile/sections/LanguagesSection.stories.tsx
+++ b/src/components/profile/sections/LanguagesSection.stories.tsx
@@ -3,7 +3,7 @@ import type { ViewableProfile } from "@shared/profile/viewableProfile";
 import type { Meta, StoryObj } from "@storybook/react-native";
 import { View } from "react-native";
 
-import { LocationSection } from "./LocationSection";
+import { LanguagesSection } from "./LanguagesSection";
 
 const baseCrew = {
   userId: "user_1" as Id<"users">,
@@ -14,26 +14,33 @@ const baseCrew = {
   nickname: undefined,
   department: "Camera" as const,
   roles: ["Director of Photography"],
-  bio: undefined,
-  website: undefined,
-  imdbId: undefined,
+  city: undefined,
+  country: undefined,
 };
 
 const selfWithData: ViewableProfile = {
   mode: "self",
   ...baseCrew,
-  city: "London",
-  country: "GB",
+  bio: undefined,
+  website: undefined,
+  imdbId: undefined,
   startYearInDepartment: undefined,
   productionTypes: undefined,
-  spokenLanguages: undefined,
+  spokenLanguages: [
+    { code: "fr", fluency: "fluent" },
+    { code: "en", fluency: "native" },
+    { code: "de", fluency: "basic" },
+    { code: "es", fluency: "conversational" },
+    { code: "ja", fluency: "professional" },
+  ],
 };
 
 const selfEmpty: ViewableProfile = {
   mode: "self",
   ...baseCrew,
-  city: undefined,
-  country: undefined,
+  bio: undefined,
+  website: undefined,
+  imdbId: undefined,
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
@@ -42,23 +49,20 @@ const selfEmpty: ViewableProfile = {
 const contactWithData: ViewableProfile = {
   mode: "contact",
   ...baseCrew,
-  city: "Los Angeles",
-  country: "US",
+  bio: undefined,
+  website: undefined,
+  imdbId: undefined,
   startYearInDepartment: undefined,
   productionTypes: undefined,
-  spokenLanguages: undefined,
-};
-
-const publicCard: ViewableProfile = {
-  mode: "public-card",
-  ...baseCrew,
-  city: "Berlin",
-  country: "DE",
+  spokenLanguages: [
+    { code: "ar", fluency: "native" },
+    { code: "en", fluency: "professional" },
+  ],
 };
 
 const meta = {
-  title: "Profile/LocationSection",
-  component: LocationSection,
+  title: "Profile/LanguagesSection",
+  component: LanguagesSection,
   decorators: [
     (Story) => (
       <View style={{ flex: 1, padding: 16 }}>
@@ -68,7 +72,7 @@ const meta = {
   ],
   tags: ["autodocs"],
   args: { profile: selfWithData },
-} satisfies Meta<typeof LocationSection>;
+} satisfies Meta<typeof LanguagesSection>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
@@ -76,4 +80,3 @@ type Story = StoryObj<typeof meta>;
 export const SelfWithData: Story = { args: { profile: selfWithData } };
 export const SelfEmpty: Story = { args: { profile: selfEmpty } };
 export const ContactWithData: Story = { args: { profile: contactWithData } };
-export const PublicCard: Story = { args: { profile: publicCard } };

--- a/src/components/profile/sections/LanguagesSection.tsx
+++ b/src/components/profile/sections/LanguagesSection.tsx
@@ -1,0 +1,81 @@
+import {
+  FLUENCY_LABELS,
+  LANGUAGE_NAMES,
+  type Fluency,
+  type LanguageCode,
+} from "@shared/profile/languages";
+import type { ViewableProfile } from "@shared/profile/viewableProfile";
+import { Card, Chip } from "heroui-native";
+import { Text, View } from "react-native";
+
+type Props = {
+  profile: ViewableProfile;
+};
+
+type SpokenLanguageEntry = { code: string; fluency: string };
+
+function hasLanguages(profile: ViewableProfile): profile is Extract<
+  ViewableProfile,
+  { spokenLanguages: SpokenLanguageEntry[] | undefined }
+> & {
+  spokenLanguages: SpokenLanguageEntry[];
+} {
+  return (
+    "spokenLanguages" in profile &&
+    Array.isArray(profile.spokenLanguages) &&
+    profile.spokenLanguages.length > 0
+  );
+}
+
+function sortLanguages(languages: SpokenLanguageEntry[]): SpokenLanguageEntry[] {
+  return [...languages].sort((a, b) => {
+    if (a.fluency === "native" && b.fluency !== "native") return -1;
+    if (a.fluency !== "native" && b.fluency === "native") return 1;
+    const nameA = LANGUAGE_NAMES[a.code as LanguageCode] ?? a.code;
+    const nameB = LANGUAGE_NAMES[b.code as LanguageCode] ?? b.code;
+    return nameA.localeCompare(nameB);
+  });
+}
+
+const fluencyColor: Record<string, "accent" | "default" | "success" | "warning" | "danger"> = {
+  native: "accent",
+  fluent: "success",
+  professional: "default",
+  conversational: "warning",
+  basic: "default",
+};
+
+export function LanguagesSection({ profile }: Props) {
+  if (hasLanguages(profile)) {
+    const sorted = sortLanguages(profile.spokenLanguages);
+    return (
+      <View className="gap-2">
+        <Text className="text-sm font-medium text-muted">Spoken Languages</Text>
+        <View className="gap-2">
+          {sorted.map((entry) => (
+            <View key={entry.code} className="flex-row items-center justify-between">
+              <Text className="text-sm text-foreground">
+                {LANGUAGE_NAMES[entry.code as LanguageCode] ?? entry.code}
+              </Text>
+              <Chip variant="secondary" color={fluencyColor[entry.fluency] ?? "default"} size="sm">
+                {FLUENCY_LABELS[entry.fluency as Fluency] ?? entry.fluency}
+              </Chip>
+            </View>
+          ))}
+        </View>
+      </View>
+    );
+  }
+
+  if (profile.mode === "self") {
+    return (
+      <Card variant="secondary">
+        <Card.Body>
+          <Text className="text-sm text-muted">Add the languages you speak</Text>
+        </Card.Body>
+      </Card>
+    );
+  }
+
+  return null;
+}

--- a/src/components/profile/sections/LinksSection.stories.tsx
+++ b/src/components/profile/sections/LinksSection.stories.tsx
@@ -43,6 +43,7 @@ export const Default: Story = {
       imdbId: "nm0000123",
       startYearInDepartment: undefined,
       productionTypes: undefined,
+      spokenLanguages: undefined,
     },
   },
 };
@@ -56,6 +57,7 @@ export const WebsiteOnly: Story = {
       imdbId: undefined,
       startYearInDepartment: undefined,
       productionTypes: undefined,
+      spokenLanguages: undefined,
     },
   },
 };
@@ -69,6 +71,7 @@ export const IMDBOnly: Story = {
       imdbId: "nm0000100",
       startYearInDepartment: undefined,
       productionTypes: undefined,
+      spokenLanguages: undefined,
     },
   },
 };
@@ -82,6 +85,7 @@ export const Empty: Story = {
       imdbId: undefined,
       startYearInDepartment: undefined,
       productionTypes: undefined,
+      spokenLanguages: undefined,
     },
   },
 };

--- a/src/components/profile/sections/ProductionTypesSection.stories.tsx
+++ b/src/components/profile/sections/ProductionTypesSection.stories.tsx
@@ -26,6 +26,7 @@ const selfWithData: ViewableProfile = {
   imdbId: undefined,
   startYearInDepartment: undefined,
   productionTypes: ["Feature Film", "TV Drama", "Documentary", "Commercial"],
+  spokenLanguages: undefined,
 };
 
 const selfEmpty: ViewableProfile = {
@@ -36,6 +37,7 @@ const selfEmpty: ViewableProfile = {
   imdbId: undefined,
   startYearInDepartment: undefined,
   productionTypes: undefined,
+  spokenLanguages: undefined,
 };
 
 const contactWithData: ViewableProfile = {
@@ -46,6 +48,7 @@ const contactWithData: ViewableProfile = {
   imdbId: undefined,
   startYearInDepartment: undefined,
   productionTypes: ["Music Video", "Short Film", "Streaming Series"],
+  spokenLanguages: undefined,
 };
 
 const meta = {

--- a/src/components/profile/sections/YearsSection.stories.tsx
+++ b/src/components/profile/sections/YearsSection.stories.tsx
@@ -20,6 +20,7 @@ const baseCrew = {
   city: undefined,
   country: undefined,
   productionTypes: undefined,
+  spokenLanguages: undefined,
 };
 
 const selfWithStartYear: ViewableProfile = {

--- a/types/profile/languages.ts
+++ b/types/profile/languages.ts
@@ -1,0 +1,83 @@
+export const LANGUAGE_CODES = [
+  "ar",
+  "bn",
+  "cs",
+  "da",
+  "de",
+  "en",
+  "es",
+  "fi",
+  "fr",
+  "he",
+  "hi",
+  "id",
+  "it",
+  "ja",
+  "ko",
+  "ms",
+  "nl",
+  "no",
+  "pl",
+  "pt",
+  "ru",
+  "sv",
+  "th",
+  "tl",
+  "tr",
+  "uk",
+  "ur",
+  "vi",
+  "zh",
+] as const;
+
+export type LanguageCode = (typeof LANGUAGE_CODES)[number];
+
+export const LANGUAGE_NAMES: Record<LanguageCode, string> = {
+  ar: "Arabic",
+  bn: "Bengali",
+  cs: "Czech",
+  da: "Danish",
+  de: "German",
+  en: "English",
+  es: "Spanish",
+  fi: "Finnish",
+  fr: "French",
+  he: "Hebrew",
+  hi: "Hindi",
+  id: "Indonesian",
+  it: "Italian",
+  ja: "Japanese",
+  ko: "Korean",
+  ms: "Malay",
+  nl: "Dutch",
+  no: "Norwegian",
+  pl: "Polish",
+  pt: "Portuguese",
+  ru: "Russian",
+  sv: "Swedish",
+  th: "Thai",
+  tl: "Filipino",
+  tr: "Turkish",
+  uk: "Ukrainian",
+  ur: "Urdu",
+  vi: "Vietnamese",
+  zh: "Chinese",
+};
+
+export const FLUENCY_LEVELS = [
+  "native",
+  "fluent",
+  "professional",
+  "conversational",
+  "basic",
+] as const;
+
+export type Fluency = (typeof FLUENCY_LEVELS)[number];
+
+export const FLUENCY_LABELS: Record<Fluency, string> = {
+  native: "Native",
+  fluent: "Fluent",
+  professional: "Professional",
+  conversational: "Conversational",
+  basic: "Basic",
+};

--- a/types/profile/viewableProfile.ts
+++ b/types/profile/viewableProfile.ts
@@ -21,9 +21,15 @@ type BioLinks = {
   imdbId: string | undefined;
 };
 
+type SpokenLanguageEntry = {
+  code: string;
+  fluency: string;
+};
+
 type CrewExtras = {
   startYearInDepartment: number | undefined;
   productionTypes: string[] | undefined;
+  spokenLanguages: SpokenLanguageEntry[] | undefined;
 };
 
 type CrewProfile = ProfileIdentity & {


### PR DESCRIPTION
Closes #255

## Summary

- Adds `types/profile/languages.ts` with ISO 639-1 language codes (29 languages), fluency levels (5 tiers), and display name maps
- Adds `updateProfileLanguages` mutation with validation for unknown codes, unknown fluency, and duplicate codes — plus 6 tests covering happy path, each rejection, empty array, and unauthenticated
- Adds `LanguagesSection` display component (native-first sort, fluency color badges) with 3 stories, and wires it into the Profile component
- Adds edit route at `/profile/edit/languages` using TanStack Form with BottomSheetSelect pickers for add/remove, and adds hub entry with language count preview
- Updates `spokenLanguages` schema field key from `language` to `code` per issue spec
- Adds `spokenLanguages` to Self and Contact viewable profile variants and query returns

## Test plan

- [x] `npm run test` — all 619 tests pass (6 new mutation tests)
- [x] `npx tsc --noEmit` — no new type errors
- [x] Pre-commit hooks pass (lint, format, test)
- [ ] Manual: Self profile shows languages sorted native-first then alphabetical
- [ ] Manual: Empty state card appears when no languages added (self only)
- [ ] Manual: Contact mode shows languages, public-card does not
- [ ] Manual: Edit route adds/removes languages with picker UIs
- [ ] Manual: Mutation rejects invalid codes/fluency/duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)