### PR TITLE
feat(profile): #258 Driving Licences section

### DIFF
--- a/convex/users/mutations/updateProfileDrivingLicences.test.ts
+++ b/convex/users/mutations/updateProfileDrivingLicences.test.ts
@@ -1,0 +1,89 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+
+import { api } from "../../_generated/api";
+import schema from "../../schema";
+
+const modules = import.meta.glob("/convex/**/*.ts");
+
+const identity = {
+  subject: "clerk_user_42",
+  issuer: "https://example.clerk.test",
+  tokenIdentifier: "https://example.clerk.test|clerk_user_42",
+};
+
+async function makeTestWithCrewUser() {
+  const t = convexTest(schema, modules);
+  await t.run((ctx) =>
+    ctx.db.insert("users", {
+      externalAuthId: identity.subject,
+      email: "me@example.com",
+      hasCompletedOnboarding: true,
+      userType: "crew",
+    }),
+  );
+  return t;
+}
+
+const mut = api.users.mutations.updateProfileDrivingLicences.updateProfileDrivingLicences;
+
+describe("updateProfileDrivingLicences", () => {
+  test("happy path: sets driving licences", async () => {
+    const t = await makeTestWithCrewUser();
+    await t.withIdentity(identity).mutation(mut, {
+      drivingLicences: ["Car (B)", "Motorcycle (A)", "Forklift"],
+    });
+    const user = await t.run((ctx) =>
+      ctx.db
+        .query("users")
+        .withIndex("byExternalAuthId", (q) => q.eq("externalAuthId", identity.subject))
+        .unique(),
+    );
+    expect(user?.drivingLicences).toEqual(["Car (B)", "Motorcycle (A)", "Forklift"]);
+  });
+
+  test("rejects unknown licence", async () => {
+    const t = await makeTestWithCrewUser();
+    await expect(
+      t.withIdentity(identity).mutation(mut, {
+        drivingLicences: ["Car (B)", "Spaceship"],
+      }),
+    ).rejects.toThrow('Unknown driving licence: "Spaceship"');
+  });
+
+  test("rejects duplicate licence", async () => {
+    const t = await makeTestWithCrewUser();
+    await expect(
+      t.withIdentity(identity).mutation(mut, {
+        drivingLicences: ["Forklift", "Forklift"],
+      }),
+    ).rejects.toThrow('Duplicate driving licence: "Forklift"');
+  });
+
+  test("accepts empty array", async () => {
+    const t = await makeTestWithCrewUser();
+    await t.withIdentity(identity).mutation(mut, {
+      drivingLicences: ["Car (B)"],
+    });
+    await t.withIdentity(identity).mutation(mut, {
+      drivingLicences: [],
+    });
+    const user = await t.run((ctx) =>
+      ctx.db
+        .query("users")
+        .withIndex("byExternalAuthId", (q) => q.eq("externalAuthId", identity.subject))
+        .unique(),
+    );
+    expect(user?.drivingLicences).toEqual([]);
+  });
+
+  test("rejects when unauthenticated", async () => {
+    const t = convexTest(schema, modules);
+    await expect(
+      t.mutation(mut, {
+        drivingLicences: ["Car (B)"],
+      }),
+    ).rejects.toThrow("Not authenticated");
+  });
+});

