### PR TITLE
feat(profile): #257 Work Eligibility section

### DIFF
--- a/convex/users/mutations/updateProfileWorkEligibility.test.ts
+++ b/convex/users/mutations/updateProfileWorkEligibility.test.ts
@@ -1,0 +1,89 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+
+import { api } from "../../_generated/api";
+import schema from "../../schema";
+
+const modules = import.meta.glob("/convex/**/*.ts");
+
+const identity = {
+  subject: "clerk_user_42",
+  issuer: "https://example.clerk.test",
+  tokenIdentifier: "https://example.clerk.test|clerk_user_42",
+};
+
+async function makeTestWithCrewUser() {
+  const t = convexTest(schema, modules);
+  await t.run((ctx) =>
+    ctx.db.insert("users", {
+      externalAuthId: identity.subject,
+      email: "me@example.com",
+      hasCompletedOnboarding: true,
+      userType: "crew",
+    }),
+  );
+  return t;
+}
+
+const mut = api.users.mutations.updateProfileWorkEligibility.updateProfileWorkEligibility;
+
+describe("updateProfileWorkEligibility", () => {
+  test("happy path: sets work eligibility regions", async () => {
+    const t = await makeTestWithCrewUser();
+    await t.withIdentity(identity).mutation(mut, {
+      workEligibility: ["Right to Work UK", "Schengen", "USA"],
+    });
+    const user = await t.run((ctx) =>
+      ctx.db
+        .query("users")
+        .withIndex("byExternalAuthId", (q) => q.eq("externalAuthId", identity.subject))
+        .unique(),
+    );
+    expect(user?.workEligibility).toEqual(["Right to Work UK", "Schengen", "USA"]);
+  });
+
+  test("rejects unknown region", async () => {
+    const t = await makeTestWithCrewUser();
+    await expect(
+      t.withIdentity(identity).mutation(mut, {
+        workEligibility: ["Right to Work UK", "Mars"],
+      }),
+    ).rejects.toThrow('Unknown work eligibility region: "Mars"');
+  });
+
+  test("rejects duplicate region", async () => {
+    const t = await makeTestWithCrewUser();
+    await expect(
+      t.withIdentity(identity).mutation(mut, {
+        workEligibility: ["USA", "USA"],
+      }),
+    ).rejects.toThrow('Duplicate work eligibility region: "USA"');
+  });
+
+  test("accepts empty array", async () => {
+    const t = await makeTestWithCrewUser();
+    await t.withIdentity(identity).mutation(mut, {
+      workEligibility: ["Canada"],
+    });
+    await t.withIdentity(identity).mutation(mut, {
+      workEligibility: [],
+    });
+    const user = await t.run((ctx) =>
+      ctx.db
+        .query("users")
+        .withIndex("byExternalAuthId", (q) => q.eq("externalAuthId", identity.subject))
+        .unique(),
+    );
+    expect(user?.workEligibility).toEqual([]);
+  });
+
+  test("rejects when unauthenticated", async () => {
+    const t = convexTest(schema, modules);
+    await expect(
+      t.mutation(mut, {
+        workEligibility: ["Right to Work UK"],
+      }),
+    ).rejects.toThrow("Not authenticated");
+  });
+});

