### PR TITLE
feat(profile): #264 Passports section

### DIFF
--- a/convex/users/mutations/updateProfilePassports.test.ts
+++ b/convex/users/mutations/updateProfilePassports.test.ts
@@ -1,0 +1,89 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+
+import { api } from "../../_generated/api";
+import schema from "../../schema";
+
+const modules = import.meta.glob("/convex/**/*.ts");
+
+const identity = {
+  subject: "clerk_user_42",
+  issuer: "https://example.clerk.test",
+  tokenIdentifier: "https://example.clerk.test|clerk_user_42",
+};
+
+async function makeTestWithCrewUser() {
+  const t = convexTest(schema, modules);
+  await t.run((ctx) =>
+    ctx.db.insert("users", {
+      externalAuthId: identity.subject,
+      email: "me@example.com",
+      hasCompletedOnboarding: true,
+      userType: "crew",
+    }),
+  );
+  return t;
+}
+
+const mut = api.users.mutations.updateProfilePassports.updateProfilePassports;
+
+describe("updateProfilePassports", () => {
+  test("happy path: sets passports", async () => {
+    const t = await makeTestWithCrewUser();
+    await t.withIdentity(identity).mutation(mut, {
+      passports: ["GB", "US", "IE"],
+    });
+    const user = await t.run((ctx) =>
+      ctx.db
+        .query("users")
+        .withIndex("byExternalAuthId", (q) => q.eq("externalAuthId", identity.subject))
+        .unique(),
+    );
+    expect(user?.passports).toEqual(["GB", "US", "IE"]);
+  });
+
+  test("rejects unknown country code", async () => {
+    const t = await makeTestWithCrewUser();
+    await expect(
+      t.withIdentity(identity).mutation(mut, {
+        passports: ["GB", "XX"],
+      }),
+    ).rejects.toThrow('Unknown country code: "XX"');
+  });
+
+  test("rejects duplicate country code", async () => {
+    const t = await makeTestWithCrewUser();
+    await expect(
+      t.withIdentity(identity).mutation(mut, {
+        passports: ["US", "US"],
+      }),
+    ).rejects.toThrow('Duplicate country code: "US"');
+  });
+
+  test("accepts empty array", async () => {
+    const t = await makeTestWithCrewUser();
+    await t.withIdentity(identity).mutation(mut, {
+      passports: ["GB"],
+    });
+    await t.withIdentity(identity).mutation(mut, {
+      passports: [],
+    });
+    const user = await t.run((ctx) =>
+      ctx.db
+        .query("users")
+        .withIndex("byExternalAuthId", (q) => q.eq("externalAuthId", identity.subject))
+        .unique(),
+    );
+    expect(user?.passports).toEqual([]);
+  });
+
+  test("rejects when unauthenticated", async () => {
+    const t = convexTest(schema, modules);
+    await expect(
+      t.mutation(mut, {
+        passports: ["GB"],
+      }),
+    ).rejects.toThrow("Not authenticated");
+  });
+});

