### PR TITLE
feat(profile): Certifications read display + expiry status

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -47,6 +47,7 @@ import type * as calendars_service_registry from "../calendars/service/registry.
 import type * as calendars_syncAfterConnect from "../calendars/syncAfterConnect.js";
 import type * as calendars_syncWithRetry from "../calendars/syncWithRetry.js";
 import type * as calendars_uploadNativeEvents from "../calendars/uploadNativeEvents.js";
+import type * as certifications_queries_listCertificationsForUser from "../certifications/queries/listCertificationsForUser.js";
 import type * as contacts_db_findContactPair from "../contacts/db/findContactPair.js";
 import type * as contacts_db_findPendingInviteBetween from "../contacts/db/findPendingInviteBetween.js";
 import type * as contacts_db_findPendingInvitesForEmail from "../contacts/db/findPendingInvitesForEmail.js";
@@ -153,6 +154,7 @@ declare const fullApi: ApiFromModules<{
   "calendars/syncAfterConnect": typeof calendars_syncAfterConnect;
   "calendars/syncWithRetry": typeof calendars_syncWithRetry;
   "calendars/uploadNativeEvents": typeof calendars_uploadNativeEvents;
+  "certifications/queries/listCertificationsForUser": typeof certifications_queries_listCertificationsForUser;
   "contacts/db/findContactPair": typeof contacts_db_findContactPair;
   "contacts/db/findPendingInviteBetween": typeof contacts_db_findPendingInviteBetween;
   "contacts/db/findPendingInvitesForEmail": typeof contacts_db_findPendingInvitesForEmail;

--- a/convex/certifications/db/fetchSortedCertifications.test.ts
+++ b/convex/certifications/db/fetchSortedCertifications.test.ts
@@ -1,0 +1,81 @@
+import { convexTest, type TestConvex } from "convex-test";
+import { describe, expect, test } from "vitest";
+
+import type { Id } from "../../_generated/dataModel";
+import schema from "../../schema";
+import { fetchSortedCertifications } from "./fetchSortedCertifications";
+
+const modules = import.meta.glob("../../**/*.ts");
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+async function insertCrewUser(t: TestConvex<typeof schema>, email: string): Promise<Id<"users">> {
+  return t.run((ctx) =>
+    ctx.db.insert("users", {
+      externalAuthId: `clerk_${email}`,
+      email,
+      hasCompletedOnboarding: true,
+      userType: "crew",
+      isPublic: false,
+    }),
+  );
+}
+
+describe("fetchSortedCertifications", () => {
+  test("sorts by expiry ascending with no-expiry last", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertCrewUser(t, "alice@example.com");
+
+    const now = Date.now();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("certifications", { userId, name: "No Expiry" });
+      await ctx.db.insert("certifications", { userId, name: "Far Future", expiresAt: now + 365 * DAY_MS });
+      await ctx.db.insert("certifications", { userId, name: "Soon", expiresAt: now + 30 * DAY_MS });
+      await ctx.db.insert("certifications", { userId, name: "Expired", expiresAt: now - 10 * DAY_MS });
+    });
+
+    const result = await t.run((ctx) => fetchSortedCertifications(ctx, userId));
+
+    expect(result).toHaveLength(4);
+    expect(result[0].name).toBe("Expired");
+    expect(result[1].name).toBe("Soon");
+    expect(result[2].name).toBe("Far Future");
+    expect(result[3].name).toBe("No Expiry");
+  });
+
+  test("returns empty array when no certifications exist", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertCrewUser(t, "bob@example.com");
+
+    const result = await t.run((ctx) => fetchSortedCertifications(ctx, userId));
+
+    expect(result).toEqual([]);
+  });
+
+  test("maps fields correctly", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertCrewUser(t, "carol@example.com");
+
+    const now = Date.now();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("certifications", {
+        userId,
+        name: "First Aid",
+        issuer: "Red Cross",
+        referenceNumber: "FA-001",
+        expiresAt: now + 90 * DAY_MS,
+      });
+    });
+
+    const result = await t.run((ctx) => fetchSortedCertifications(ctx, userId));
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      name: "First Aid",
+      issuer: "Red Cross",
+      referenceNumber: "FA-001",
+      expiresAt: now + 90 * DAY_MS,
+    });
+    expect(result[0].id).toBeDefined();
+  });
+});

--- a/convex/certifications/db/fetchSortedCertifications.ts
+++ b/convex/certifications/db/fetchSortedCertifications.ts
@@ -1,0 +1,32 @@
+import type { Id } from "../../_generated/dataModel";
+import type { QueryCtx } from "../../_generated/server";
+
+export type CertificationSummary = {
+  id: Id<"certifications">;
+  name: string;
+  issuer: string | undefined;
+  referenceNumber: string | undefined;
+  expiresAt: number | undefined;
+};
+
+export async function fetchSortedCertifications(
+  ctx: QueryCtx,
+  userId: Id<"users">,
+): Promise<CertificationSummary[]> {
+  const rows = await ctx.db
+    .query("certifications")
+    .withIndex("byUserIdAndExpiresAt", (q) => q.eq("userId", userId))
+    .collect();
+
+  const withExpiry = rows.filter((r) => r.expiresAt !== undefined);
+  const withoutExpiry = rows.filter((r) => r.expiresAt === undefined);
+  withExpiry.sort((a, b) => (a.expiresAt as number) - (b.expiresAt as number));
+
+  return [...withExpiry, ...withoutExpiry].map((r) => ({
+    id: r._id,
+    name: r.name,
+    issuer: r.issuer,
+    referenceNumber: r.referenceNumber,
+    expiresAt: r.expiresAt,
+  }));
+}

