### PR TITLE
feat(profile): Memberships read display

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -76,6 +76,7 @@ import type * as jobs_domain_generateIcs from "../jobs/domain/generateIcs.js";
 import type * as jobs_http from "../jobs/http.js";
 import type * as jobs_queries from "../jobs/queries.js";
 import type * as lib_parseOrConvexError from "../lib/parseOrConvexError.js";
+import type * as memberships_queries_listMembershipsForUser from "../memberships/queries/listMembershipsForUser.js";
 import type * as notifications_actions from "../notifications/actions.js";
 import type * as notifications_db_countUnreadForUser from "../notifications/db/countUnreadForUser.js";
 import type * as notifications_db_createNotification from "../notifications/db/createNotification.js";
@@ -182,6 +183,7 @@ declare const fullApi: ApiFromModules<{
   "jobs/http": typeof jobs_http;
   "jobs/queries": typeof jobs_queries;
   "lib/parseOrConvexError": typeof lib_parseOrConvexError;
+  "memberships/queries/listMembershipsForUser": typeof memberships_queries_listMembershipsForUser;
   "notifications/actions": typeof notifications_actions;
   "notifications/db/countUnreadForUser": typeof notifications_db_countUnreadForUser;
   "notifications/db/createNotification": typeof notifications_db_createNotification;

--- a/convex/memberships/queries/listMembershipsForUser.test.ts
+++ b/convex/memberships/queries/listMembershipsForUser.test.ts
@@ -1,0 +1,146 @@
+/// <reference types="vite/client" />
+import { convexTest, type TestConvex } from "convex-test";
+import { describe, expect, test } from "vitest";
+
+import { api } from "../../_generated/api";
+import type { Id } from "../../_generated/dataModel";
+import schema from "../../schema";
+
+const modules = import.meta.glob("/convex/**/*.ts");
+
+const aliceIdentity = {
+  subject: "clerk_alice",
+  issuer: "https://example.clerk.test",
+  tokenIdentifier: "https://example.clerk.test|clerk_alice",
+};
+
+const bobIdentity = {
+  subject: "clerk_bob",
+  issuer: "https://example.clerk.test",
+  tokenIdentifier: "https://example.clerk.test|clerk_bob",
+};
+
+async function insertCrewUser(
+  t: TestConvex<typeof schema>,
+  externalAuthId: string,
+  email: string,
+  opts?: { isPublic?: boolean },
+): Promise<Id<"users">> {
+  return t.run((ctx) =>
+    ctx.db.insert("users", {
+      externalAuthId,
+      email,
+      hasCompletedOnboarding: true,
+      userType: "crew",
+      isPublic: opts?.isPublic ?? false,
+    }),
+  );
+}
+
+describe("listMembershipsForUser", () => {
+  test("self returns rows sorted alphabetically", async () => {
+    const t = convexTest(schema, modules);
+    const aliceId = await insertCrewUser(t, aliceIdentity.subject, "alice@example.com");
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("memberships", { userId: aliceId, name: "GBCT" });
+      await ctx.db.insert("memberships", { userId: aliceId, name: "BECTU", memberNumber: "12345" });
+      await ctx.db.insert("memberships", { userId: aliceId, name: "BSC" });
+    });
+
+    const result = await t
+      .withIdentity(aliceIdentity)
+      .query(api.memberships.queries.listMembershipsForUser.listMembershipsForUser, {
+        userId: aliceId,
+      });
+
+    expect(result).toHaveLength(3);
+    expect(result[0].name).toBe("BECTU");
+    expect(result[0].memberNumber).toBe("12345");
+    expect(result[1].name).toBe("BSC");
+    expect(result[2].name).toBe("GBCT");
+  });
+
+  test("contact returns rows", async () => {
+    const t = convexTest(schema, modules);
+    const aliceId = await insertCrewUser(t, aliceIdentity.subject, "alice@example.com");
+    const bobId = await insertCrewUser(t, bobIdentity.subject, "bob@example.com");
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("memberships", { userId: aliceId, name: "BECTU" });
+      await ctx.db.insert("contacts", {
+        ownerId: bobId,
+        contactUserId: aliceId,
+        createdAt: Date.now(),
+      });
+    });
+
+    const result = await t
+      .withIdentity(bobIdentity)
+      .query(api.memberships.queries.listMembershipsForUser.listMembershipsForUser, {
+        userId: aliceId,
+      });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("BECTU");
+  });
+
+  test("public-card returns empty array", async () => {
+    const t = convexTest(schema, modules);
+    const aliceId = await insertCrewUser(t, aliceIdentity.subject, "alice@example.com", {
+      isPublic: true,
+    });
+    await insertCrewUser(t, bobIdentity.subject, "bob@example.com");
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("memberships", { userId: aliceId, name: "BECTU" });
+    });
+
+    const result = await t
+      .withIdentity(bobIdentity)
+      .query(api.memberships.queries.listMembershipsForUser.listMembershipsForUser, {
+        userId: aliceId,
+      });
+
+    expect(result).toEqual([]);
+  });
+
+  test("hidden returns empty array", async () => {
+    const t = convexTest(schema, modules);
+    const aliceId = await insertCrewUser(t, aliceIdentity.subject, "alice@example.com", {
+      isPublic: false,
+    });
+    await insertCrewUser(t, bobIdentity.subject, "bob@example.com");
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("memberships", { userId: aliceId, name: "BECTU" });
+    });
+
+    const result = await t
+      .withIdentity(bobIdentity)
+      .query(api.memberships.queries.listMembershipsForUser.listMembershipsForUser, {
+        userId: aliceId,
+      });
+
+    expect(result).toEqual([]);
+  });
+
+  test("alphabetical order is verified", async () => {
+    const t = convexTest(schema, modules);
+    const aliceId = await insertCrewUser(t, aliceIdentity.subject, "alice@example.com");
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("memberships", { userId: aliceId, name: "Zimmer" });
+      await ctx.db.insert("memberships", { userId: aliceId, name: "Alpha" });
+      await ctx.db.insert("memberships", { userId: aliceId, name: "Middle" });
+    });
+
+    const result = await t
+      .withIdentity(aliceIdentity)
+      .query(api.memberships.queries.listMembershipsForUser.listMembershipsForUser, {
+        userId: aliceId,
+      });
+
+    expect(result.map((r) => r.name)).toEqual(["Alpha", "Middle", "Zimmer"]);
+  });
+});