--- a/convex/users/mutations/updateProfileDrivingLicences.ts
+++ b/convex/users/mutations/updateProfileDrivingLicences.ts
@@ -1,0 +1,33 @@
+import { DRIVING_LICENCES } from "@shared/profile/drivingLicences";
+import { ConvexError, v } from "convex/values";
+
+import { mutation } from "../../_generated/server";
+import { getUserByExternalId } from "../db/getUser";
+
+export const updateProfileDrivingLicences = mutation({
+  args: {
+    drivingLicences: v.array(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new ConvexError("Not authenticated");
+
+    const user = await getUserByExternalId(ctx, identity.subject);
+    if (!user) throw new ConvexError("User not found");
+
+    const seen = new Set<string>();
+    for (const entry of args.drivingLicences) {
+      if (!(DRIVING_LICENCES as readonly string[]).includes(entry)) {
+        throw new ConvexError(`Unknown driving licence: "${entry}"`);
+      }
+      if (seen.has(entry)) {
+        throw new ConvexError(`Duplicate driving licence: "${entry}"`);
+      }
+      seen.add(entry);
+    }
+
+    await ctx.db.patch(user._id, {
+      drivingLicences: args.drivingLicences,
+    });
+  },
+});

--- a/convex/users/queries.ts
+++ b/convex/users/queries.ts
@@ -58,6 +58,7 @@ export const getMyProfile = query({
         startYearInDepartment: viewer.startYearInDepartment,
         productionTypes: viewer.productionTypes,
         spokenLanguages: viewer.spokenLanguages,
+        drivingLicences: viewer.drivingLicences,
       };
     }
 
@@ -131,6 +132,7 @@ export const getViewableProfile = query({
         startYearInDepartment: subject.startYearInDepartment,
         productionTypes: subject.productionTypes,
         spokenLanguages: subject.spokenLanguages,
+        drivingLicences: subject.drivingLicences,
       };
     }
 

--- a/convex/users/schema.ts
+++ b/convex/users/schema.ts
@@ -42,6 +42,7 @@ export const User = {
   passports: v.optional(v.array(v.string())),
   kit: v.optional(v.array(v.string())),
   productionTypes: v.optional(v.array(v.string())),
+  drivingLicences: v.optional(v.array(v.string())),
 
   hasCompletedOnboarding: v.boolean(),
   isPublic: v.optional(v.boolean()),

--- a/src/app/profile/edit/driving-licences.tsx
+++ b/src/app/profile/edit/driving-licences.tsx
@@ -1,0 +1,108 @@
+import { api } from "@convex/_generated/api";
+import { DRIVING_LICENCES } from "@shared/profile/drivingLicences";
+import { useForm } from "@tanstack/react-form";
+import { useMutation, useQuery } from "convex/react";
+import { useRouter } from "expo-router";
+import { Button, Checkbox, ControlField, Label, Spinner } from "heroui-native";
+import { ScrollView, View } from "react-native";
+
+import { Title } from "@/components/ui/Title";
+
+export default function EditDrivingLicencesScreen() {
+  const router = useRouter();
+  const profile = useQuery(api.users.queries.getMyProfile);
+  const updateDrivingLicences = useMutation(
+    api.users.mutations.updateProfileDrivingLicences.updateProfileDrivingLicences,
+  );
+
+  if (profile === undefined) {
+    return (
+      <View className="flex-1 items-center justify-center">
+        <Spinner />
+      </View>
+    );
+  }
+
+  if (profile === null || profile.userType !== "crew") {
+    return (
+      <View className="flex-1 items-center justify-center px-4">
+        <Title title="Sign in to edit your profile" />
+      </View>
+    );
+  }
+
+  const current =
+    profile.mode === "self" || profile.mode === "contact" ? (profile.drivingLicences ?? []) : [];
+
+  return (
+    <EditDrivingLicencesForm
+      initialLicences={current}
+      onDone={() => router.back()}
+      onSubmit={updateDrivingLicences}
+    />
+  );
+}
+
+type FormProps = {
+  initialLicences: string[];
+  onDone: () => void;
+  onSubmit: (args: { drivingLicences: string[] }) => Promise<unknown>;
+};
+
+function EditDrivingLicencesForm({ initialLicences, onDone, onSubmit }: FormProps) {
+  const form = useForm({
+    defaultValues: {
+      drivingLicences: initialLicences,
+    },
+    onSubmit: async ({ value }) => {
+      await onSubmit({ drivingLicences: value.drivingLicences });
+      onDone();
+    },
+  });
+
+  return (
+    <ScrollView className="flex-1" contentContainerClassName="p-4 gap-6">
+      <form.Field name="drivingLicences">
+        {(field) => (
+          <View className="gap-3">
+            {DRIVING_LICENCES.map((licence) => {
+              const isSelected = field.state.value.includes(licence);
+              return (
+                <ControlField
+                  key={licence}
+                  isSelected={isSelected}
+                  onSelectedChange={() => {
+                    const next = isSelected
+                      ? field.state.value.filter((l) => l !== licence)
+                      : [...field.state.value, licence];
+                    field.handleChange(next);
+                  }}
+                >
+                  <ControlField.Indicator>
+                    <Checkbox />
+                  </ControlField.Indicator>
+                  <Label>{licence}</Label>
+                </ControlField>
+              );
+            })}
+          </View>
+        )}
+      </form.Field>
+
+      <form.Subscribe
+        selector={(state) => ({ canSubmit: state.canSubmit, isSubmitting: state.isSubmitting })}
+      >
+        {({ canSubmit, isSubmitting }) => (
+          <Button
+            variant="primary"
+            onPress={() => form.handleSubmit()}
+            isDisabled={!canSubmit || isSubmitting}
+            className="w-full"
+          >
+            {isSubmitting ? "Saving..." : "Save"}
+          </Button>
+        )}
+      </form.Subscribe>
+    </ScrollView>
+  );
+}

--- a/src/components/profile/Profile.stories.tsx
+++ b/src/components/profile/Profile.stories.tsx
@@ -35,6 +35,7 @@ const selfWithNicknameProfile: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  drivingLicences: undefined,
 };
 
 const selfWithoutNicknameProfile: ViewableProfile = {
@@ -48,6 +49,7 @@ const selfWithoutNicknameProfile: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  drivingLicences: undefined,
 };
 
 const contactProfile: ViewableProfile = {
@@ -61,6 +63,7 @@ const contactProfile: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  drivingLicences: undefined,
 };
 
 const publicCardProfile: ViewableProfile = {

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -5,6 +5,7 @@ import { usePictureUpload } from "./PictureUploadFlow";
 import { BioSection } from "./sections/BioSection";
 import { CvSection } from "./sections/CvSection";
 import { DepartmentRolesSection } from "./sections/DepartmentRolesSection";
+import { DrivingLicencesSection } from "./sections/DrivingLicencesSection";
 import { IdentitySection } from "./sections/IdentitySection";
 import { LanguagesSection } from "./sections/LanguagesSection";
 import { LinksSection } from "./sections/LinksSection";
@@ -25,6 +26,7 @@ export function Profile({ profile }: Props) {
       <DepartmentRolesSection profile={profile} />
       <YearsSection profile={profile} />
       <ProductionTypesSection profile={profile} />
+      <DrivingLicencesSection profile={profile} />
       <LanguagesSection profile={profile} />
       <LocationSection profile={profile} />
       <BioSection profile={profile} />

--- a/src/components/profile/sections/BioSection.stories.tsx
+++ b/src/components/profile/sections/BioSection.stories.tsx
@@ -28,6 +28,7 @@ const selfWithBio: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  drivingLicences: undefined,
 };
 
 const selfEmpty: ViewableProfile = {
@@ -37,6 +38,7 @@ const selfEmpty: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  drivingLicences: undefined,
 };
 
 const contactWithBio: ViewableProfile = {
@@ -46,6 +48,7 @@ const contactWithBio: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  drivingLicences: undefined,
 };
 
 const meta = {

--- a/src/components/profile/sections/DepartmentRolesSection.stories.tsx
+++ b/src/components/profile/sections/DepartmentRolesSection.stories.tsx
@@ -28,6 +28,7 @@ const selfWithData: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  drivingLicences: undefined,
 };
 
 const selfEmpty: ViewableProfile = {
@@ -42,6 +43,7 @@ const selfEmpty: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  drivingLicences: undefined,
 };
 
 const contact: ViewableProfile = {
@@ -56,6 +58,7 @@ const contact: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  drivingLicences: undefined,
 };
 
 const publicCard: ViewableProfile = {

--- a/src/components/profile/sections/DrivingLicencesSection.stories.tsx
+++ b/src/components/profile/sections/DrivingLicencesSection.stories.tsx
@@ -3,7 +3,7 @@ import type { ViewableProfile } from "@shared/profile/viewableProfile";
 import type { Meta, StoryObj } from "@storybook/react-native";
 import { View } from "react-native";
 
-import { CvSection } from "./CvSection";
+import { DrivingLicencesSection } from "./DrivingLicencesSection";
 
 const baseCrew = {
   userId: "user_1" as Id<"users">,
@@ -14,27 +14,29 @@ const baseCrew = {
   nickname: undefined,
   department: "Camera" as const,
   roles: ["Director of Photography"],
-  website: undefined,
-  imdbId: undefined,
   city: undefined,
   country: undefined,
 };
 
-const selfWithCv: ViewableProfile = {
+const selfWithData: ViewableProfile = {
   mode: "self",
   ...baseCrew,
   bio: undefined,
-  cvUrl: "https://storage.example.com/cv.pdf",
+  website: undefined,
+  imdbId: undefined,
+  cvUrl: undefined,
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
-  drivingLicences: undefined,
+  drivingLicences: ["Car (B)", "Motorcycle (A)", "HGV/LGV (C)"],
 };
 
 const selfEmpty: ViewableProfile = {
   mode: "self",
   ...baseCrew,
   bio: undefined,
+  website: undefined,
+  imdbId: undefined,
   cvUrl: undefined,
   startYearInDepartment: undefined,
   productionTypes: undefined,
@@ -42,20 +44,22 @@ const selfEmpty: ViewableProfile = {
   drivingLicences: undefined,
 };
 
-const contactWithCv: ViewableProfile = {
+const contactWithData: ViewableProfile = {
   mode: "contact",
   ...baseCrew,
   bio: undefined,
-  cvUrl: "https://storage.example.com/cv.pdf",
+  website: undefined,
+  imdbId: undefined,
+  cvUrl: undefined,
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
-  drivingLicences: undefined,
+  drivingLicences: ["Car (B)", "Forklift"],
 };
 
 const meta = {
-  title: "Profile/CvSection",
-  component: CvSection,
+  title: "Profile/DrivingLicencesSection",
+  component: DrivingLicencesSection,
   decorators: [
     (Story) => (
       <View style={{ flex: 1, padding: 16 }}>
@@ -64,12 +68,12 @@ const meta = {
     ),
   ],
   tags: ["autodocs"],
-  args: { profile: selfWithCv },
-} satisfies Meta<typeof CvSection>;
+  args: { profile: selfWithData },
+} satisfies Meta<typeof DrivingLicencesSection>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const SelfWithCv: Story = { args: { profile: selfWithCv } };
+export const SelfWithData: Story = { args: { profile: selfWithData } };
 export const SelfEmpty: Story = { args: { profile: selfEmpty } };
-export const ContactWithCv: Story = { args: { profile: contactWithCv } };
+export const ContactWithData: Story = { args: { profile: contactWithData } };

--- a/src/components/profile/sections/DrivingLicencesSection.tsx
+++ b/src/components/profile/sections/DrivingLicencesSection.tsx
@@ -1,0 +1,37 @@
+import type { ViewableProfile } from "@shared/profile/viewableProfile";
+import { Chip } from "heroui-native";
+import { Text, View } from "react-native";
+
+type Props = {
+  profile: ViewableProfile;
+};
+
+function hasDrivingLicences(profile: ViewableProfile): profile is Extract<
+  ViewableProfile,
+  { drivingLicences: string[] | undefined }
+> & {
+  drivingLicences: string[];
+} {
+  return (
+    "drivingLicences" in profile &&
+    Array.isArray(profile.drivingLicences) &&
+    profile.drivingLicences.length > 0
+  );
+}
+
+export function DrivingLicencesSection({ profile }: Props) {
+  if (!hasDrivingLicences(profile)) return null;
+
+  return (
+    <View className="gap-2">
+      <Text className="text-sm font-medium text-muted">Driving Licences</Text>
+      <View className="flex-row flex-wrap gap-2">
+        {profile.drivingLicences.map((licence) => (
+          <Chip key={licence} variant="secondary" size="sm">
+            {licence}
+          </Chip>
+        ))}
+      </View>
+    </View>
+  );
+}

--- a/src/components/profile/sections/IdentitySection.stories.tsx
+++ b/src/components/profile/sections/IdentitySection.stories.tsx
@@ -36,6 +36,7 @@ const selfWithNicknameProfile: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  drivingLicences: undefined,
 };
 
 const selfWithoutNicknameProfile: ViewableProfile = {
@@ -49,6 +50,7 @@ const selfWithoutNicknameProfile: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  drivingLicences: undefined,
 };
 
 const selfWithPictureProfile: ViewableProfile = {
@@ -63,6 +65,7 @@ const selfWithPictureProfile: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  drivingLicences: undefined,
 };
 
 const contactProfile: ViewableProfile = {
@@ -76,6 +79,7 @@ const contactProfile: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  drivingLicences: undefined,
 };
 
 const publicCardProfile: ViewableProfile = {

--- a/src/components/profile/sections/LanguagesSection.stories.tsx
+++ b/src/components/profile/sections/LanguagesSection.stories.tsx
@@ -34,6 +34,7 @@ const selfWithData: ViewableProfile = {
     { code: "es", fluency: "conversational" },
     { code: "ja", fluency: "professional" },
   ],
+  drivingLicences: undefined,
 };
 
 const selfEmpty: ViewableProfile = {
@@ -46,6 +47,7 @@ const selfEmpty: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  drivingLicences: undefined,
 };
 
 const contactWithData: ViewableProfile = {
@@ -61,6 +63,7 @@ const contactWithData: ViewableProfile = {
     { code: "ar", fluency: "native" },
     { code: "en", fluency: "professional" },
   ],
+  drivingLicences: undefined,
 };
 
 const meta = {

--- a/src/components/profile/sections/LinksSection.stories.tsx
+++ b/src/components/profile/sections/LinksSection.stories.tsx
@@ -45,6 +45,7 @@ export const Default: Story = {
       startYearInDepartment: undefined,
       productionTypes: undefined,
       spokenLanguages: undefined,
+      drivingLicences: undefined,
     },
   },
 };
@@ -59,6 +60,7 @@ export const WebsiteOnly: Story = {
       startYearInDepartment: undefined,
       productionTypes: undefined,
       spokenLanguages: undefined,
+      drivingLicences: undefined,
     },
   },
 };
@@ -73,6 +75,7 @@ export const IMDBOnly: Story = {
       startYearInDepartment: undefined,
       productionTypes: undefined,
       spokenLanguages: undefined,
+      drivingLicences: undefined,
     },
   },
 };
@@ -87,6 +90,7 @@ export const Empty: Story = {
       startYearInDepartment: undefined,
       productionTypes: undefined,
       spokenLanguages: undefined,
+      drivingLicences: undefined,
     },
   },
 };

