### PR TITLE
feat(profile): #262 Visibility toggle (isPublic)

### DIFF
--- a/convex/users/mutations/updateProfileVisibility.test.ts
+++ b/convex/users/mutations/updateProfileVisibility.test.ts
@@ -1,0 +1,61 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+
+import { api } from "../../_generated/api";
+import schema from "../../schema";
+
+const modules = import.meta.glob("/convex/**/*.ts");
+
+const identity = {
+  subject: "clerk_user_42",
+  issuer: "https://example.clerk.test",
+  tokenIdentifier: "https://example.clerk.test|clerk_user_42",
+};
+
+async function makeTestWithCrewUser() {
+  const t = convexTest(schema, modules);
+  await t.run((ctx) =>
+    ctx.db.insert("users", {
+      externalAuthId: identity.subject,
+      email: "me@example.com",
+      hasCompletedOnboarding: true,
+      userType: "crew",
+    }),
+  );
+  return t;
+}
+
+const mut = api.users.mutations.updateProfileVisibility.updateProfileVisibility;
+
+describe("updateProfileVisibility", () => {
+  test("happy path: sets isPublic to true", async () => {
+    const t = await makeTestWithCrewUser();
+    await t.withIdentity(identity).mutation(mut, { isPublic: true });
+    const user = await t.run((ctx) =>
+      ctx.db
+        .query("users")
+        .withIndex("byExternalAuthId", (q) => q.eq("externalAuthId", identity.subject))
+        .unique(),
+    );
+    expect(user?.isPublic).toBe(true);
+  });
+
+  test("happy path: flips isPublic from true to false", async () => {
+    const t = await makeTestWithCrewUser();
+    await t.withIdentity(identity).mutation(mut, { isPublic: true });
+    await t.withIdentity(identity).mutation(mut, { isPublic: false });
+    const user = await t.run((ctx) =>
+      ctx.db
+        .query("users")
+        .withIndex("byExternalAuthId", (q) => q.eq("externalAuthId", identity.subject))
+        .unique(),
+    );
+    expect(user?.isPublic).toBe(false);
+  });
+
+  test("rejects when unauthenticated", async () => {
+    const t = convexTest(schema, modules);
+    await expect(t.mutation(mut, { isPublic: true })).rejects.toThrow("Not authenticated");
+  });
+});

--- a/convex/users/mutations/updateProfileVisibility.ts
+++ b/convex/users/mutations/updateProfileVisibility.ts
@@ -1,0 +1,21 @@
+import { ConvexError, v } from "convex/values";
+
+import { mutation } from "../../_generated/server";
+import { getUserByExternalId } from "../db/getUser";
+
+export const updateProfileVisibility = mutation({
+  args: {
+    isPublic: v.boolean(),
+  },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new ConvexError("Not authenticated");
+
+    const user = await getUserByExternalId(ctx, identity.subject);
+    if (!user) throw new ConvexError("User not found");
+
+    await ctx.db.patch(user._id, {
+      isPublic: args.isPublic,
+    });
+  },
+});