--- a/convex/memberships/queries/listMembershipsForUser.ts
+++ b/convex/memberships/queries/listMembershipsForUser.ts
@@ -1,0 +1,48 @@
+import { v } from "convex/values";
+
+import { query } from "../../_generated/server";
+import { getUserByExternalId } from "../../users/db/getUser";
+import { resolveProfileVisibility } from "../../users/lib/resolveProfileVisibility";
+
+export const listMembershipsForUser = query({
+  args: { userId: v.id("users") },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    const viewer = identity ? await getUserByExternalId(ctx, identity.subject) : null;
+
+    const subject = await ctx.db.get(args.userId);
+    if (!subject) return [];
+
+    let isContact = false;
+    if (viewer !== null) {
+      const result = await ctx.db
+        .query("contacts")
+        .withIndex("byOwnerAndContact", (q) =>
+          q.eq("ownerId", viewer._id).eq("contactUserId", subject._id),
+        )
+        .unique();
+      isContact = result !== null;
+    }
+
+    const visibility = resolveProfileVisibility({
+      viewerUserId: viewer?._id ?? null,
+      subject: { _id: subject._id, userType: subject.userType, isPublic: subject.isPublic },
+      isContact,
+    });
+
+    if (visibility.mode !== "self" && visibility.mode !== "contact") return [];
+
+    const rows = await ctx.db
+      .query("memberships")
+      .withIndex("byUserId", (q) => q.eq("userId", args.userId))
+      .collect();
+
+    rows.sort((a, b) => a.name.localeCompare(b.name));
+
+    return rows.map((r) => ({
+      id: r._id,
+      name: r.name,
+      memberNumber: r.memberNumber,
+    }));
+  },
+});

--- a/convex/memberships/schema.ts
+++ b/convex/memberships/schema.ts
@@ -1,0 +1,12 @@
+import { defineTable } from "convex/server";
+import { v } from "convex/values";
+
+export const Membership = {
+  userId: v.id("users"),
+  name: v.string(),
+  memberNumber: v.optional(v.string()),
+};
+
+export const membershipsSchema = {
+  memberships: defineTable(Membership).index("byUserId", ["userId"]),
+};

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -4,6 +4,7 @@ import { calendarsSchema } from "./calendars/schema";
 import { contactsSchema } from "./contacts/schema";
 import { jobsSchema } from "./jobs/schema";
 import { kitSchema } from "./kit/schema";