--- a/convex/users/mutations/updateProfilePassports.ts
+++ b/convex/users/mutations/updateProfilePassports.ts
@@ -1,0 +1,35 @@
+import { COUNTRIES } from "@shared/countries/countries";
+import { ConvexError, v } from "convex/values";
+
+import { mutation } from "../../_generated/server";
+import { getUserByExternalId } from "../db/getUser";
+
+const VALID_COUNTRY_CODES: Set<string> = new Set(COUNTRIES.map((c) => c.code));
+
+export const updateProfilePassports = mutation({
+  args: {
+    passports: v.array(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new ConvexError("Not authenticated");
+
+    const user = await getUserByExternalId(ctx, identity.subject);
+    if (!user) throw new ConvexError("User not found");
+
+    const seen = new Set<string>();
+    for (const code of args.passports) {
+      if (!VALID_COUNTRY_CODES.has(code)) {
+        throw new ConvexError(`Unknown country code: "${code}"`);
+      }
+      if (seen.has(code)) {
+        throw new ConvexError(`Duplicate country code: "${code}"`);
+      }
+      seen.add(code);
+    }
+
+    await ctx.db.patch(user._id, {
+      passports: args.passports,
+    });
+  },
+});

--- a/convex/users/queries.ts
+++ b/convex/users/queries.ts
@@ -58,6 +58,7 @@ export const getMyProfile = query({
         startYearInDepartment: viewer.startYearInDepartment,
         productionTypes: viewer.productionTypes,
         spokenLanguages: viewer.spokenLanguages,
+        passports: viewer.passports,
       };
     }
 
@@ -131,6 +132,7 @@ export const getViewableProfile = query({
         startYearInDepartment: subject.startYearInDepartment,
         productionTypes: subject.productionTypes,
         spokenLanguages: subject.spokenLanguages,
+        passports: subject.passports,
       };
     }
 

--- a/src/app/profile/edit/passports.tsx
+++ b/src/app/profile/edit/passports.tsx
@@ -1,0 +1,130 @@
+import { api } from "@convex/_generated/api";
+import { COUNTRIES } from "@shared/countries/countries";
+import { useForm } from "@tanstack/react-form";
+import { useMutation, useQuery } from "convex/react";
+import { useRouter } from "expo-router";
+import { Button, Checkbox, ControlField, Label, Spinner } from "heroui-native";
+import { useMemo, useState } from "react";
+import { ScrollView, TextInput, View } from "react-native";
+
+import { Title } from "@/components/ui/Title";
+
+const COUNTRY_OPTIONS = COUNTRIES.map((c) => ({ code: c.code, name: c.name }));
+
+export default function EditPassportsScreen() {
+  const router = useRouter();
+  const profile = useQuery(api.users.queries.getMyProfile);
+  const updatePassports = useMutation(
+    api.users.mutations.updateProfilePassports.updateProfilePassports,
+  );
+
+  if (profile === undefined) {
+    return (
+      <View className="flex-1 items-center justify-center">
+        <Spinner />
+      </View>
+    );
+  }
+
+  if (profile === null || profile.userType !== "crew") {
+    return (
+      <View className="flex-1 items-center justify-center px-4">
+        <Title title="Sign in to edit your profile" />
+      </View>
+    );
+  }
+
+  const current =
+    profile.mode === "self" || profile.mode === "contact" ? (profile.passports ?? []) : [];
+
+  return (
+    <EditPassportsForm
+      initialPassports={current}
+      onDone={() => router.back()}
+      onSubmit={updatePassports}
+    />
+  );
+}
+
+type FormProps = {
+  initialPassports: string[];
+  onDone: () => void;
+  onSubmit: (args: { passports: string[] }) => Promise<unknown>;
+};
+
+function EditPassportsForm({ initialPassports, onDone, onSubmit }: FormProps) {
+  const [search, setSearch] = useState("");
+
+  const form = useForm({
+    defaultValues: {
+      passports: initialPassports,
+    },
+    onSubmit: async ({ value }) => {
+      await onSubmit({ passports: value.passports });
+      onDone();
+    },
+  });
+
+  const filtered = useMemo(() => {
+    if (!search.trim()) return COUNTRY_OPTIONS;
+    const q = search.trim().toLowerCase();
+    return COUNTRY_OPTIONS.filter(
+      (c) => c.name.toLowerCase().includes(q) || c.code.toLowerCase().includes(q),
+    );
+  }, [search]);
+
+  return (
+    <ScrollView className="flex-1" contentContainerClassName="p-4 gap-4">
+      <TextInput
+        className="border-divider rounded-lg border px-3 py-2 text-sm text-foreground"
+        placeholder="Search countries..."
+        value={search}
+        onChangeText={setSearch}
+        autoCapitalize="none"
+        autoCorrect={false}
+      />
+
+      <form.Field name="passports">
+        {(field) => (
+          <View className="gap-3">
+            {filtered.map((country) => {
+              const isSelected = field.state.value.includes(country.code);
+              return (
+                <ControlField
+                  key={country.code}
+                  isSelected={isSelected}
+                  onSelectedChange={() => {
+                    const next = isSelected
+                      ? field.state.value.filter((c) => c !== country.code)
+                      : [...field.state.value, country.code];
+                    field.handleChange(next);
+                  }}
+                >
+                  <ControlField.Indicator>
+                    <Checkbox />
+                  </ControlField.Indicator>
+                  <Label>{country.name}</Label>
+                </ControlField>
+              );
+            })}
+          </View>
+        )}
+      </form.Field>
+
+      <form.Subscribe
+        selector={(state) => ({ canSubmit: state.canSubmit, isSubmitting: state.isSubmitting })}
+      >
+        {({ canSubmit, isSubmitting }) => (
+          <Button
+            variant="primary"
+            onPress={() => form.handleSubmit()}
+            isDisabled={!canSubmit || isSubmitting}
+            className="w-full"
+          >
+            {isSubmitting ? "Saving..." : "Save"}
+          </Button>
+        )}
+      </form.Subscribe>
+    </ScrollView>
+  );
+}

--- a/src/components/profile/Profile.stories.tsx
+++ b/src/components/profile/Profile.stories.tsx
@@ -35,6 +35,7 @@ const selfWithNicknameProfile: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  passports: undefined,
 };
 
 const selfWithoutNicknameProfile: ViewableProfile = {
@@ -48,6 +49,7 @@ const selfWithoutNicknameProfile: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  passports: undefined,
 };
 
 const contactProfile: ViewableProfile = {
@@ -61,6 +63,7 @@ const contactProfile: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  passports: undefined,
 };
 
 const publicCardProfile: ViewableProfile = {

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -9,6 +9,7 @@ import { IdentitySection } from "./sections/IdentitySection";
 import { LanguagesSection } from "./sections/LanguagesSection";
 import { LinksSection } from "./sections/LinksSection";
 import { LocationSection } from "./sections/LocationSection";
+import { PassportsSection } from "./sections/PassportsSection";
 import { ProductionTypesSection } from "./sections/ProductionTypesSection";
 import { YearsSection } from "./sections/YearsSection";
 
@@ -25,6 +26,7 @@ export function Profile({ profile }: Props) {
       <DepartmentRolesSection profile={profile} />
       <YearsSection profile={profile} />
       <ProductionTypesSection profile={profile} />
+      <PassportsSection profile={profile} />
       <LanguagesSection profile={profile} />
       <LocationSection profile={profile} />
       <BioSection profile={profile} />

--- a/src/components/profile/sections/BioSection.stories.tsx
+++ b/src/components/profile/sections/BioSection.stories.tsx
@@ -28,6 +28,7 @@ const selfWithBio: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  passports: undefined,
 };
 
 const selfEmpty: ViewableProfile = {
@@ -37,6 +38,7 @@ const selfEmpty: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  passports: undefined,
 };
 
 const contactWithBio: ViewableProfile = {
@@ -46,6 +48,7 @@ const contactWithBio: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  passports: undefined,
 };
 
 const meta = {

--- a/src/components/profile/sections/CvSection.stories.tsx
+++ b/src/components/profile/sections/CvSection.stories.tsx
@@ -28,6 +28,7 @@ const selfWithCv: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  passports: undefined,
 };
 
 const selfEmpty: ViewableProfile = {
@@ -38,6 +39,7 @@ const selfEmpty: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  passports: undefined,
 };
 
 const contactWithCv: ViewableProfile = {
@@ -48,6 +50,7 @@ const contactWithCv: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  passports: undefined,
 };
 
 const meta = {

--- a/src/components/profile/sections/DepartmentRolesSection.stories.tsx
+++ b/src/components/profile/sections/DepartmentRolesSection.stories.tsx
@@ -28,6 +28,7 @@ const selfWithData: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  passports: undefined,
 };
 
 const selfEmpty: ViewableProfile = {
@@ -42,6 +43,7 @@ const selfEmpty: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  passports: undefined,
 };
 
 const contact: ViewableProfile = {
@@ -56,6 +58,7 @@ const contact: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  passports: undefined,
 };
 
 const publicCard: ViewableProfile = {

--- a/src/components/profile/sections/IdentitySection.stories.tsx
+++ b/src/components/profile/sections/IdentitySection.stories.tsx
@@ -36,6 +36,7 @@ const selfWithNicknameProfile: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  passports: undefined,
 };
 
 const selfWithoutNicknameProfile: ViewableProfile = {
@@ -49,6 +50,7 @@ const selfWithoutNicknameProfile: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  passports: undefined,
 };
 
 const selfWithPictureProfile: ViewableProfile = {
@@ -63,6 +65,7 @@ const selfWithPictureProfile: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  passports: undefined,
 };
 
 const contactProfile: ViewableProfile = {
@@ -76,6 +79,7 @@ const contactProfile: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  passports: undefined,
 };
 
 const publicCardProfile: ViewableProfile = {

--- a/src/components/profile/sections/LinksSection.stories.tsx
+++ b/src/components/profile/sections/LinksSection.stories.tsx
@@ -45,6 +45,7 @@ export const Default: Story = {
       startYearInDepartment: undefined,
       productionTypes: undefined,
       spokenLanguages: undefined,
+      passports: undefined,
     },
   },
 };