--- a/convex/users/queries.ts
+++ b/convex/users/queries.ts
@@ -41,6 +41,7 @@ export const getMyProfile = query({
       const cvUrl = await resolveStorageUrl(ctx, viewer.cvFileId);
       return {
         mode: "self",
+        isPublic: viewer.isPublic ?? false,
         userId: viewer._id,
         firstName: viewer.firstName,
         lastName: viewer.lastName,
@@ -121,8 +122,7 @@ export const getViewableProfile = query({
         return { mode, ...base };
       }
       const cvUrl = await resolveStorageUrl(ctx, subject.cvFileId);
-      return {
-        mode,
+      const crewExtras = {
         ...base,
         bio: subject.bio,
         website: subject.website,
@@ -132,6 +132,10 @@ export const getViewableProfile = query({
         productionTypes: subject.productionTypes,
         spokenLanguages: subject.spokenLanguages,
       };
+      if (mode === "self") {
+        return { mode, isPublic: subject.isPublic ?? false, ...crewExtras };
+      }
+      return { mode, ...crewExtras };
     }
 
     const userType = subject.userType as "production-manager";

--- a/src/components/profile/Profile.stories.tsx
+++ b/src/components/profile/Profile.stories.tsx
@@ -26,6 +26,7 @@ const basePm = {
 
 const selfWithNicknameProfile: ViewableProfile = {
   mode: "self",
+  isPublic: false,
   ...baseCrew,
   nickname: "Ace",
   bio: undefined,
@@ -39,6 +40,7 @@ const selfWithNicknameProfile: ViewableProfile = {
 
 const selfWithoutNicknameProfile: ViewableProfile = {
   mode: "self",
+  isPublic: false,
   ...baseCrew,
   nickname: undefined,
   bio: undefined,

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -1,4 +1,6 @@
+import { api } from "@convex/_generated/api";
 import type { ViewableProfile } from "@shared/profile/viewableProfile";
+import { useMutation } from "convex/react";
 import { ScrollView } from "react-native";
 
 import { usePictureUpload } from "./PictureUploadFlow";
@@ -10,6 +12,7 @@ import { LanguagesSection } from "./sections/LanguagesSection";
 import { LinksSection } from "./sections/LinksSection";
 import { LocationSection } from "./sections/LocationSection";
 import { ProductionTypesSection } from "./sections/ProductionTypesSection";
+import { VisibilityToggleSection } from "./sections/VisibilityToggleSection";
 import { YearsSection } from "./sections/YearsSection";
 
 type Props = {
@@ -18,6 +21,9 @@ type Props = {
 
 export function Profile({ profile }: Props) {
   const pickAndUpload = usePictureUpload();
+  const updateVisibility = useMutation(
+    api.users.mutations.updateProfileVisibility.updateProfileVisibility,
+  );
 
   return (
     <ScrollView contentContainerClassName="gap-4 p-4">
@@ -30,6 +36,12 @@ export function Profile({ profile }: Props) {
       <BioSection profile={profile} />
       <LinksSection profile={profile} />
       <CvSection profile={profile} />
+      {profile.mode === "self" && (
+        <VisibilityToggleSection
+          isPublic={profile.isPublic}
+          onToggle={(value) => updateVisibility({ isPublic: value })}
+        />
+      )}
     </ScrollView>
   );
 }

--- a/src/components/profile/sections/BioSection.stories.tsx
+++ b/src/components/profile/sections/BioSection.stories.tsx
@@ -23,6 +23,7 @@ const baseCrew = {
 
 const selfWithBio: ViewableProfile = {
   mode: "self",
+  isPublic: false,
   ...baseCrew,
   bio: "Camera operator with 15 years experience in film and television.",
   startYearInDepartment: undefined,
@@ -32,6 +33,7 @@ const selfWithBio: ViewableProfile = {
 
 const selfEmpty: ViewableProfile = {
   mode: "self",
+  isPublic: false,
   ...baseCrew,
   bio: undefined,
   startYearInDepartment: undefined,

--- a/src/components/profile/sections/CvSection.stories.tsx
+++ b/src/components/profile/sections/CvSection.stories.tsx
@@ -22,6 +22,7 @@ const baseCrew = {
 
 const selfWithCv: ViewableProfile = {
   mode: "self",
+  isPublic: false,
   ...baseCrew,
   bio: undefined,
   cvUrl: "https://storage.example.com/cv.pdf",
@@ -32,6 +33,7 @@ const selfWithCv: ViewableProfile = {
 
 const selfEmpty: ViewableProfile = {
   mode: "self",
+  isPublic: false,
   ...baseCrew,
   bio: undefined,
   cvUrl: undefined,

--- a/src/components/profile/sections/DepartmentRolesSection.stories.tsx
+++ b/src/components/profile/sections/DepartmentRolesSection.stories.tsx
@@ -18,6 +18,7 @@ const baseCrew = {
 
 const selfWithData: ViewableProfile = {
   mode: "self",
+  isPublic: false,
   ...baseCrew,
   department: "Camera",
   roles: ["Director of Photography", "1st AC"],
@@ -32,6 +33,7 @@ const selfWithData: ViewableProfile = {
 
 const selfEmpty: ViewableProfile = {
   mode: "self",
+  isPublic: false,
   ...baseCrew,
   department: undefined,
   roles: undefined,

--- a/src/components/profile/sections/IdentitySection.stories.tsx
+++ b/src/components/profile/sections/IdentitySection.stories.tsx
@@ -27,6 +27,7 @@ const basePm = {
 
 const selfWithNicknameProfile: ViewableProfile = {
   mode: "self",
+  isPublic: false,
   ...baseCrew,
   nickname: "Ace",
   bio: undefined,
@@ -40,6 +41,7 @@ const selfWithNicknameProfile: ViewableProfile = {
 
 const selfWithoutNicknameProfile: ViewableProfile = {
   mode: "self",
+  isPublic: false,
   ...baseCrew,
   nickname: undefined,
   bio: undefined,
@@ -53,6 +55,7 @@ const selfWithoutNicknameProfile: ViewableProfile = {
 
 const selfWithPictureProfile: ViewableProfile = {
   mode: "self",
+  isPublic: false,
   ...baseCrew,
   profilePictureUrl: "https://i.pravatar.cc/300?u=ada",
   nickname: undefined,

--- a/src/components/profile/sections/LanguagesSection.stories.tsx
+++ b/src/components/profile/sections/LanguagesSection.stories.tsx
@@ -20,6 +20,7 @@ const baseCrew = {
 
 const selfWithData: ViewableProfile = {
   mode: "self",
+  isPublic: false,
   ...baseCrew,
   bio: undefined,
   website: undefined,
@@ -38,6 +39,7 @@ const selfWithData: ViewableProfile = {
 
 const selfEmpty: ViewableProfile = {
   mode: "self",
+  isPublic: false,
   ...baseCrew,
   bio: undefined,
   website: undefined,

--- a/src/components/profile/sections/LinksSection.stories.tsx
+++ b/src/components/profile/sections/LinksSection.stories.tsx
@@ -39,6 +39,7 @@ export const Default: Story = {
   args: {
     profile: {
       mode: "self",
+      isPublic: false,
       ...baseCrew,
       website: "https://adalovelace.com",
       imdbId: "nm0000123",
@@ -53,6 +54,7 @@ export const WebsiteOnly: Story = {
   args: {
     profile: {
       mode: "self",
+      isPublic: false,
       ...baseCrew,
       website: "https://adalovelace.com",
       imdbId: undefined,
@@ -67,6 +69,7 @@ export const IMDBOnly: Story = {
   args: {
     profile: {
       mode: "self",
+      isPublic: false,
       ...baseCrew,
       website: undefined,
       imdbId: "nm0000100",
@@ -81,6 +84,7 @@ export const Empty: Story = {
   args: {
     profile: {
       mode: "self",
+      isPublic: false,
       ...baseCrew,
       website: undefined,
       imdbId: undefined,

--- a/src/components/profile/sections/LocationSection.stories.tsx
+++ b/src/components/profile/sections/LocationSection.stories.tsx
@@ -22,6 +22,7 @@ const baseCrew = {
 
 const selfWithData: ViewableProfile = {
   mode: "self",
+  isPublic: false,
   ...baseCrew,
   city: "London",
   country: "GB",
@@ -32,6 +33,7 @@ const selfWithData: ViewableProfile = {
 
 const selfEmpty: ViewableProfile = {
   mode: "self",
+  isPublic: false,
   ...baseCrew,
   city: undefined,
   country: undefined,

--- a/src/components/profile/sections/ProductionTypesSection.stories.tsx
+++ b/src/components/profile/sections/ProductionTypesSection.stories.tsx
@@ -20,6 +20,7 @@ const baseCrew = {
 
 const selfWithData: ViewableProfile = {
   mode: "self",
+  isPublic: false,
   ...baseCrew,
   bio: undefined,
   website: undefined,
@@ -32,6 +33,7 @@ const selfWithData: ViewableProfile = {
 
 const selfEmpty: ViewableProfile = {
   mode: "self",
+  isPublic: false,
   ...baseCrew,
   bio: undefined,
   website: undefined,

--- a/src/components/profile/sections/VisibilityToggleSection.stories.tsx
+++ b/src/components/profile/sections/VisibilityToggleSection.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from "@storybook/react-native";
+import { useState } from "react";
+import { View } from "react-native";
+
+import { VisibilityToggleSection } from "./VisibilityToggleSection";
+
+function Harness({ isPublic: initialValue }: { isPublic: boolean }) {
+  const [isPublic, setIsPublic] = useState(initialValue);
+  return <VisibilityToggleSection isPublic={isPublic} onToggle={setIsPublic} />;
+}
+
+const meta = {
+  title: "Profile/VisibilityToggleSection",
+  component: VisibilityToggleSection,
+  decorators: [
+    (Story) => (
+      <View style={{ flex: 1, padding: 16 }}>
+        <Story />
+      </View>
+    ),
+  ],
+  tags: ["autodocs"],
+  args: { isPublic: true, onToggle: () => {} },
+} satisfies Meta<typeof VisibilityToggleSection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ToggleOn: Story = {
+  render: () => <Harness isPublic={true} />,
+};
+
+export const ToggleOff: Story = {
+  render: () => <Harness isPublic={false} />,
+};

--- a/src/components/profile/sections/VisibilityToggleSection.tsx
+++ b/src/components/profile/sections/VisibilityToggleSection.tsx
@@ -1,0 +1,21 @@
+import { Switch } from "heroui-native";
+import { Text, View } from "react-native";
+
+type Props = {
+  isPublic: boolean;
+  onToggle: (value: boolean) => void;
+};
+
+export function VisibilityToggleSection({ isPublic, onToggle }: Props) {
+  return (
+    <View className="flex-row items-center justify-between gap-4">
+      <View className="flex-1">
+        <Text className="text-sm font-medium text-foreground">Discoverable</Text>
+        <Text className="text-xs text-muted">
+          Allow crew who don't yet know you to find you in search
+        </Text>
+      </View>
+      <Switch isSelected={isPublic} onSelectedChange={onToggle} />
+    </View>
+  );
+}

--- a/src/components/profile/sections/YearsSection.stories.tsx
+++ b/src/components/profile/sections/YearsSection.stories.tsx
@@ -26,12 +26,14 @@ const baseCrew = {
 
 const selfWithStartYear: ViewableProfile = {
   mode: "self",
+  isPublic: false,
   ...baseCrew,
   startYearInDepartment: 2015,
 };
 
 const selfEmpty: ViewableProfile = {
   mode: "self",
+  isPublic: false,
   ...baseCrew,
   startYearInDepartment: undefined,
 };

--- a/types/profile/viewableProfile.ts
+++ b/types/profile/viewableProfile.ts
@@ -44,7 +44,7 @@ type ProductionManagerProfile = ProfileIdentity & {
 };
 
 export type ViewableProfile =
-  | ({ mode: "self" } & CrewProfile & BioLinks & Location & CrewExtras)
+  | ({ mode: "self"; isPublic: boolean } & CrewProfile & BioLinks & Location & CrewExtras)
   | ({ mode: "contact" } & CrewProfile & BioLinks & Location & CrewExtras)
   | ({ mode: "public-card" } & CrewProfile & Location)
   | ({ mode: "pm-self" } & ProductionManagerProfile)


### PR DESCRIPTION
Closes #262

## Summary

- Adds a Self-mode-only visibility toggle using HeroUI Native Switch that flips `users.isPublic`
- `isPublic` added to the Self variant of ViewableProfile and wired through both profile queries
- Mutation is simple boolean patch with auth check; section is presentational with props

## Test plan

- [x] `updateProfileVisibility` mutation tests: set to true, flip true→false, unauthenticated rejection (3 tests)
- [x] All existing tests pass (633 total)
- [x] Lint and format pass
- [ ] Manual: Self user sees toggle; flipping off causes non-contacts to get "Profile not found"
- [ ] Manual: Non-Self viewers never see the toggle
- [ ] Manual: Toggle state persists across page refreshes

🤖 Generated with [Claude Code](https://claude.com/claude-code)