+import { membershipsSchema } from "./memberships/schema";
 import { notificationsSchema } from "./notifications/schema";
 import { usersSchema } from "./users/schema";
 
@@ -14,4 +15,5 @@ export default defineSchema({
   ...jobsSchema,
   ...contactsSchema,
   ...notificationsSchema,
+  ...membershipsSchema,
 });

--- a/convex/users/queries.ts
+++ b/convex/users/queries.ts
@@ -39,6 +39,15 @@ export const getMyProfile = query({
 
     if (viewer.userType === "crew") {
       const cvUrl = await resolveStorageUrl(ctx, viewer.cvFileId);
+      const membershipRows = await ctx.db
+        .query("memberships")
+        .withIndex("byUserId", (q) => q.eq("userId", viewer._id))
+        .collect();
+      membershipRows.sort((a, b) => a.name.localeCompare(b.name));
+      const memberships =
+        membershipRows.length > 0
+          ? membershipRows.map((r) => ({ id: r._id, name: r.name, memberNumber: r.memberNumber }))
+          : undefined;
       return {
         mode: "self",
         isPublic: viewer.isPublic ?? false,
@@ -62,6 +71,7 @@ export const getMyProfile = query({
         passports: viewer.passports,
         drivingLicences: viewer.drivingLicences,
         workEligibility: viewer.workEligibility,
+        memberships,
       };
     }
 
@@ -125,6 +135,15 @@ export const getViewableProfile = query({
         return { mode, ...base };
       }
       const cvUrl = await resolveStorageUrl(ctx, subject.cvFileId);
+      const membershipRows = await ctx.db
+        .query("memberships")
+        .withIndex("byUserId", (q) => q.eq("userId", subject._id))
+        .collect();
+      membershipRows.sort((a, b) => a.name.localeCompare(b.name));
+      const memberships =
+        membershipRows.length > 0
+          ? membershipRows.map((r) => ({ id: r._id, name: r.name, memberNumber: r.memberNumber }))
+          : undefined;
       const crewExtras = {
         ...base,
         bio: subject.bio,
@@ -137,6 +156,7 @@ export const getViewableProfile = query({
         passports: subject.passports,
         drivingLicences: subject.drivingLicences,
         workEligibility: subject.workEligibility,
+        memberships,
       };
       if (mode === "self") {
         return { mode, isPublic: subject.isPublic ?? false, ...crewExtras };

--- a/src/components/profile/Profile.stories.tsx
+++ b/src/components/profile/Profile.stories.tsx
@@ -39,6 +39,7 @@ const selfWithNicknameProfile: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  memberships: undefined,
 };
 
 const selfWithoutNicknameProfile: ViewableProfile = {
@@ -56,6 +57,7 @@ const selfWithoutNicknameProfile: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  memberships: undefined,
 };
 
 const contactProfile: ViewableProfile = {
@@ -72,6 +74,7 @@ const contactProfile: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  memberships: undefined,
 };
 
 const publicCardProfile: ViewableProfile = {

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -12,6 +12,7 @@ import { IdentitySection } from "./sections/IdentitySection";
 import { LanguagesSection } from "./sections/LanguagesSection";
 import { LinksSection } from "./sections/LinksSection";
 import { LocationSection } from "./sections/LocationSection";
+import { MembershipsSection } from "./sections/MembershipsSection";
 import { PassportsSection } from "./sections/PassportsSection";
 import { ProductionTypesSection } from "./sections/ProductionTypesSection";
 import { VisibilityToggleSection } from "./sections/VisibilityToggleSection";
@@ -38,6 +39,7 @@ export function Profile({ profile }: Props) {
       <DrivingLicencesSection profile={profile} />
       <WorkEligibilitySection profile={profile} />
       <LanguagesSection profile={profile} />
+      <MembershipsSection profile={profile} />
       <LocationSection profile={profile} />
       <BioSection profile={profile} />
       <LinksSection profile={profile} />

--- a/src/components/profile/sections/BioSection.stories.tsx
+++ b/src/components/profile/sections/BioSection.stories.tsx
@@ -32,6 +32,7 @@ const selfWithBio: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  memberships: undefined,
 };
 
 const selfEmpty: ViewableProfile = {
@@ -45,6 +46,7 @@ const selfEmpty: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  memberships: undefined,
 };
 
 const contactWithBio: ViewableProfile = {
@@ -57,6 +59,7 @@ const contactWithBio: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  memberships: undefined,
 };
 
 const meta = {

--- a/src/components/profile/sections/CvSection.stories.tsx
+++ b/src/components/profile/sections/CvSection.stories.tsx
@@ -32,6 +32,7 @@ const selfWithCv: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  memberships: undefined,
 };
 
 const selfEmpty: ViewableProfile = {
@@ -46,6 +47,7 @@ const selfEmpty: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  memberships: undefined,
 };
 
 const contactWithCv: ViewableProfile = {
@@ -59,6 +61,7 @@ const contactWithCv: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  memberships: undefined,
 };
 
 const meta = {

--- a/src/components/profile/sections/DepartmentRolesSection.stories.tsx
+++ b/src/components/profile/sections/DepartmentRolesSection.stories.tsx
@@ -32,6 +32,7 @@ const selfWithData: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  memberships: undefined,
 };
 
 const selfEmpty: ViewableProfile = {
@@ -50,6 +51,7 @@ const selfEmpty: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  memberships: undefined,
 };
 
 const contact: ViewableProfile = {
@@ -67,6 +69,7 @@ const contact: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  memberships: undefined,
 };
 
 const publicCard: ViewableProfile = {

--- a/src/components/profile/sections/DrivingLicencesSection.stories.tsx
+++ b/src/components/profile/sections/DrivingLicencesSection.stories.tsx
@@ -28,7 +28,10 @@ const selfWithData: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  passports: undefined,
   drivingLicences: ["Car (B)", "Motorcycle (A)", "HGV/LGV (C)"],
+  workEligibility: undefined,
+  memberships: undefined,
 };
 
 const selfEmpty: ViewableProfile = {
@@ -41,7 +44,10 @@ const selfEmpty: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  passports: undefined,
   drivingLicences: undefined,
+  workEligibility: undefined,
+  memberships: undefined,
 };
 
 const contactWithData: ViewableProfile = {
@@ -54,7 +60,10 @@ const contactWithData: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  passports: undefined,
   drivingLicences: ["Car (B)", "Forklift"],
+  workEligibility: undefined,
+  memberships: undefined,
 };
 
 const meta = {

--- a/src/components/profile/sections/IdentitySection.stories.tsx
+++ b/src/components/profile/sections/IdentitySection.stories.tsx
@@ -40,6 +40,7 @@ const selfWithNicknameProfile: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  memberships: undefined,
 };
 
 const selfWithoutNicknameProfile: ViewableProfile = {
@@ -57,6 +58,7 @@ const selfWithoutNicknameProfile: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  memberships: undefined,
 };
 
 const selfWithPictureProfile: ViewableProfile = {
@@ -75,6 +77,7 @@ const selfWithPictureProfile: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  memberships: undefined,
 };
 
 const contactProfile: ViewableProfile = {
@@ -91,6 +94,7 @@ const contactProfile: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  memberships: undefined,
 };
 
 const publicCardProfile: ViewableProfile = {

--- a/src/components/profile/sections/LanguagesSection.stories.tsx
+++ b/src/components/profile/sections/LanguagesSection.stories.tsx
@@ -38,6 +38,7 @@ const selfWithData: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  memberships: undefined,
 };
 
 const selfEmpty: ViewableProfile = {
@@ -54,6 +55,7 @@ const selfEmpty: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  memberships: undefined,
 };
 
 const contactWithData: ViewableProfile = {
@@ -72,6 +74,7 @@ const contactWithData: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  memberships: undefined,
 };
 
 const meta = {

--- a/src/components/profile/sections/LinksSection.stories.tsx
+++ b/src/components/profile/sections/LinksSection.stories.tsx
@@ -49,6 +49,7 @@ export const Default: Story = {
       passports: undefined,
       drivingLicences: undefined,
       workEligibility: undefined,
+      memberships: undefined,
     },
   },
 };
@@ -67,6 +68,7 @@ export const WebsiteOnly: Story = {
       passports: undefined,
       drivingLicences: undefined,
       workEligibility: undefined,
+      memberships: undefined,
     },
   },
 };
@@ -85,6 +87,7 @@ export const IMDBOnly: Story = {
       passports: undefined,
       drivingLicences: undefined,
       workEligibility: undefined,
+      memberships: undefined,
     },
   },
 };
@@ -103,6 +106,7 @@ export const Empty: Story = {
       passports: undefined,
       drivingLicences: undefined,
       workEligibility: undefined,
+      memberships: undefined,
     },
   },
 };

--- a/src/components/profile/sections/LocationSection.stories.tsx
+++ b/src/components/profile/sections/LocationSection.stories.tsx
@@ -32,6 +32,7 @@ const selfWithData: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  memberships: undefined,
 };
 
 const selfEmpty: ViewableProfile = {
@@ -46,6 +47,7 @@ const selfEmpty: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  memberships: undefined,
 };
 
 const contactWithData: ViewableProfile = {
@@ -59,6 +61,7 @@ const contactWithData: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  memberships: undefined,
 };
 
 const publicCard: ViewableProfile = {

--- a/src/components/profile/sections/MembershipsSection.stories.tsx
+++ b/src/components/profile/sections/MembershipsSection.stories.tsx
@@ -3,7 +3,7 @@ import type { ViewableProfile } from "@shared/profile/viewableProfile";
 import type { Meta, StoryObj } from "@storybook/react-native";
 import { View } from "react-native";
 
-import { PassportsSection } from "./PassportsSection";
+import { MembershipsSection } from "./MembershipsSection";
 
 const baseCrew = {
   userId: "user_1" as Id<"users">,
@@ -18,25 +18,7 @@ const baseCrew = {
   country: undefined,
 };
 
-const selfWithData: ViewableProfile = {
-  mode: "self",
-  ...baseCrew,
-  bio: undefined,
-  website: undefined,
-  imdbId: undefined,
-  cvUrl: undefined,
-  startYearInDepartment: undefined,
-  productionTypes: undefined,
-  spokenLanguages: undefined,
-  passports: ["GB", "IE", "US"],
-  drivingLicences: undefined,
-  workEligibility: undefined,
-  memberships: undefined,
-};
-
-const selfEmpty: ViewableProfile = {
-  mode: "self",
-  ...baseCrew,
+const extras = {
   bio: undefined,
   website: undefined,
   imdbId: undefined,
@@ -47,28 +29,41 @@ const selfEmpty: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+};
+
+const selfWithData: ViewableProfile = {
+  mode: "self",
+  isPublic: false,
+  ...baseCrew,
+  ...extras,
+  memberships: [
+    { id: "m1", name: "BECTU", memberNumber: "123456" },
+    { id: "m2", name: "BSC", memberNumber: undefined },
+    { id: "m3", name: "GBCT", memberNumber: "GB-789" },
+  ],
+};
+
+const selfEmpty: ViewableProfile = {
+  mode: "self",
+  isPublic: false,
+  ...baseCrew,
+  ...extras,
   memberships: undefined,
 };
 
 const contactWithData: ViewableProfile = {
   mode: "contact",
   ...baseCrew,
-  bio: undefined,
-  website: undefined,
-  imdbId: undefined,
-  cvUrl: undefined,
-  startYearInDepartment: undefined,
-  productionTypes: undefined,
-  spokenLanguages: undefined,
-  passports: ["AU", "NZ"],
-  drivingLicences: undefined,
-  workEligibility: undefined,
-  memberships: undefined,
+  ...extras,
+  memberships: [
+    { id: "m1", name: "BAFTA", memberNumber: "BA-001" },
+    { id: "m2", name: "BECTU", memberNumber: undefined },
+  ],
 };
 
 const meta = {
-  title: "Profile/PassportsSection",
-  component: PassportsSection,
+  title: "Profile/MembershipsSection",
+  component: MembershipsSection,
   decorators: [
     (Story) => (
       <View style={{ flex: 1, padding: 16 }}>
@@ -78,7 +73,7 @@ const meta = {
   ],
   tags: ["autodocs"],
   args: { profile: selfWithData },
-} satisfies Meta<typeof PassportsSection>;
+} satisfies Meta<typeof MembershipsSection>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/src/components/profile/sections/MembershipsSection.tsx
+++ b/src/components/profile/sections/MembershipsSection.tsx
@@ -1,0 +1,35 @@
+import type { MembershipEntry, ViewableProfile } from "@shared/profile/viewableProfile";
+import { Chip } from "heroui-native";
+import { Text, View } from "react-native";
+
+type Props = {
+  profile: ViewableProfile;
+};
+
+function hasMemberships(profile: ViewableProfile): profile is Extract<
+  ViewableProfile,
+  { memberships: MembershipEntry[] | undefined }
+> & {
+  memberships: MembershipEntry[];
+} {
+  return (
+    "memberships" in profile && Array.isArray(profile.memberships) && profile.memberships.length > 0
+  );
+}
+
+export function MembershipsSection({ profile }: Props) {
+  if (!hasMemberships(profile)) return null;
+
+  return (
+    <View className="gap-2">
+      <Text className="text-sm font-medium text-muted">Memberships</Text>
+      <View className="flex-row flex-wrap gap-2">
+        {profile.memberships.map((m) => (
+          <Chip key={m.id} variant="secondary" size="sm">
+            {m.memberNumber ? `${m.name} (${m.memberNumber})` : m.name}
+          </Chip>
+        ))}
+      </View>
+    </View>
+  );
+}

--- a/src/components/profile/sections/ProductionTypesSection.stories.tsx
+++ b/src/components/profile/sections/ProductionTypesSection.stories.tsx
@@ -32,6 +32,7 @@ const selfWithData: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  memberships: undefined,
 };
 
 const selfEmpty: ViewableProfile = {
@@ -48,6 +49,7 @@ const selfEmpty: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  memberships: undefined,
 };
 
 const contactWithData: ViewableProfile = {
@@ -63,6 +65,7 @@ const contactWithData: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  memberships: undefined,
 };
 
 const meta = {

--- a/src/components/profile/sections/WorkEligibilitySection.stories.tsx
+++ b/src/components/profile/sections/WorkEligibilitySection.stories.tsx
@@ -29,6 +29,7 @@ const selfWithData: ViewableProfile = {
   productionTypes: undefined,
   spokenLanguages: undefined,
   workEligibility: ["Right to Work UK", "Schengen", "Ireland"],
+  memberships: undefined,
 };
 
 const selfEmpty: ViewableProfile = {
@@ -42,6 +43,7 @@ const selfEmpty: ViewableProfile = {
   productionTypes: undefined,
   spokenLanguages: undefined,
   workEligibility: undefined,
+  memberships: undefined,
 };
 
 const contactWithData: ViewableProfile = {
@@ -55,6 +57,7 @@ const contactWithData: ViewableProfile = {
   productionTypes: undefined,
   spokenLanguages: undefined,
   workEligibility: ["USA", "Canada", "Australia"],
+  memberships: undefined,
 };
 
 const meta = {

--- a/src/components/profile/sections/YearsSection.stories.tsx
+++ b/src/components/profile/sections/YearsSection.stories.tsx
@@ -25,6 +25,7 @@ const baseCrew = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  memberships: undefined,
 };
 
 const selfWithStartYear: ViewableProfile = {

--- a/types/profile/viewableProfile.ts
+++ b/types/profile/viewableProfile.ts
@@ -27,6 +27,12 @@ type SpokenLanguageEntry = {
   fluency: string;
 };
 
+export type MembershipEntry = {
+  id: string;
+  name: string;
+  memberNumber: string | undefined;
+};
+
 type CrewExtras = {
   startYearInDepartment: number | undefined;
   productionTypes: string[] | undefined;
@@ -34,6 +40,7 @@ type CrewExtras = {
   passports: string[] | undefined;
   drivingLicences: string[] | undefined;
   workEligibility: string[] | undefined;
+  memberships: MembershipEntry[] | undefined;
 };
 
 type CrewProfile = ProfileIdentity & {


### PR DESCRIPTION
Closes #261

## Summary
- Adds `memberships` table with `byUserId` index and resolver-gated query (`listMembershipsForUser`) that returns rows only in Self/Contact modes, sorted alphabetically by name
- Extends `ViewableProfile` type with `MembershipEntry` in `CrewExtras`; hydrates memberships in both `getMyProfile` and `getViewableProfile`
- Adds `MembershipsSection` presentational component (Chip-based, shows optional member number parenthetically) with stories for Self with data, Self empty, and Contact with data

## Test plan
- [x] `listMembershipsForUser` tests: Self returns rows sorted alphabetically, Contact returns rows, Public Card returns `[]`, Hidden returns `[]`, alphabetical order verified (5 tests)
- [x] All 653 existing tests pass
- [x] Pre-commit hooks pass (lint, format, tests)
- [x] No new TypeScript errors introduced (all remaining errors are pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)