@@ -59,6 +60,7 @@ export const WebsiteOnly: Story = {
       startYearInDepartment: undefined,
       productionTypes: undefined,
       spokenLanguages: undefined,
+      passports: undefined,
     },
   },
 };
@@ -73,6 +75,7 @@ export const IMDBOnly: Story = {
       startYearInDepartment: undefined,
       productionTypes: undefined,
       spokenLanguages: undefined,
+      passports: undefined,
     },
   },
 };
@@ -87,6 +90,7 @@ export const Empty: Story = {
       startYearInDepartment: undefined,
       productionTypes: undefined,
       spokenLanguages: undefined,
+      passports: undefined,
     },
   },
 };

--- a/src/components/profile/sections/LocationSection.stories.tsx
+++ b/src/components/profile/sections/LocationSection.stories.tsx
@@ -28,6 +28,7 @@ const selfWithData: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  passports: undefined,
 };
 
 const selfEmpty: ViewableProfile = {
@@ -38,6 +39,7 @@ const selfEmpty: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  passports: undefined,
 };
 
 const contactWithData: ViewableProfile = {
@@ -48,6 +50,7 @@ const contactWithData: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  passports: undefined,
 };
 
 const publicCard: ViewableProfile = {

--- a/src/components/profile/sections/PassportsSection.stories.tsx
+++ b/src/components/profile/sections/PassportsSection.stories.tsx
@@ -3,7 +3,7 @@ import type { ViewableProfile } from "@shared/profile/viewableProfile";
 import type { Meta, StoryObj } from "@storybook/react-native";
 import { View } from "react-native";
 
-import { LanguagesSection } from "./LanguagesSection";
+import { PassportsSection } from "./PassportsSection";
 
 const baseCrew = {
   userId: "user_1" as Id<"users">,
@@ -27,14 +27,8 @@ const selfWithData: ViewableProfile = {
   cvUrl: undefined,
   startYearInDepartment: undefined,
   productionTypes: undefined,
-  spokenLanguages: [
-    { code: "fr", fluency: "fluent" },
-    { code: "en", fluency: "native" },
-    { code: "de", fluency: "basic" },
-    { code: "es", fluency: "conversational" },
-    { code: "ja", fluency: "professional" },
-  ],
-  passports: undefined,
+  spokenLanguages: undefined,
+  passports: ["GB", "IE", "US"],
 };
 
 const selfEmpty: ViewableProfile = {
@@ -59,16 +53,13 @@ const contactWithData: ViewableProfile = {
   cvUrl: undefined,
   startYearInDepartment: undefined,
   productionTypes: undefined,
-  spokenLanguages: [
-    { code: "ar", fluency: "native" },
-    { code: "en", fluency: "professional" },
-  ],
-  passports: undefined,
+  spokenLanguages: undefined,
+  passports: ["AU", "NZ"],
 };
 
 const meta = {
-  title: "Profile/LanguagesSection",
-  component: LanguagesSection,
+  title: "Profile/PassportsSection",
+  component: PassportsSection,
   decorators: [
     (Story) => (
       <View style={{ flex: 1, padding: 16 }}>
@@ -78,7 +69,7 @@ const meta = {
   ],
   tags: ["autodocs"],
   args: { profile: selfWithData },
-} satisfies Meta<typeof LanguagesSection>;
+} satisfies Meta<typeof PassportsSection>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/src/components/profile/sections/PassportsSection.tsx
+++ b/src/components/profile/sections/PassportsSection.tsx
@@ -1,0 +1,36 @@
+import { COUNTRIES } from "@shared/countries/countries";
+import type { ViewableProfile } from "@shared/profile/viewableProfile";
+import { Chip } from "heroui-native";
+import { Text, View } from "react-native";
+
+const COUNTRY_NAME_BY_CODE = new Map(COUNTRIES.map((c) => [c.code, c.name]));
+
+type Props = {
+  profile: ViewableProfile;
+};
+
+function hasPassports(profile: ViewableProfile): profile is Extract<
+  ViewableProfile,
+  { passports: string[] | undefined }
+> & {
+  passports: string[];
+} {
+  return "passports" in profile && Array.isArray(profile.passports) && profile.passports.length > 0;
+}
+
+export function PassportsSection({ profile }: Props) {
+  if (!hasPassports(profile)) return null;
+
+  return (
+    <View className="gap-2">
+      <Text className="text-sm font-medium text-muted">Passports</Text>
+      <View className="flex-row flex-wrap gap-2">
+        {profile.passports.map((code) => (
+          <Chip key={code} variant="secondary" size="sm">
+            {COUNTRY_NAME_BY_CODE.get(code) ?? code}
+          </Chip>
+        ))}
+      </View>
+    </View>
+  );
+}

--- a/src/components/profile/sections/ProductionTypesSection.stories.tsx
+++ b/src/components/profile/sections/ProductionTypesSection.stories.tsx
@@ -28,6 +28,7 @@ const selfWithData: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: ["Feature Film", "TV Drama", "Documentary", "Commercial"],
   spokenLanguages: undefined,
+  passports: undefined,
 };
 
 const selfEmpty: ViewableProfile = {
@@ -40,6 +41,7 @@ const selfEmpty: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  passports: undefined,
 };
 
 const contactWithData: ViewableProfile = {
@@ -52,6 +54,7 @@ const contactWithData: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: ["Music Video", "Short Film", "Streaming Series"],
   spokenLanguages: undefined,
+  passports: undefined,
 };
 
 const meta = {

--- a/src/components/profile/sections/YearsSection.stories.tsx
+++ b/src/components/profile/sections/YearsSection.stories.tsx
@@ -22,6 +22,7 @@ const baseCrew = {
   country: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  passports: undefined,
 };
 
 const selfWithStartYear: ViewableProfile = {

--- a/types/profile/viewableProfile.ts
+++ b/types/profile/viewableProfile.ts
@@ -31,6 +31,7 @@ type CrewExtras = {
   startYearInDepartment: number | undefined;
   productionTypes: string[] | undefined;
   spokenLanguages: SpokenLanguageEntry[] | undefined;
+  passports: string[] | undefined;
 };
 
 type CrewProfile = ProfileIdentity & {


### PR DESCRIPTION
Closes #264

## Summary

- Adds Passports section — multi-select of ISO 3166-1 alpha-2 country codes validated against the canonical `types/countries/countries.ts` list
- Section resolves alpha-2 codes to human-readable country names; renders as chip list in insertion order
- Design pivot applied: empty sections hidden (no ghost card), section is read-only presentational

## Test plan

- [x] `updateProfilePassports` mutation tests: happy path, unknown code rejection, duplicate rejection, empty array, unauthenticated rejection (5 tests)
- [x] All existing tests pass (635 total)
- [x] Lint and format pass
- [ ] Manual: Self view shows country name chips when passports set, hides section when empty
- [ ] Manual: Contact view shows chip list, Public Card omits section
- [ ] Manual: Edit route search filters countries correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)