--- a/convex/certifications/queries/listCertificationsForUser.test.ts
+++ b/convex/certifications/queries/listCertificationsForUser.test.ts
@@ -1,0 +1,151 @@
+/// <reference types="vite/client" />
+import { convexTest, type TestConvex } from "convex-test";
+import { describe, expect, test } from "vitest";
+
+import { api } from "../../_generated/api";
+import type { Id } from "../../_generated/dataModel";
+import schema from "../../schema";
+
+const modules = import.meta.glob("/convex/**/*.ts");
+
+const aliceIdentity = {
+  subject: "clerk_alice",
+  issuer: "https://example.clerk.test",
+  tokenIdentifier: "https://example.clerk.test|clerk_alice",
+};
+
+const bobIdentity = {
+  subject: "clerk_bob",
+  issuer: "https://example.clerk.test",
+  tokenIdentifier: "https://example.clerk.test|clerk_bob",
+};
+
+async function insertCrewUser(
+  t: TestConvex<typeof schema>,
+  externalAuthId: string,
+  email: string,
+  opts?: { isPublic?: boolean },
+): Promise<Id<"users">> {
+  return t.run((ctx) =>
+    ctx.db.insert("users", {
+      externalAuthId,
+      email,
+      hasCompletedOnboarding: true,
+      userType: "crew",
+      isPublic: opts?.isPublic ?? false,
+    }),
+  );
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+describe("listCertificationsForUser", () => {
+  test("self returns rows sorted by expiry ascending, no-expiry last", async () => {
+    const t = convexTest(schema, modules);
+    const aliceId = await insertCrewUser(t, aliceIdentity.subject, "alice@example.com");
+
+    const now = Date.now();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("certifications", {
+        userId: aliceId,
+        name: "No Expiry Cert",
+      });
+      await ctx.db.insert("certifications", {
+        userId: aliceId,
+        name: "Far Future Cert",
+        expiresAt: now + 365 * DAY_MS,
+      });
+      await ctx.db.insert("certifications", {
+        userId: aliceId,
+        name: "Soon Cert",
+        expiresAt: now + 30 * DAY_MS,
+      });
+      await ctx.db.insert("certifications", {
+        userId: aliceId,
+        name: "Expired Cert",
+        expiresAt: now - 10 * DAY_MS,
+      });
+    });
+
+    const result = await t
+      .withIdentity(aliceIdentity)
+      .query(api.certifications.queries.listCertificationsForUser.listCertificationsForUser, {
+        userId: aliceId,
+      });
+
+    expect(result).toHaveLength(4);
+    expect(result[0].name).toBe("Expired Cert");
+    expect(result[1].name).toBe("Soon Cert");
+    expect(result[2].name).toBe("Far Future Cert");
+    expect(result[3].name).toBe("No Expiry Cert");
+  });
+
+  test("contact returns rows", async () => {
+    const t = convexTest(schema, modules);
+    const aliceId = await insertCrewUser(t, aliceIdentity.subject, "alice@example.com");
+    const bobId = await insertCrewUser(t, bobIdentity.subject, "bob@example.com");
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("certifications", {
+        userId: aliceId,
+        name: "First Aid",
+        issuer: "Red Cross",
+      });
+      await ctx.db.insert("contacts", {
+        ownerId: bobId,
+        contactUserId: aliceId,
+        createdAt: Date.now(),
+      });
+    });
+
+    const result = await t
+      .withIdentity(bobIdentity)
+      .query(api.certifications.queries.listCertificationsForUser.listCertificationsForUser, {
+        userId: aliceId,
+      });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("First Aid");
+    expect(result[0].issuer).toBe("Red Cross");
+  });
+
+  test("public-card returns empty array", async () => {
+    const t = convexTest(schema, modules);
+    const aliceId = await insertCrewUser(t, aliceIdentity.subject, "alice@example.com", {
+      isPublic: true,
+    });
+    await insertCrewUser(t, bobIdentity.subject, "bob@example.com");
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("certifications", { userId: aliceId, name: "CSCS" });
+    });
+
+    const result = await t
+      .withIdentity(bobIdentity)
+      .query(api.certifications.queries.listCertificationsForUser.listCertificationsForUser, {
+        userId: aliceId,
+      });
+
+    expect(result).toEqual([]);
+  });
+
+  test("hidden returns empty array", async () => {
+    const t = convexTest(schema, modules);
+    const aliceId = await insertCrewUser(t, aliceIdentity.subject, "alice@example.com", {
+      isPublic: false,
+    });
+    await insertCrewUser(t, bobIdentity.subject, "bob@example.com");
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("certifications", { userId: aliceId, name: "CSCS" });
+    });
+
+    const result = await t
+      .withIdentity(bobIdentity)
+      .query(api.certifications.queries.listCertificationsForUser.listCertificationsForUser, {
+        userId: aliceId,
+      });
+
+    expect(result).toEqual([]);
+  });
+});

--- a/convex/certifications/queries/listCertificationsForUser.ts
+++ b/convex/certifications/queries/listCertificationsForUser.ts
@@ -1,0 +1,52 @@
+import { v } from "convex/values";
+
+import { query } from "../../_generated/server";
+import { getUserByExternalId } from "../../users/db/getUser";
+import { resolveProfileVisibility } from "../../users/lib/resolveProfileVisibility";
+
+export const listCertificationsForUser = query({
+  args: { userId: v.id("users") },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    const viewer = identity ? await getUserByExternalId(ctx, identity.subject) : null;
+
+    const subject = await ctx.db.get(args.userId);
+    if (!subject) return [];
+
+    let isContact = false;
+    if (viewer !== null) {
+      const result = await ctx.db
+        .query("contacts")
+        .withIndex("byOwnerAndContact", (q) =>
+          q.eq("ownerId", viewer._id).eq("contactUserId", subject._id),
+        )
+        .unique();
+      isContact = result !== null;
+    }
+
+    const visibility = resolveProfileVisibility({
+      viewerUserId: viewer?._id ?? null,
+      subject: { _id: subject._id, userType: subject.userType, isPublic: subject.isPublic },
+      isContact,
+    });
+
+    if (visibility.mode !== "self" && visibility.mode !== "contact") return [];
+
+    const rows = await ctx.db
+      .query("certifications")
+      .withIndex("byUserIdAndExpiresAt", (q) => q.eq("userId", args.userId))
+      .collect();
+
+    const withExpiry = rows.filter((r) => r.expiresAt !== undefined);
+    const withoutExpiry = rows.filter((r) => r.expiresAt === undefined);
+    withExpiry.sort((a, b) => (a.expiresAt as number) - (b.expiresAt as number));
+
+    return [...withExpiry, ...withoutExpiry].map((r) => ({
+      id: r._id,
+      name: r.name,
+      issuer: r.issuer,
+      referenceNumber: r.referenceNumber,
+      expiresAt: r.expiresAt,
+    }));
+  },
+});