--- a/src/components/profile/sections/LocationSection.stories.tsx
+++ b/src/components/profile/sections/LocationSection.stories.tsx
@@ -28,6 +28,7 @@ const selfWithData: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  drivingLicences: undefined,
 };
 
 const selfEmpty: ViewableProfile = {
@@ -38,6 +39,7 @@ const selfEmpty: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  drivingLicences: undefined,
 };
 
 const contactWithData: ViewableProfile = {
@@ -48,6 +50,7 @@ const contactWithData: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  drivingLicences: undefined,
 };
 
 const publicCard: ViewableProfile = {

--- a/src/components/profile/sections/ProductionTypesSection.stories.tsx
+++ b/src/components/profile/sections/ProductionTypesSection.stories.tsx
@@ -28,6 +28,7 @@ const selfWithData: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: ["Feature Film", "TV Drama", "Documentary", "Commercial"],
   spokenLanguages: undefined,
+  drivingLicences: undefined,
 };
 
 const selfEmpty: ViewableProfile = {
@@ -40,6 +41,7 @@ const selfEmpty: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  drivingLicences: undefined,
 };
 
 const contactWithData: ViewableProfile = {
@@ -52,6 +54,7 @@ const contactWithData: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: ["Music Video", "Short Film", "Streaming Series"],
   spokenLanguages: undefined,
+  drivingLicences: undefined,
 };
 
 const meta = {

--- a/src/components/profile/sections/YearsSection.stories.tsx
+++ b/src/components/profile/sections/YearsSection.stories.tsx
@@ -22,6 +22,7 @@ const baseCrew = {
   country: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  drivingLicences: undefined,
 };
 
 const selfWithStartYear: ViewableProfile = {

--- a/types/profile/drivingLicences.ts
+++ b/types/profile/drivingLicences.ts
@@ -1,0 +1,11 @@
+export const DRIVING_LICENCES = [
+  "Car (B)",
+  "Motorcycle (A)",
+  "HGV/LGV (C)",
+  "Bus (D)",
+  "Trailer (BE/CE)",
+  "Forklift",
+  "Other",
+] as const;
+
+export type DrivingLicence = (typeof DRIVING_LICENCES)[number];

--- a/types/profile/viewableProfile.ts
+++ b/types/profile/viewableProfile.ts
@@ -31,6 +31,7 @@ type CrewExtras = {
   startYearInDepartment: number | undefined;
   productionTypes: string[] | undefined;
   spokenLanguages: SpokenLanguageEntry[] | undefined;
+  drivingLicences: string[] | undefined;
 };
 
 type CrewProfile = ProfileIdentity & {


### PR DESCRIPTION
Closes #258

## Summary

- Adds Driving Licences section with canonical licence categories (Car (B), Motorcycle (A), HGV/LGV (C), Bus (D), Trailer (BE/CE), Forklift, Other) stored as `users.drivingLicences: string[]`
- Mutation validates entries against the canonical list and rejects duplicates; visible in Self and Contact modes only (not Public Card)
- Design pivot applied: empty sections hidden (no ghost card), section is read-only presentational (no pencil affordance)

## Test plan

- [x] `updateProfileDrivingLicences` mutation tests: happy path, unknown licence rejection, duplicate rejection, empty array, unauthenticated rejection (5 tests)
- [x] All existing tests pass (635 total)
- [x] Lint and format pass
- [x] TypeScript compiles (only expected codegen errors for the new mutation API reference)
- [ ] Manual: Self view shows chip list when licences set, hides section when empty
- [ ] Manual: Contact view shows chip list, Public Card omits section

🤖 Generated with [Claude Code](https://claude.com/claude-code)