--- a/convex/users/mutations/updateProfileWorkEligibility.ts
+++ b/convex/users/mutations/updateProfileWorkEligibility.ts
@@ -1,0 +1,33 @@
+import { WORK_ELIGIBILITY_REGIONS } from "@shared/profile/workEligibility";
+import { ConvexError, v } from "convex/values";
+
+import { mutation } from "../../_generated/server";
+import { getUserByExternalId } from "../db/getUser";
+
+export const updateProfileWorkEligibility = mutation({
+  args: {
+    workEligibility: v.array(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new ConvexError("Not authenticated");
+
+    const user = await getUserByExternalId(ctx, identity.subject);
+    if (!user) throw new ConvexError("User not found");
+
+    const seen = new Set<string>();
+    for (const entry of args.workEligibility) {
+      if (!(WORK_ELIGIBILITY_REGIONS as readonly string[]).includes(entry)) {
+        throw new ConvexError(`Unknown work eligibility region: "${entry}"`);
+      }
+      if (seen.has(entry)) {
+        throw new ConvexError(`Duplicate work eligibility region: "${entry}"`);
+      }
+      seen.add(entry);
+    }
+
+    await ctx.db.patch(user._id, {
+      workEligibility: args.workEligibility,
+    });
+  },
+});

--- a/convex/users/queries.ts
+++ b/convex/users/queries.ts
@@ -58,6 +58,7 @@ export const getMyProfile = query({
         startYearInDepartment: viewer.startYearInDepartment,
         productionTypes: viewer.productionTypes,
         spokenLanguages: viewer.spokenLanguages,
+        workEligibility: viewer.workEligibility,
       };
     }
 
@@ -131,6 +132,7 @@ export const getViewableProfile = query({
         startYearInDepartment: subject.startYearInDepartment,
         productionTypes: subject.productionTypes,
         spokenLanguages: subject.spokenLanguages,
+        workEligibility: subject.workEligibility,
       };
     }
 

--- a/convex/users/schema.ts
+++ b/convex/users/schema.ts
@@ -42,6 +42,7 @@ export const User = {
   passports: v.optional(v.array(v.string())),
   kit: v.optional(v.array(v.string())),
   productionTypes: v.optional(v.array(v.string())),
+  workEligibility: v.optional(v.array(v.string())),
 
   hasCompletedOnboarding: v.boolean(),
   isPublic: v.optional(v.boolean()),

--- a/src/app/profile/edit/work-eligibility.tsx
+++ b/src/app/profile/edit/work-eligibility.tsx
@@ -1,0 +1,108 @@
+import { api } from "@convex/_generated/api";
+import { WORK_ELIGIBILITY_REGIONS } from "@shared/profile/workEligibility";
+import { useForm } from "@tanstack/react-form";
+import { useMutation, useQuery } from "convex/react";
+import { useRouter } from "expo-router";
+import { Button, Checkbox, ControlField, Label, Spinner } from "heroui-native";
+import { ScrollView, View } from "react-native";
+
+import { Title } from "@/components/ui/Title";
+
+export default function EditWorkEligibilityScreen() {
+  const router = useRouter();
+  const profile = useQuery(api.users.queries.getMyProfile);
+  const updateWorkEligibility = useMutation(
+    api.users.mutations.updateProfileWorkEligibility.updateProfileWorkEligibility,
+  );
+
+  if (profile === undefined) {
+    return (
+      <View className="flex-1 items-center justify-center">
+        <Spinner />
+      </View>
+    );
+  }
+
+  if (profile === null || profile.userType !== "crew") {
+    return (
+      <View className="flex-1 items-center justify-center px-4">
+        <Title title="Sign in to edit your profile" />
+      </View>
+    );
+  }
+
+  const current =
+    profile.mode === "self" || profile.mode === "contact" ? (profile.workEligibility ?? []) : [];
+
+  return (
+    <EditWorkEligibilityForm
+      initialRegions={current}
+      onDone={() => router.back()}
+      onSubmit={updateWorkEligibility}
+    />
+  );
+}
+
+type FormProps = {
+  initialRegions: string[];
+  onDone: () => void;
+  onSubmit: (args: { workEligibility: string[] }) => Promise<unknown>;
+};
+
+function EditWorkEligibilityForm({ initialRegions, onDone, onSubmit }: FormProps) {
+  const form = useForm({
+    defaultValues: {
+      workEligibility: initialRegions,
+    },
+    onSubmit: async ({ value }) => {
+      await onSubmit({ workEligibility: value.workEligibility });
+      onDone();
+    },
+  });
+
+  return (
+    <ScrollView className="flex-1" contentContainerClassName="p-4 gap-6">
+      <form.Field name="workEligibility">
+        {(field) => (
+          <View className="gap-3">
+            {WORK_ELIGIBILITY_REGIONS.map((region) => {
+              const isSelected = field.state.value.includes(region);
+              return (
+                <ControlField
+                  key={region}
+                  isSelected={isSelected}
+                  onSelectedChange={() => {
+                    const next = isSelected
+                      ? field.state.value.filter((r) => r !== region)
+                      : [...field.state.value, region];
+                    field.handleChange(next);
+                  }}
+                >
+                  <ControlField.Indicator>
+                    <Checkbox />
+                  </ControlField.Indicator>
+                  <Label>{region}</Label>
+                </ControlField>
+              );
+            })}
+          </View>
+        )}
+      </form.Field>
+
+      <form.Subscribe
+        selector={(state) => ({ canSubmit: state.canSubmit, isSubmitting: state.isSubmitting })}
+      >
+        {({ canSubmit, isSubmitting }) => (
+          <Button
+            variant="primary"
+            onPress={() => form.handleSubmit()}
+            isDisabled={!canSubmit || isSubmitting}
+            className="w-full"
+          >
+            {isSubmitting ? "Saving..." : "Save"}
+          </Button>
+        )}
+      </form.Subscribe>
+    </ScrollView>
+  );
+}

--- a/src/components/profile/Profile.stories.tsx
+++ b/src/components/profile/Profile.stories.tsx
@@ -35,6 +35,7 @@ const selfWithNicknameProfile: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  workEligibility: undefined,
 };
 
 const selfWithoutNicknameProfile: ViewableProfile = {
@@ -48,6 +49,7 @@ const selfWithoutNicknameProfile: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  workEligibility: undefined,
 };
 
 const contactProfile: ViewableProfile = {
@@ -61,6 +63,7 @@ const contactProfile: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  workEligibility: undefined,
 };
 
 const publicCardProfile: ViewableProfile = {

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -10,6 +10,7 @@ import { LanguagesSection } from "./sections/LanguagesSection";
 import { LinksSection } from "./sections/LinksSection";
 import { LocationSection } from "./sections/LocationSection";
 import { ProductionTypesSection } from "./sections/ProductionTypesSection";
+import { WorkEligibilitySection } from "./sections/WorkEligibilitySection";
 import { YearsSection } from "./sections/YearsSection";
 
 type Props = {
@@ -25,6 +26,7 @@ export function Profile({ profile }: Props) {
       <DepartmentRolesSection profile={profile} />
       <YearsSection profile={profile} />
       <ProductionTypesSection profile={profile} />
+      <WorkEligibilitySection profile={profile} />
       <LanguagesSection profile={profile} />
       <LocationSection profile={profile} />
       <BioSection profile={profile} />

--- a/src/components/profile/sections/BioSection.stories.tsx
+++ b/src/components/profile/sections/BioSection.stories.tsx
@@ -28,6 +28,7 @@ const selfWithBio: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  workEligibility: undefined,
 };
 
 const selfEmpty: ViewableProfile = {
@@ -37,6 +38,7 @@ const selfEmpty: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  workEligibility: undefined,
 };
 
 const contactWithBio: ViewableProfile = {
@@ -46,6 +48,7 @@ const contactWithBio: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  workEligibility: undefined,
 };
 
 const meta = {

--- a/src/components/profile/sections/CvSection.stories.tsx
+++ b/src/components/profile/sections/CvSection.stories.tsx
@@ -28,6 +28,7 @@ const selfWithCv: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  workEligibility: undefined,
 };
 
 const selfEmpty: ViewableProfile = {
@@ -38,6 +39,7 @@ const selfEmpty: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  workEligibility: undefined,
 };
 
 const contactWithCv: ViewableProfile = {
@@ -48,6 +50,7 @@ const contactWithCv: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  workEligibility: undefined,
 };
 
 const meta = {

--- a/src/components/profile/sections/DepartmentRolesSection.stories.tsx
+++ b/src/components/profile/sections/DepartmentRolesSection.stories.tsx
@@ -28,6 +28,7 @@ const selfWithData: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  workEligibility: undefined,
 };
 
 const selfEmpty: ViewableProfile = {
@@ -42,6 +43,7 @@ const selfEmpty: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  workEligibility: undefined,
 };
 
 const contact: ViewableProfile = {
@@ -56,6 +58,7 @@ const contact: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  workEligibility: undefined,
 };
 
 const publicCard: ViewableProfile = {

--- a/src/components/profile/sections/IdentitySection.stories.tsx
+++ b/src/components/profile/sections/IdentitySection.stories.tsx
@@ -36,6 +36,7 @@ const selfWithNicknameProfile: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  workEligibility: undefined,
 };
 
 const selfWithoutNicknameProfile: ViewableProfile = {
@@ -49,6 +50,7 @@ const selfWithoutNicknameProfile: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  workEligibility: undefined,
 };
 
 const selfWithPictureProfile: ViewableProfile = {
@@ -63,6 +65,7 @@ const selfWithPictureProfile: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  workEligibility: undefined,
 };
 
 const contactProfile: ViewableProfile = {
@@ -76,6 +79,7 @@ const contactProfile: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  workEligibility: undefined,
 };
 
 const publicCardProfile: ViewableProfile = {

--- a/src/components/profile/sections/LinksSection.stories.tsx
+++ b/src/components/profile/sections/LinksSection.stories.tsx
@@ -45,6 +45,7 @@ export const Default: Story = {
       startYearInDepartment: undefined,
       productionTypes: undefined,
       spokenLanguages: undefined,
+      workEligibility: undefined,
     },
   },
 };
@@ -59,6 +60,7 @@ export const WebsiteOnly: Story = {
       startYearInDepartment: undefined,
       productionTypes: undefined,
       spokenLanguages: undefined,
+      workEligibility: undefined,
     },
   },
 };