--- a/convex/certifications/queries/listCertificationsForUser.ts
+++ b/convex/certifications/queries/listCertificationsForUser.ts
@@ -3,6 +3,7 @@ import { v } from "convex/values";
 import { query } from "../../_generated/server";
 import { getUserByExternalId } from "../../users/db/getUser";
 import { resolveProfileVisibility } from "../../users/lib/resolveProfileVisibility";
+import { fetchSortedCertifications } from "../db/fetchSortedCertifications";
 
 export const listCertificationsForUser = query({
   args: { userId: v.id("users") },
@@ -32,21 +33,6 @@ export const listCertificationsForUser = query({
 
     if (visibility.mode !== "self" && visibility.mode !== "contact") return [];
 
-    const rows = await ctx.db
-      .query("certifications")
-      .withIndex("byUserIdAndExpiresAt", (q) => q.eq("userId", args.userId))
-      .collect();
-
-    const withExpiry = rows.filter((r) => r.expiresAt !== undefined);
-    const withoutExpiry = rows.filter((r) => r.expiresAt === undefined);
-    withExpiry.sort((a, b) => (a.expiresAt as number) - (b.expiresAt as number));
-
-    return [...withExpiry, ...withoutExpiry].map((r) => ({
-      id: r._id,
-      name: r.name,
-      issuer: r.issuer,
-      referenceNumber: r.referenceNumber,
-      expiresAt: r.expiresAt,
-    }));
+    return fetchSortedCertifications(ctx, args.userId);
   },
 });

--- a/convex/certifications/schema.ts
+++ b/convex/certifications/schema.ts
@@ -1,0 +1,17 @@
+import { defineTable } from "convex/server";
+import { v } from "convex/values";
+
+export const Certification = {
+  userId: v.id("users"),
+  name: v.string(),
+  issuer: v.optional(v.string()),
+  referenceNumber: v.optional(v.string()),
+  expiresAt: v.optional(v.number()),
+  evidenceFileId: v.optional(v.id("_storage")),
+};
+
+export const certificationsSchema = {
+  certifications: defineTable(Certification)
+    .index("byUserId", ["userId"])
+    .index("byUserIdAndExpiresAt", ["userId", "expiresAt"]),
+};

--- a/convex/memberships/db/fetchSortedMemberships.test.ts
+++ b/convex/memberships/db/fetchSortedMemberships.test.ts
@@ -1,0 +1,64 @@
+import { convexTest, type TestConvex } from "convex-test";
+import { describe, expect, test } from "vitest";
+
+import type { Id } from "../../_generated/dataModel";
+import schema from "../../schema";
+import { fetchSortedMemberships } from "./fetchSortedMemberships";
+
+const modules = import.meta.glob("../../**/*.ts");
+
+async function insertCrewUser(t: TestConvex<typeof schema>, email: string): Promise<Id<"users">> {
+  return t.run((ctx) =>
+    ctx.db.insert("users", {
+      externalAuthId: `clerk_${email}`,
+      email,
+      hasCompletedOnboarding: true,
+      userType: "crew",
+      isPublic: false,
+    }),
+  );
+}
+
+describe("fetchSortedMemberships", () => {
+  test("sorts alphabetically by name", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertCrewUser(t, "alice@example.com");
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("memberships", { userId, name: "Zimmer" });
+      await ctx.db.insert("memberships", { userId, name: "Alpha" });
+      await ctx.db.insert("memberships", { userId, name: "Middle" });
+    });
+
+    const result = await t.run((ctx) => fetchSortedMemberships(ctx, userId));
+
+    expect(result.map((r) => r.name)).toEqual(["Alpha", "Middle", "Zimmer"]);
+  });
+
+  test("returns empty array when no memberships exist", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertCrewUser(t, "bob@example.com");
+
+    const result = await t.run((ctx) => fetchSortedMemberships(ctx, userId));
+
+    expect(result).toEqual([]);
+  });
+
+  test("maps fields correctly", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await insertCrewUser(t, "carol@example.com");
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("memberships", { userId, name: "BECTU", memberNumber: "12345" });
+    });
+
+    const result = await t.run((ctx) => fetchSortedMemberships(ctx, userId));
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      name: "BECTU",
+      memberNumber: "12345",
+    });
+    expect(result[0].id).toBeDefined();
+  });
+});

--- a/convex/memberships/db/fetchSortedMemberships.ts
+++ b/convex/memberships/db/fetchSortedMemberships.ts
@@ -1,0 +1,26 @@
+import type { Id } from "../../_generated/dataModel";
+import type { QueryCtx } from "../../_generated/server";
+
+export type MembershipSummary = {
+  id: Id<"memberships">;
+  name: string;
+  memberNumber: string | undefined;
+};
+
+export async function fetchSortedMemberships(
+  ctx: QueryCtx,
+  userId: Id<"users">,
+): Promise<MembershipSummary[]> {
+  const rows = await ctx.db
+    .query("memberships")
+    .withIndex("byUserId", (q) => q.eq("userId", userId))
+    .collect();
+
+  rows.sort((a, b) => a.name.localeCompare(b.name));
+
+  return rows.map((r) => ({
+    id: r._id,
+    name: r.name,
+    memberNumber: r.memberNumber,
+  }));
+}