@@ -73,6 +75,7 @@ export const IMDBOnly: Story = {
       startYearInDepartment: undefined,
       productionTypes: undefined,
       spokenLanguages: undefined,
+      workEligibility: undefined,
     },
   },
 };
@@ -87,6 +90,7 @@ export const Empty: Story = {
       startYearInDepartment: undefined,
       productionTypes: undefined,
       spokenLanguages: undefined,
+      workEligibility: undefined,
     },
   },
 };

--- a/src/components/profile/sections/LocationSection.stories.tsx
+++ b/src/components/profile/sections/LocationSection.stories.tsx
@@ -28,6 +28,7 @@ const selfWithData: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  workEligibility: undefined,
 };
 
 const selfEmpty: ViewableProfile = {
@@ -38,6 +39,7 @@ const selfEmpty: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  workEligibility: undefined,
 };
 
 const contactWithData: ViewableProfile = {
@@ -48,6 +50,7 @@ const contactWithData: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  workEligibility: undefined,
 };
 
 const publicCard: ViewableProfile = {

--- a/src/components/profile/sections/ProductionTypesSection.stories.tsx
+++ b/src/components/profile/sections/ProductionTypesSection.stories.tsx
@@ -28,6 +28,7 @@ const selfWithData: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: ["Feature Film", "TV Drama", "Documentary", "Commercial"],
   spokenLanguages: undefined,
+  workEligibility: undefined,
 };
 
 const selfEmpty: ViewableProfile = {
@@ -40,6 +41,7 @@ const selfEmpty: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  workEligibility: undefined,
 };
 
 const contactWithData: ViewableProfile = {
@@ -52,6 +54,7 @@ const contactWithData: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: ["Music Video", "Short Film", "Streaming Series"],
   spokenLanguages: undefined,
+  workEligibility: undefined,
 };
 
 const meta = {

--- a/src/components/profile/sections/WorkEligibilitySection.stories.tsx
+++ b/src/components/profile/sections/WorkEligibilitySection.stories.tsx
@@ -3,7 +3,7 @@ import type { ViewableProfile } from "@shared/profile/viewableProfile";
 import type { Meta, StoryObj } from "@storybook/react-native";
 import { View } from "react-native";
 
-import { LanguagesSection } from "./LanguagesSection";
+import { WorkEligibilitySection } from "./WorkEligibilitySection";
 
 const baseCrew = {
   userId: "user_1" as Id<"users">,
@@ -27,14 +27,8 @@ const selfWithData: ViewableProfile = {
   cvUrl: undefined,
   startYearInDepartment: undefined,
   productionTypes: undefined,
-  spokenLanguages: [
-    { code: "fr", fluency: "fluent" },
-    { code: "en", fluency: "native" },
-    { code: "de", fluency: "basic" },
-    { code: "es", fluency: "conversational" },
-    { code: "ja", fluency: "professional" },
-  ],
-  workEligibility: undefined,
+  spokenLanguages: undefined,
+  workEligibility: ["Right to Work UK", "Schengen", "Ireland"],
 };
 
 const selfEmpty: ViewableProfile = {
@@ -59,16 +53,13 @@ const contactWithData: ViewableProfile = {
   cvUrl: undefined,
   startYearInDepartment: undefined,
   productionTypes: undefined,
-  spokenLanguages: [
-    { code: "ar", fluency: "native" },
-    { code: "en", fluency: "professional" },
-  ],
-  workEligibility: undefined,
+  spokenLanguages: undefined,
+  workEligibility: ["USA", "Canada", "Australia"],
 };
 
 const meta = {
-  title: "Profile/LanguagesSection",
-  component: LanguagesSection,
+  title: "Profile/WorkEligibilitySection",
+  component: WorkEligibilitySection,
   decorators: [
     (Story) => (
       <View style={{ flex: 1, padding: 16 }}>
@@ -78,7 +69,7 @@ const meta = {
   ],
   tags: ["autodocs"],
   args: { profile: selfWithData },
-} satisfies Meta<typeof LanguagesSection>;
+} satisfies Meta<typeof WorkEligibilitySection>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/src/components/profile/sections/WorkEligibilitySection.tsx
+++ b/src/components/profile/sections/WorkEligibilitySection.tsx
@@ -1,0 +1,37 @@
+import type { ViewableProfile } from "@shared/profile/viewableProfile";
+import { Chip } from "heroui-native";
+import { Text, View } from "react-native";
+
+type Props = {
+  profile: ViewableProfile;
+};
+
+function hasWorkEligibility(profile: ViewableProfile): profile is Extract<
+  ViewableProfile,
+  { workEligibility: string[] | undefined }
+> & {
+  workEligibility: string[];
+} {
+  return (
+    "workEligibility" in profile &&
+    Array.isArray(profile.workEligibility) &&
+    profile.workEligibility.length > 0
+  );
+}
+
+export function WorkEligibilitySection({ profile }: Props) {
+  if (!hasWorkEligibility(profile)) return null;
+
+  return (
+    <View className="gap-2">
+      <Text className="text-sm font-medium text-muted">Work Eligibility</Text>
+      <View className="flex-row flex-wrap gap-2">
+        {profile.workEligibility.map((region) => (
+          <Chip key={region} variant="secondary" size="sm">
+            {region}
+          </Chip>
+        ))}
+      </View>
+    </View>
+  );
+}

--- a/src/components/profile/sections/YearsSection.stories.tsx
+++ b/src/components/profile/sections/YearsSection.stories.tsx
@@ -22,6 +22,7 @@ const baseCrew = {
   country: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  workEligibility: undefined,
 };
 
 const selfWithStartYear: ViewableProfile = {

--- a/types/profile/viewableProfile.ts
+++ b/types/profile/viewableProfile.ts
@@ -31,6 +31,7 @@ type CrewExtras = {
   startYearInDepartment: number | undefined;
   productionTypes: string[] | undefined;
   spokenLanguages: SpokenLanguageEntry[] | undefined;
+  workEligibility: string[] | undefined;
 };
 
 type CrewProfile = ProfileIdentity & {

--- a/types/profile/workEligibility.ts
+++ b/types/profile/workEligibility.ts
@@ -1,0 +1,12 @@
+export const WORK_ELIGIBILITY_REGIONS = [
+  "Right to Work UK",
+  "Schengen",
+  "USA",
+  "Canada",
+  "Australia",
+  "New Zealand",
+  "Ireland",
+  "Other",
+] as const;
+
+export type WorkEligibilityRegion = (typeof WORK_ELIGIBILITY_REGIONS)[number];


### PR DESCRIPTION
Closes #257

## Summary

- Adds Work Eligibility section with canonical region list (Right to Work UK, Schengen, USA, Canada, Australia, New Zealand, Ireland, Other) stored as `users.workEligibility: string[]`
- Mutation validates entries against the canonical list and rejects duplicates; visible in Self and Contact modes only (not Public Card)
- Design pivot applied: empty sections hidden (no ghost card), section is read-only presentational (no pencil affordance)

## Test plan

- [x] `updateProfileWorkEligibility` mutation tests: happy path, unknown region rejection, duplicate rejection, empty array, unauthenticated rejection (5 tests)
- [x] All existing tests pass (635 total)
- [x] Lint and format pass
- [x] TypeScript compiles (only expected codegen errors for the new mutation API reference)
- [ ] Manual: PM profile still renders correctly (no work eligibility for PMs)
- [ ] Manual: Self view shows chip list when regions set, hides section when empty
- [ ] Manual: Contact view shows chip list, Public Card omits section

🤖 Generated with [Claude Code](https://claude.com/claude-code)