--- a/convex/memberships/queries/listMembershipsForUser.ts
+++ b/convex/memberships/queries/listMembershipsForUser.ts
@@ -3,6 +3,7 @@ import { v } from "convex/values";
 import { query } from "../../_generated/server";
 import { getUserByExternalId } from "../../users/db/getUser";
 import { resolveProfileVisibility } from "../../users/lib/resolveProfileVisibility";
+import { fetchSortedMemberships } from "../db/fetchSortedMemberships";
 
 export const listMembershipsForUser = query({
   args: { userId: v.id("users") },
@@ -32,17 +33,6 @@ export const listMembershipsForUser = query({
 
     if (visibility.mode !== "self" && visibility.mode !== "contact") return [];
 
-    const rows = await ctx.db
-      .query("memberships")
-      .withIndex("byUserId", (q) => q.eq("userId", args.userId))
-      .collect();
-
-    rows.sort((a, b) => a.name.localeCompare(b.name));
-
-    return rows.map((r) => ({
-      id: r._id,
-      name: r.name,
-      memberNumber: r.memberNumber,
-    }));
+    return fetchSortedMemberships(ctx, args.userId);
   },
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1,6 +1,7 @@
 import { defineSchema } from "convex/server";
 
 import { calendarsSchema } from "./calendars/schema";
+import { certificationsSchema } from "./certifications/schema";
 import { contactsSchema } from "./contacts/schema";
 import { jobsSchema } from "./jobs/schema";
 import { kitSchema } from "./kit/schema";
@@ -14,4 +15,5 @@ export default defineSchema({
   ...jobsSchema,
   ...contactsSchema,
   ...notificationsSchema,
+  ...certificationsSchema,
 });

--- a/convex/users/queries.ts
+++ b/convex/users/queries.ts
@@ -39,6 +39,24 @@ export const getMyProfile = query({
 
     if (viewer.userType === "crew") {
       const cvUrl = await resolveStorageUrl(ctx, viewer.cvFileId);
+      const certRows = await ctx.db
+        .query("certifications")
+        .withIndex("byUserIdAndExpiresAt", (q) => q.eq("userId", viewer._id))
+        .collect();
+      const withExpiry = certRows.filter((r) => r.expiresAt !== undefined);
+      const withoutExpiry = certRows.filter((r) => r.expiresAt === undefined);
+      withExpiry.sort((a, b) => (a.expiresAt as number) - (b.expiresAt as number));
+      const sortedCerts = [...withExpiry, ...withoutExpiry];
+      const certifications =
+        sortedCerts.length > 0
+          ? sortedCerts.map((r) => ({
+              id: r._id,
+              name: r.name,
+              issuer: r.issuer,
+              referenceNumber: r.referenceNumber,
+              expiresAt: r.expiresAt,
+            }))
+          : undefined;
       return {
         mode: "self",
         isPublic: viewer.isPublic ?? false,
@@ -62,6 +80,7 @@ export const getMyProfile = query({
         passports: viewer.passports,
         drivingLicences: viewer.drivingLicences,
         workEligibility: viewer.workEligibility,
+        certifications,
       };
     }
 
@@ -125,6 +144,24 @@ export const getViewableProfile = query({
         return { mode, ...base };
       }
       const cvUrl = await resolveStorageUrl(ctx, subject.cvFileId);
+      const certRows = await ctx.db
+        .query("certifications")
+        .withIndex("byUserIdAndExpiresAt", (q) => q.eq("userId", subject._id))
+        .collect();
+      const withExpiry = certRows.filter((r) => r.expiresAt !== undefined);
+      const withoutExpiry = certRows.filter((r) => r.expiresAt === undefined);
+      withExpiry.sort((a, b) => (a.expiresAt as number) - (b.expiresAt as number));
+      const sortedCerts = [...withExpiry, ...withoutExpiry];
+      const certifications =
+        sortedCerts.length > 0
+          ? sortedCerts.map((r) => ({
+              id: r._id,
+              name: r.name,
+              issuer: r.issuer,
+              referenceNumber: r.referenceNumber,
+              expiresAt: r.expiresAt,
+            }))
+          : undefined;
       const crewExtras = {
         ...base,
         bio: subject.bio,
@@ -137,6 +174,7 @@ export const getViewableProfile = query({
         passports: subject.passports,
         drivingLicences: subject.drivingLicences,
         workEligibility: subject.workEligibility,
+        certifications,
       };
       if (mode === "self") {
         return { mode, isPublic: subject.isPublic ?? false, ...crewExtras };

--- a/convex/users/queries.ts
+++ b/convex/users/queries.ts
@@ -1,6 +1,8 @@
 import type { ViewableProfile } from "@shared/profile/viewableProfile";
 import { v } from "convex/values";
 
+import { fetchSortedCertifications } from "../certifications/db/fetchSortedCertifications";
+import { fetchSortedMemberships } from "../memberships/db/fetchSortedMemberships";
 import type { Id } from "../_generated/dataModel";
 import type { QueryCtx } from "../_generated/server";
 import { query } from "../_generated/server";
@@ -39,32 +41,10 @@ export const getMyProfile = query({
 
     if (viewer.userType === "crew") {
       const cvUrl = await resolveStorageUrl(ctx, viewer.cvFileId);
-      const certRows = await ctx.db
-        .query("certifications")
-        .withIndex("byUserIdAndExpiresAt", (q) => q.eq("userId", viewer._id))
-        .collect();
-      const withExpiry = certRows.filter((r) => r.expiresAt !== undefined);
-      const withoutExpiry = certRows.filter((r) => r.expiresAt === undefined);
-      withExpiry.sort((a, b) => (a.expiresAt as number) - (b.expiresAt as number));
-      const sortedCerts = [...withExpiry, ...withoutExpiry];
-      const certifications =
-        sortedCerts.length > 0
-          ? sortedCerts.map((r) => ({
-              id: r._id,
-              name: r.name,
-              issuer: r.issuer,
-              referenceNumber: r.referenceNumber,
-              expiresAt: r.expiresAt,
-            })) : undefined
-      const membershipRows = await ctx.db
-        .query("memberships")
-        .withIndex("byUserId", (q) => q.eq("userId", viewer._id))
-        .collect();
-      membershipRows.sort((a, b) => a.name.localeCompare(b.name));
-      const memberships =
-        membershipRows.length > 0
-          ? membershipRows.map((r) => ({ id: r._id, name: r.name, memberNumber: r.memberNumber }))
-          : undefined;
+      const sortedCerts = await fetchSortedCertifications(ctx, viewer._id);
+      const certifications = sortedCerts.length > 0 ? sortedCerts : undefined;
+      const sortedMemberships = await fetchSortedMemberships(ctx, viewer._id);
+      const memberships = sortedMemberships.length > 0 ? sortedMemberships : undefined;
       return {
         mode: "self",
         isPublic: viewer.isPublic ?? false,
@@ -153,32 +133,10 @@ export const getViewableProfile = query({
         return { mode, ...base };
       }
       const cvUrl = await resolveStorageUrl(ctx, subject.cvFileId);
-      const certRows = await ctx.db
-        .query("certifications")
-        .withIndex("byUserIdAndExpiresAt", (q) => q.eq("userId", subject._id))
-        .collect();
-      const withExpiry = certRows.filter((r) => r.expiresAt !== undefined);
-      const withoutExpiry = certRows.filter((r) => r.expiresAt === undefined);
-      withExpiry.sort((a, b) => (a.expiresAt as number) - (b.expiresAt as number));
-      const sortedCerts = [...withExpiry, ...withoutExpiry];
-      const certifications =
-        sortedCerts.length > 0
-          ? sortedCerts.map((r) => ({
-              id: r._id,
-              name: r.name,
-              issuer: r.issuer,
-              referenceNumber: r.referenceNumber,
-              expiresAt: r.expiresAt,
-            })) : undefined;
-      const membershipRows = await ctx.db
-        .query("memberships")
-        .withIndex("byUserId", (q) => q.eq("userId", subject._id))
-        .collect();
-      membershipRows.sort((a, b) => a.name.localeCompare(b.name));
-      const memberships =
-        membershipRows.length > 0
-          ? membershipRows.map((r) => ({ id: r._id, name: r.name, memberNumber: r.memberNumber }))
-          : undefined;
+      const sortedCerts = await fetchSortedCertifications(ctx, subject._id);
+      const certifications = sortedCerts.length > 0 ? sortedCerts : undefined;
+      const sortedMemberships = await fetchSortedMemberships(ctx, subject._id);
+      const memberships = sortedMemberships.length > 0 ? sortedMemberships : undefined;
       const crewExtras = {
         ...base,
         bio: subject.bio,

--- a/src/components/profile/Profile.stories.tsx
+++ b/src/components/profile/Profile.stories.tsx
@@ -39,6 +39,7 @@ const selfWithNicknameProfile: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  certifications: undefined,
 };
 
 const selfWithoutNicknameProfile: ViewableProfile = {
@@ -56,6 +57,7 @@ const selfWithoutNicknameProfile: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  certifications: undefined,
 };
 
 const contactProfile: ViewableProfile = {
@@ -72,6 +74,7 @@ const contactProfile: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  certifications: undefined,
 };
 
 const publicCardProfile: ViewableProfile = {

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -5,6 +5,7 @@ import { ScrollView } from "react-native";
 
 import { usePictureUpload } from "./PictureUploadFlow";
 import { BioSection } from "./sections/BioSection";
+import { CertificationsSection } from "./sections/CertificationsSection";
 import { CvSection } from "./sections/CvSection";
 import { DepartmentRolesSection } from "./sections/DepartmentRolesSection";
 import { DrivingLicencesSection } from "./sections/DrivingLicencesSection";
@@ -38,6 +39,7 @@ export function Profile({ profile }: Props) {
       <DrivingLicencesSection profile={profile} />
       <WorkEligibilitySection profile={profile} />
       <LanguagesSection profile={profile} />
+      <CertificationsSection profile={profile} />
       <LocationSection profile={profile} />
       <BioSection profile={profile} />
       <LinksSection profile={profile} />

--- a/src/components/profile/sections/BioSection.stories.tsx
+++ b/src/components/profile/sections/BioSection.stories.tsx
@@ -32,6 +32,7 @@ const selfWithBio: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  certifications: undefined,
 };
 
 const selfEmpty: ViewableProfile = {
@@ -45,6 +46,7 @@ const selfEmpty: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  certifications: undefined,
 };
 
 const contactWithBio: ViewableProfile = {
@@ -57,6 +59,7 @@ const contactWithBio: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  certifications: undefined,
 };
 
 const meta = {

--- a/src/components/profile/sections/CertificationsSection.stories.tsx
+++ b/src/components/profile/sections/CertificationsSection.stories.tsx
@@ -1,0 +1,116 @@
+import type { Id } from "@convex/_generated/dataModel";
+import type { ViewableProfile } from "@shared/profile/viewableProfile";
+import type { Meta, StoryObj } from "@storybook/react-native";
+import { View } from "react-native";
+
+import { CertificationsSection } from "./CertificationsSection";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = Date.now();
+
+const baseCrew = {
+  userId: "user_1" as Id<"users">,
+  firstName: "Ada",
+  lastName: "Lovelace",
+  profilePictureUrl: undefined,
+  userType: "crew" as const,
+  nickname: undefined,
+  department: "Camera" as const,
+  roles: ["Director of Photography"],
+  city: undefined,
+  country: undefined,
+};
+
+const extras = {
+  bio: undefined,
+  website: undefined,
+  imdbId: undefined,
+  cvUrl: undefined,
+  startYearInDepartment: undefined,
+  productionTypes: undefined,
+  spokenLanguages: undefined,
+  passports: undefined,
+  drivingLicences: undefined,
+  workEligibility: undefined,
+};
+
+const selfWithMixed: ViewableProfile = {
+  mode: "self",
+  isPublic: false,
+  ...baseCrew,
+  ...extras,
+  certifications: [
+    {
+      id: "c1",
+      name: "CSCS Card",
+      issuer: "CITB",
+      referenceNumber: "CSC-12345",
+      expiresAt: NOW - 30 * DAY_MS,
+    },
+    {
+      id: "c2",
+      name: "First Aid at Work",
+      issuer: "St John Ambulance",
+      referenceNumber: undefined,
+      expiresAt: NOW + 15 * DAY_MS,
+    },
+    {
+      id: "c3",
+      name: "IPAF Licence",
+      issuer: "IPAF",
+      referenceNumber: "IPAF-789",
+      expiresAt: NOW + 180 * DAY_MS,
+    },
+    {
+      id: "c4",
+      name: "Manual Handling",
+      issuer: undefined,
+      referenceNumber: undefined,
+      expiresAt: undefined,
+    },
+  ],
+};
+
+const selfEmpty: ViewableProfile = {
+  mode: "self",
+  isPublic: false,
+  ...baseCrew,
+  ...extras,
+  certifications: undefined,
+};
+
+const contactWithData: ViewableProfile = {
+  mode: "contact",
+  ...baseCrew,
+  ...extras,
+  certifications: [
+    {
+      id: "c1",
+      name: "DBS Check",
+      issuer: "Disclosure and Barring Service",
+      referenceNumber: "DBS-001",
+      expiresAt: NOW + 90 * DAY_MS,
+    },
+  ],
+};
+
+const meta = {
+  title: "Profile/CertificationsSection",
+  component: CertificationsSection,
+  decorators: [
+    (Story) => (
+      <View style={{ flex: 1, padding: 16 }}>
+        <Story />
+      </View>
+    ),
+  ],
+  tags: ["autodocs"],
+  args: { profile: selfWithMixed },
+} satisfies Meta<typeof CertificationsSection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const SelfWithMixed: Story = { args: { profile: selfWithMixed } };
+export const SelfEmpty: Story = { args: { profile: selfEmpty } };
+export const ContactWithData: Story = { args: { profile: contactWithData } };

--- a/src/components/profile/sections/CertificationsSection.tsx
+++ b/src/components/profile/sections/CertificationsSection.tsx
@@ -1,0 +1,60 @@
+import type { CertificationEntry, ViewableProfile } from "@shared/profile/viewableProfile";
+import { Chip } from "heroui-native";
+import { Text, View } from "react-native";
+
+import { formatCertificationExpiry } from "@/lib/profile/formatCertificationExpiry";
+
+type Props = {
+  profile: ViewableProfile;
+};
+
+const STATUS_COLOR = {
+  "no-expiry": "default",
+  valid: "success",
+  "expiring-soon": "warning",
+  expired: "danger",
+} as const;
+
+function hasCertifications(profile: ViewableProfile): profile is Extract<
+  ViewableProfile,
+  { certifications: CertificationEntry[] | undefined }
+> & {
+  certifications: CertificationEntry[];
+} {
+  return (
+    "certifications" in profile &&
+    Array.isArray(profile.certifications) &&
+    profile.certifications.length > 0
+  );
+}
+
+export function CertificationsSection({ profile }: Props) {
+  if (!hasCertifications(profile)) return null;
+
+  const now = Date.now();
+
+  return (
+    <View className="gap-2">
+      <Text className="text-sm font-medium text-muted">Certifications</Text>
+      <View className="gap-3">
+        {profile.certifications.map((cert) => {
+          const expiry = formatCertificationExpiry(cert.expiresAt, now);
+          return (
+            <View key={cert.id} className="gap-1">
+              <View className="flex-row items-center gap-2">
+                <Text className="text-base font-medium text-foreground">{cert.name}</Text>
+                <Chip size="sm" variant="secondary" color={STATUS_COLOR[expiry.status]}>
+                  {expiry.label}
+                </Chip>
+              </View>
+              {cert.issuer && <Text className="text-sm text-muted">{cert.issuer}</Text>}
+              {cert.referenceNumber && (
+                <Text className="text-sm text-muted">Ref: {cert.referenceNumber}</Text>
+              )}
+            </View>
+          );
+        })}
+      </View>
+    </View>
+  );
+}

--- a/src/components/profile/sections/CvSection.stories.tsx
+++ b/src/components/profile/sections/CvSection.stories.tsx
@@ -32,6 +32,7 @@ const selfWithCv: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  certifications: undefined,
 };
 
 const selfEmpty: ViewableProfile = {
@@ -46,6 +47,7 @@ const selfEmpty: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  certifications: undefined,
 };
 
 const contactWithCv: ViewableProfile = {
@@ -59,6 +61,7 @@ const contactWithCv: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  certifications: undefined,
 };
 
 const meta = {

--- a/src/components/profile/sections/DepartmentRolesSection.stories.tsx
+++ b/src/components/profile/sections/DepartmentRolesSection.stories.tsx
@@ -32,6 +32,7 @@ const selfWithData: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  certifications: undefined,
 };
 
 const selfEmpty: ViewableProfile = {
@@ -50,6 +51,7 @@ const selfEmpty: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  certifications: undefined,
 };
 
 const contact: ViewableProfile = {
@@ -67,6 +69,7 @@ const contact: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  certifications: undefined,
 };
 
 const publicCard: ViewableProfile = {

--- a/src/components/profile/sections/DrivingLicencesSection.stories.tsx
+++ b/src/components/profile/sections/DrivingLicencesSection.stories.tsx
@@ -28,7 +28,10 @@ const selfWithData: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  passports: undefined,
   drivingLicences: ["Car (B)", "Motorcycle (A)", "HGV/LGV (C)"],
+  workEligibility: undefined,
+  certifications: undefined,
 };
 
 const selfEmpty: ViewableProfile = {
@@ -41,7 +44,10 @@ const selfEmpty: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  passports: undefined,
   drivingLicences: undefined,
+  workEligibility: undefined,
+  certifications: undefined,
 };
 
 const contactWithData: ViewableProfile = {
@@ -54,7 +60,10 @@ const contactWithData: ViewableProfile = {
   startYearInDepartment: undefined,
   productionTypes: undefined,
   spokenLanguages: undefined,
+  passports: undefined,
   drivingLicences: ["Car (B)", "Forklift"],
+  workEligibility: undefined,
+  certifications: undefined,
 };
 
 const meta = {

--- a/src/components/profile/sections/IdentitySection.stories.tsx
+++ b/src/components/profile/sections/IdentitySection.stories.tsx
@@ -40,6 +40,7 @@ const selfWithNicknameProfile: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  certifications: undefined,
 };
 
 const selfWithoutNicknameProfile: ViewableProfile = {
@@ -57,6 +58,7 @@ const selfWithoutNicknameProfile: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  certifications: undefined,
 };
 
 const selfWithPictureProfile: ViewableProfile = {
@@ -75,6 +77,7 @@ const selfWithPictureProfile: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  certifications: undefined,
 };
 
 const contactProfile: ViewableProfile = {
@@ -91,6 +94,7 @@ const contactProfile: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  certifications: undefined,
 };
 
 const publicCardProfile: ViewableProfile = {

--- a/src/components/profile/sections/LanguagesSection.stories.tsx
+++ b/src/components/profile/sections/LanguagesSection.stories.tsx
@@ -38,6 +38,7 @@ const selfWithData: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  certifications: undefined,
 };
 
 const selfEmpty: ViewableProfile = {
@@ -54,6 +55,7 @@ const selfEmpty: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  certifications: undefined,
 };
 
 const contactWithData: ViewableProfile = {
@@ -72,6 +74,7 @@ const contactWithData: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  certifications: undefined,
 };
 
 const meta = {

--- a/src/components/profile/sections/LinksSection.stories.tsx
+++ b/src/components/profile/sections/LinksSection.stories.tsx
@@ -49,6 +49,7 @@ export const Default: Story = {
       passports: undefined,
       drivingLicences: undefined,
       workEligibility: undefined,
+      certifications: undefined,
     },
   },
 };
@@ -67,6 +68,7 @@ export const WebsiteOnly: Story = {
       passports: undefined,
       drivingLicences: undefined,
       workEligibility: undefined,
+      certifications: undefined,
     },
   },
 };
@@ -85,6 +87,7 @@ export const IMDBOnly: Story = {
       passports: undefined,
       drivingLicences: undefined,
       workEligibility: undefined,
+      certifications: undefined,
     },
   },
 };
@@ -103,6 +106,7 @@ export const Empty: Story = {
       passports: undefined,
       drivingLicences: undefined,
       workEligibility: undefined,
+      certifications: undefined,
     },
   },
 };

--- a/src/components/profile/sections/LocationSection.stories.tsx
+++ b/src/components/profile/sections/LocationSection.stories.tsx
@@ -32,6 +32,7 @@ const selfWithData: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  certifications: undefined,
 };
 
 const selfEmpty: ViewableProfile = {
@@ -46,6 +47,7 @@ const selfEmpty: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  certifications: undefined,
 };
 
 const contactWithData: ViewableProfile = {
@@ -59,6 +61,7 @@ const contactWithData: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  certifications: undefined,
 };
 
 const publicCard: ViewableProfile = {

--- a/src/components/profile/sections/PassportsSection.stories.tsx
+++ b/src/components/profile/sections/PassportsSection.stories.tsx
@@ -29,6 +29,9 @@ const selfWithData: ViewableProfile = {
   productionTypes: undefined,
   spokenLanguages: undefined,
   passports: ["GB", "IE", "US"],
+  drivingLicences: undefined,
+  workEligibility: undefined,
+  certifications: undefined,
 };
 
 const selfEmpty: ViewableProfile = {
@@ -42,6 +45,9 @@ const selfEmpty: ViewableProfile = {
   productionTypes: undefined,
   spokenLanguages: undefined,
   passports: undefined,
+  drivingLicences: undefined,
+  workEligibility: undefined,
+  certifications: undefined,
 };
 
 const contactWithData: ViewableProfile = {
@@ -55,6 +61,9 @@ const contactWithData: ViewableProfile = {
   productionTypes: undefined,
   spokenLanguages: undefined,
   passports: ["AU", "NZ"],
+  drivingLicences: undefined,
+  workEligibility: undefined,
+  certifications: undefined,
 };
 
 const meta = {

--- a/src/components/profile/sections/ProductionTypesSection.stories.tsx
+++ b/src/components/profile/sections/ProductionTypesSection.stories.tsx
@@ -32,6 +32,7 @@ const selfWithData: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  certifications: undefined,
 };
 
 const selfEmpty: ViewableProfile = {
@@ -48,6 +49,7 @@ const selfEmpty: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  certifications: undefined,
 };
 
 const contactWithData: ViewableProfile = {
@@ -63,6 +65,7 @@ const contactWithData: ViewableProfile = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  certifications: undefined,
 };
 
 const meta = {

--- a/src/components/profile/sections/WorkEligibilitySection.stories.tsx
+++ b/src/components/profile/sections/WorkEligibilitySection.stories.tsx
@@ -29,6 +29,7 @@ const selfWithData: ViewableProfile = {
   productionTypes: undefined,
   spokenLanguages: undefined,
   workEligibility: ["Right to Work UK", "Schengen", "Ireland"],
+  certifications: undefined,
 };
 
 const selfEmpty: ViewableProfile = {
@@ -42,6 +43,7 @@ const selfEmpty: ViewableProfile = {
   productionTypes: undefined,
   spokenLanguages: undefined,
   workEligibility: undefined,
+  certifications: undefined,
 };
 
 const contactWithData: ViewableProfile = {
@@ -55,6 +57,7 @@ const contactWithData: ViewableProfile = {
   productionTypes: undefined,
   spokenLanguages: undefined,
   workEligibility: ["USA", "Canada", "Australia"],
+  certifications: undefined,
 };
 
 const meta = {

--- a/src/components/profile/sections/YearsSection.stories.tsx
+++ b/src/components/profile/sections/YearsSection.stories.tsx
@@ -25,6 +25,7 @@ const baseCrew = {
   passports: undefined,
   drivingLicences: undefined,
   workEligibility: undefined,
+  certifications: undefined,
 };
 
 const selfWithStartYear: ViewableProfile = {

--- a/src/lib/profile/formatCertificationExpiry.test.ts
+++ b/src/lib/profile/formatCertificationExpiry.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "vitest";
+
+import { formatCertificationExpiry } from "./formatCertificationExpiry";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = Date.UTC(2026, 0, 15);
+
+describe("formatCertificationExpiry", () => {
+  test("no expiresAt returns no-expiry", () => {
+    const result = formatCertificationExpiry(undefined, NOW);
+    expect(result.status).toBe("no-expiry");
+    expect(result.label).toBe("No expiry");
+  });
+
+  test("61 days ahead returns valid", () => {
+    const result = formatCertificationExpiry(NOW + 61 * DAY_MS, NOW);
+    expect(result.status).toBe("valid");
+    expect(result.label).toBe("Valid");
+  });
+
+  test("exactly 60 days ahead returns expiring-soon", () => {
+    const result = formatCertificationExpiry(NOW + 60 * DAY_MS, NOW);
+    expect(result.status).toBe("expiring-soon");
+    expect(result.label).toMatch(/Expires in 60 days/);
+  });
+
+  test("1 day ahead returns expiring-soon", () => {
+    const result = formatCertificationExpiry(NOW + 1 * DAY_MS, NOW);
+    expect(result.status).toBe("expiring-soon");
+    expect(result.label).toBe("Expires in 1 day");
+  });
+
+  test("expiresAt equals now returns expired", () => {
+    const result = formatCertificationExpiry(NOW, NOW);
+    expect(result.status).toBe("expired");
+    expect(result.label).toBe("Expired");
+  });
+
+  test("1 day past returns expired", () => {
+    const result = formatCertificationExpiry(NOW - 1 * DAY_MS, NOW);
+    expect(result.status).toBe("expired");
+    expect(result.label).toBe("Expired");
+  });
+});

--- a/src/lib/profile/formatCertificationExpiry.ts
+++ b/src/lib/profile/formatCertificationExpiry.ts
@@ -1,0 +1,31 @@
+const SIXTY_DAYS_MS = 60 * 24 * 60 * 60 * 1000;
+
+type ExpiryStatus = "no-expiry" | "valid" | "expiring-soon" | "expired";
+
+type ExpiryResult = {
+  status: ExpiryStatus;
+  label: string;
+};
+
+export function formatCertificationExpiry(
+  expiresAt: number | undefined,
+  now: number,
+): ExpiryResult {
+  if (expiresAt === undefined) {
+    return { status: "no-expiry", label: "No expiry" };
+  }
+
+  if (expiresAt <= now) {
+    return { status: "expired", label: "Expired" };
+  }
+
+  if (expiresAt <= now + SIXTY_DAYS_MS) {
+    const daysLeft = Math.ceil((expiresAt - now) / (24 * 60 * 60 * 1000));
+    return {
+      status: "expiring-soon",
+      label: `Expires in ${daysLeft} day${daysLeft === 1 ? "" : "s"}`,
+    };
+  }
+
+  return { status: "valid", label: "Valid" };
+}

--- a/types/profile/viewableProfile.ts
+++ b/types/profile/viewableProfile.ts
@@ -27,6 +27,14 @@ type SpokenLanguageEntry = {
   fluency: string;
 };
 
+export type CertificationEntry = {
+  id: string;
+  name: string;
+  issuer: string | undefined;
+  referenceNumber: string | undefined;
+  expiresAt: number | undefined;
+};
+
 type CrewExtras = {
   startYearInDepartment: number | undefined;
   productionTypes: string[] | undefined;
@@ -34,6 +42,7 @@ type CrewExtras = {
   passports: string[] | undefined;
   drivingLicences: string[] | undefined;
   workEligibility: string[] | undefined;
+  certifications: CertificationEntry[] | undefined;
 };
 
 type CrewProfile = ProfileIdentity & {


### PR DESCRIPTION
Closes #260

## Summary
- Adds `certifications` table with `byUserId` and `byUserIdAndExpiresAt` indexes, plus a resolver-gated query returning rows sorted by expiry ascending (no-expiry last) for Self/Contact modes only
- Implements `formatCertificationExpiry` pure function with four status bands (no-expiry, valid, expiring-soon at 60-day threshold, expired) and boundary-tested unit tests
- Adds `CertificationsSection` presentational component with HeroUI Chip status badges using semantic colors (success/warning/danger/default), displaying name, issuer, reference number, and expiry status

## Test plan
- [x] `formatCertificationExpiry` boundary tests: no expiry, 61 days (valid), 60 days (expiring-soon), 1 day (expiring-soon), 0 (expired), -1 day (expired) — 6 tests
- [x] `listCertificationsForUser` tests: Self returns sorted rows, Contact returns rows, Public Card returns `[]`, Hidden returns `[]` — 4 tests
- [x] All 658 tests pass
- [x] Pre-commit hooks pass (lint, format, tests)
- [x] No new TypeScript errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)