### PR TITLE
feat(profile): #265 Production Manager Profile (minimal Self)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -102,6 +102,7 @@ import type * as users_mutations_updateProfileBioLinks from "../users/mutations/
 import type * as users_mutations_updateProfileLanguages from "../users/mutations/updateProfileLanguages.js";
 import type * as users_mutations_updateProfileLocation from "../users/mutations/updateProfileLocation.js";
 import type * as users_mutations_updateProfileProductionTypes from "../users/mutations/updateProfileProductionTypes.js";
+import type * as users_mutations_updateProductionCompany from "../users/mutations/updateProductionCompany.js";
 import type * as users_mutations_updateProfileYears from "../users/mutations/updateProfileYears.js";
 import type * as users_queries from "../users/queries.js";
 import type * as users_syncVerifiedPhone from "../users/syncVerifiedPhone.js";
@@ -209,6 +210,7 @@ declare const fullApi: ApiFromModules<{
   "users/mutations/updateProfileLanguages": typeof users_mutations_updateProfileLanguages;
   "users/mutations/updateProfileLocation": typeof users_mutations_updateProfileLocation;
   "users/mutations/updateProfileProductionTypes": typeof users_mutations_updateProfileProductionTypes;
+  "users/mutations/updateProductionCompany": typeof users_mutations_updateProductionCompany;
   "users/mutations/updateProfileYears": typeof users_mutations_updateProfileYears;
   "users/queries": typeof users_queries;
   "users/syncVerifiedPhone": typeof users_syncVerifiedPhone;

--- a/convex/users/mutations/updateProductionCompany.test.ts
+++ b/convex/users/mutations/updateProductionCompany.test.ts
@@ -1,0 +1,136 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+
+import { api } from "../../_generated/api";
+import schema from "../../schema";
+
+const modules = import.meta.glob("/convex/**/*.ts");
+
+const identity = {
+  subject: "clerk_user_42",
+  issuer: "https://example.clerk.test",
+  tokenIdentifier: "https://example.clerk.test|clerk_user_42",
+};
+
+async function makeTestWithPmUser() {
+  const t = convexTest(schema, modules);
+  await t.run((ctx) =>
+    ctx.db.insert("users", {
+      externalAuthId: identity.subject,
+      email: "pm@example.com",
+      hasCompletedOnboarding: true,
+      userType: "production-manager",
+    }),
+  );
+  return t;
+}
+
+async function makeTestWithCrewUser() {
+  const t = convexTest(schema, modules);
+  await t.run((ctx) =>
+    ctx.db.insert("users", {
+      externalAuthId: identity.subject,
+      email: "crew@example.com",
+      hasCompletedOnboarding: true,
+      userType: "crew",
+    }),
+  );
+  return t;
+}
+
+const mut = api.users.mutations.updateProductionCompany.updateProductionCompany;
+
+describe("updateProductionCompany", () => {
+  test("happy path: sets production company", async () => {
+    const t = await makeTestWithPmUser();
+    await t.withIdentity(identity).mutation(mut, {
+      productionCompany: "Acme Films",
+    });
+    const user = await t.run((ctx) =>
+      ctx.db
+        .query("users")
+        .withIndex("byExternalAuthId", (q) => q.eq("externalAuthId", identity.subject))
+        .unique(),
+    );
+    expect(user?.productionCompany).toBe("Acme Films");
+  });
+
+  test("trims whitespace", async () => {
+    const t = await makeTestWithPmUser();
+    await t.withIdentity(identity).mutation(mut, {
+      productionCompany: "  Acme Films  ",
+    });
+    const user = await t.run((ctx) =>
+      ctx.db
+        .query("users")
+        .withIndex("byExternalAuthId", (q) => q.eq("externalAuthId", identity.subject))
+        .unique(),
+    );
+    expect(user?.productionCompany).toBe("Acme Films");
+  });
+
+  test("clears field when given empty string", async () => {
+    const t = await makeTestWithPmUser();
+    await t.withIdentity(identity).mutation(mut, {
+      productionCompany: "Acme Films",
+    });
+    await t.withIdentity(identity).mutation(mut, {
+      productionCompany: "",
+    });
+    const user = await t.run((ctx) =>
+      ctx.db
+        .query("users")
+        .withIndex("byExternalAuthId", (q) => q.eq("externalAuthId", identity.subject))
+        .unique(),
+    );
+    expect(user?.productionCompany).toBeUndefined();
+  });
+
+  test("rejects value longer than 100 characters", async () => {
+    const t = await makeTestWithPmUser();
+    await expect(
+      t.withIdentity(identity).mutation(mut, {
+        productionCompany: "x".repeat(101),
+      }),
+    ).rejects.toThrow("Production company must be 100 characters or fewer");
+  });
+
+  test("rejects when caller is crew", async () => {
+    const t = await makeTestWithCrewUser();
+    await expect(
+      t.withIdentity(identity).mutation(mut, {
+        productionCompany: "Acme Films",
+      }),
+    ).rejects.toThrow("Only production manager accounts can update production company");
+  });
+
+  test("rejects when unauthenticated", async () => {
+    const t = convexTest(schema, modules);
+    await expect(t.mutation(mut, { productionCompany: "Acme Films" })).rejects.toThrow(
+      "Not authenticated",
+    );
+  });
+
+  test("does not affect other fields", async () => {
+    const t = await makeTestWithPmUser();
+    await t.run(async (ctx) => {
+      const user = await ctx.db
+        .query("users")
+        .withIndex("byExternalAuthId", (q) => q.eq("externalAuthId", identity.subject))
+        .unique();
+      await ctx.db.patch(user!._id, { bio: "Test bio" });
+    });
+    await t.withIdentity(identity).mutation(mut, {
+      productionCompany: "Acme Films",
+    });
+    const user = await t.run((ctx) =>
+      ctx.db
+        .query("users")
+        .withIndex("byExternalAuthId", (q) => q.eq("externalAuthId", identity.subject))
+        .unique(),
+    );
+    expect(user?.bio).toBe("Test bio");
+    expect(user?.productionCompany).toBe("Acme Films");
+  });
+});

--- a/convex/users/mutations/updateProductionCompany.ts
+++ b/convex/users/mutations/updateProductionCompany.ts
@@ -1,0 +1,31 @@
+import { ConvexError, v } from "convex/values";
+
+import { mutation } from "../../_generated/server";
+import { getUserByExternalId } from "../db/getUser";
+
+export const updateProductionCompany = mutation({
+  args: {
+    productionCompany: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new ConvexError("Not authenticated");
+
+    const user = await getUserByExternalId(ctx, identity.subject);
+    if (!user) throw new ConvexError("User not found");
+
+    if (user.userType !== "production-manager") {
+      throw new ConvexError("Only production manager accounts can update production company");
+    }
+
+    if (args.productionCompany !== undefined) {
+      const trimmed = args.productionCompany.trim();
+      if (trimmed.length > 100) {
+        throw new ConvexError("Production company must be 100 characters or fewer");
+      }
+      await ctx.db.patch(user._id, {
+        productionCompany: trimmed === "" ? undefined : trimmed,
+      });
+    }
+  },
+});

--- a/convex/users/queries.ts
+++ b/convex/users/queries.ts
@@ -83,6 +83,11 @@ export const getMyProfile = query({
       nickname: viewer.nickname,
       profilePictureUrl,
       userType: "production-manager",
+      city: viewer.city,
+      country: viewer.country,
+      productionCompany: viewer.productionCompany,
+      bio: viewer.bio,
+      website: viewer.website,
     };
   },
 });
@@ -173,6 +178,11 @@ export const getViewableProfile = query({
       nickname: subject.nickname,
       profilePictureUrl,
       userType,
+      city: subject.city,
+      country: subject.country,
+      productionCompany: subject.productionCompany,
+      bio: subject.bio,
+      website: subject.website,
     };
   },
 });

--- a/convex/users/schema.ts
+++ b/convex/users/schema.ts
@@ -44,6 +44,7 @@ export const User = {
   productionTypes: v.optional(v.array(v.string())),
   drivingLicences: v.optional(v.array(v.string())),
   workEligibility: v.optional(v.array(v.string())),
+  productionCompany: v.optional(v.string()),
 
   hasCompletedOnboarding: v.boolean(),
   isPublic: v.optional(v.boolean()),

--- a/src/app/(home)/profile.tsx
+++ b/src/app/(home)/profile.tsx
@@ -7,6 +7,7 @@ import { LogOutIcon, PencilIcon, SettingsIcon } from "lucide-react-native";
 import { View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
+import { PmProfile } from "@/components/profile/PmProfile";
 import { Profile } from "@/components/profile/Profile";
 import { Title } from "@/components/ui/Title";
 
@@ -51,7 +52,11 @@ export default function ProfileScreen() {
         </View>
       ) : (
         <View className="flex-1">
-          <Profile profile={profile} />
+          {profile.mode === "pm-self" ? (
+            <PmProfile profile={profile} />
+          ) : (
+            <Profile profile={profile} />
+          )}
         </View>
       )}
 

--- a/src/app/profile/edit/bio-links.tsx
+++ b/src/app/profile/edit/bio-links.tsx
@@ -30,16 +30,19 @@ export default function EditBioLinksScreen() {
     );
   }
 
-  const bio = profile.mode === "self" || profile.mode === "contact" ? profile.bio : undefined;
-  const website =
-    profile.mode === "self" || profile.mode === "contact" ? profile.website : undefined;
+  const hasBioLinks =
+    profile.mode === "self" || profile.mode === "contact" || profile.mode === "pm-self";
+  const bio = hasBioLinks ? profile.bio : undefined;
+  const website = hasBioLinks ? profile.website : undefined;
   const imdbId = profile.mode === "self" || profile.mode === "contact" ? profile.imdbId : undefined;
+  const showImdb = profile.userType === "crew";
 
   return (
     <EditBioLinksForm
       initialBio={bio ?? ""}
       initialWebsite={website ?? ""}
       initialImdbId={imdbId ?? ""}
+      showImdb={showImdb}
       onDone={() => router.back()}
       onSubmit={updateProfileBioLinks}
     />
@@ -50,6 +53,7 @@ type FormProps = {
   initialBio: string;
   initialWebsite: string;
   initialImdbId: string;
+  showImdb: boolean;
   onDone: () => void;
   onSubmit: (args: { bio?: string; website?: string; imdbId?: string }) => Promise<unknown>;
 };
@@ -58,6 +62,7 @@ function EditBioLinksForm({
   initialBio,
   initialWebsite,
   initialImdbId,
+  showImdb,
   onDone,
   onSubmit,
 }: FormProps) {
@@ -123,25 +128,27 @@ function EditBioLinksForm({
             )}
           </form.Field>
 
-          <form.Field name="imdbId">
-            {(field) => (
-              <TextField>
-                <Label>IMDB</Label>
-                <Input
-                  value={field.state.value}
-                  onChangeText={field.handleChange}
-                  onBlur={field.handleBlur}
-                  placeholder="nm1234567 or full IMDB URL"
-                  autoCapitalize="none"
-                  autoCorrect={false}
-                  returnKeyType="done"
-                />
-                <FieldError isInvalid={!!field.state.meta.errors.length}>
-                  {field.state.meta.errors[0]}
-                </FieldError>
-              </TextField>
-            )}
-          </form.Field>
+          {showImdb ? (
+            <form.Field name="imdbId">
+              {(field) => (
+                <TextField>
+                  <Label>IMDB</Label>
+                  <Input
+                    value={field.state.value}
+                    onChangeText={field.handleChange}
+                    onBlur={field.handleBlur}
+                    placeholder="nm1234567 or full IMDB URL"
+                    autoCapitalize="none"
+                    autoCorrect={false}
+                    returnKeyType="done"
+                  />
+                  <FieldError isInvalid={!!field.state.meta.errors.length}>
+                    {field.state.meta.errors[0]}
+                  </FieldError>
+                </TextField>
+              )}
+            </form.Field>
+          ) : null}
         </Card.Body>
 
         <Card.Footer className="flex-col gap-4">

--- a/src/app/profile/edit/index.tsx
+++ b/src/app/profile/edit/index.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "expo-router";
 import { ListGroup, PressableFeedback, Spinner } from "heroui-native";
 import {
   BriefcaseIcon,
+  BuildingIcon,
   CalendarIcon,
   ChevronRightIcon,
   ClapperboardIcon,
@@ -59,10 +60,15 @@ export default function EditProfileHubScreen() {
 
   const locationPreview = "city" in profile && profile.city ? profile.city : "Not added";
 
-  const bioPreview =
-    profile.mode === "self" && profile.bio ? profile.bio.slice(0, 40) : "Not added";
+  const bioPreview = "bio" in profile && profile.bio ? profile.bio.slice(0, 40) : "Not added";
 
-  const cvPreview = profile.mode === "self" && profile.cvUrl ? "Uploaded" : "Not added";
+  const productionCompanyPreview =
+    "productionCompany" in profile && profile.productionCompany
+      ? profile.productionCompany
+      : "Not added";
+
+  const cvPreview =
+    profile.mode === "self" && "cvUrl" in profile && profile.cvUrl ? "Uploaded" : "Not added";
 
   return (
     <ScrollView className="flex-1" contentContainerClassName="p-4 gap-4">
@@ -186,6 +192,28 @@ export default function EditProfileHubScreen() {
           </PressableFeedback.Scale>
         </PressableFeedback>
 
+        {profile.userType === "production-manager" ? (
+          <PressableFeedback
+            animation={false}
+            onPress={() => router.push("/profile/edit/production-company")}
+          >
+            <PressableFeedback.Scale>
+              <ListGroup.Item>
+                <ListGroup.ItemPrefix>
+                  <BuildingIcon size={20} />
+                </ListGroup.ItemPrefix>
+                <ListGroup.ItemContent>
+                  <ListGroup.ItemTitle>Production Company</ListGroup.ItemTitle>
+                  <ListGroup.ItemDescription>{productionCompanyPreview}</ListGroup.ItemDescription>
+                </ListGroup.ItemContent>
+                <ListGroup.ItemSuffix>
+                  <ChevronRightIcon size={16} />
+                </ListGroup.ItemSuffix>
+              </ListGroup.Item>
+            </PressableFeedback.Scale>
+          </PressableFeedback>
+        ) : null}
+
         <PressableFeedback animation={false} onPress={() => router.push("/profile/edit/bio-links")}>
           <PressableFeedback.Scale>
             <ListGroup.Item>
@@ -203,22 +231,24 @@ export default function EditProfileHubScreen() {
           </PressableFeedback.Scale>
         </PressableFeedback>
 
-        <PressableFeedback animation={false} onPress={() => router.push("/profile/edit/cv")}>
-          <PressableFeedback.Scale>
-            <ListGroup.Item>
-              <ListGroup.ItemPrefix>
-                <FileIcon size={20} />
-              </ListGroup.ItemPrefix>
-              <ListGroup.ItemContent>
-                <ListGroup.ItemTitle>CV</ListGroup.ItemTitle>
-                <ListGroup.ItemDescription>{cvPreview}</ListGroup.ItemDescription>
-              </ListGroup.ItemContent>
-              <ListGroup.ItemSuffix>
-                <ChevronRightIcon size={16} />
-              </ListGroup.ItemSuffix>
-            </ListGroup.Item>
-          </PressableFeedback.Scale>
-        </PressableFeedback>
+        {profile.userType === "crew" ? (
+          <PressableFeedback animation={false} onPress={() => router.push("/profile/edit/cv")}>
+            <PressableFeedback.Scale>
+              <ListGroup.Item>
+                <ListGroup.ItemPrefix>
+                  <FileIcon size={20} />
+                </ListGroup.ItemPrefix>
+                <ListGroup.ItemContent>
+                  <ListGroup.ItemTitle>CV</ListGroup.ItemTitle>
+                  <ListGroup.ItemDescription>{cvPreview}</ListGroup.ItemDescription>
+                </ListGroup.ItemContent>
+                <ListGroup.ItemSuffix>
+                  <ChevronRightIcon size={16} />
+                </ListGroup.ItemSuffix>
+              </ListGroup.Item>
+            </PressableFeedback.Scale>
+          </PressableFeedback>
+        ) : null}
       </ListGroup>
     </ScrollView>
   );

--- a/src/app/profile/edit/production-company.tsx
+++ b/src/app/profile/edit/production-company.tsx
@@ -1,0 +1,102 @@
+import { api } from "@convex/_generated/api";
+import { useForm } from "@tanstack/react-form";
+import { useMutation, useQuery } from "convex/react";
+import { useRouter } from "expo-router";
+import { Button, Card, FieldError, Input, Label, Spinner, TextField } from "heroui-native";
+import { ScrollView, View } from "react-native";
+
+import { Title } from "@/components/ui/Title";
+
+export default function EditProductionCompanyScreen() {
+  const router = useRouter();
+  const profile = useQuery(api.users.queries.getMyProfile);
+  const updateProductionCompany = useMutation(
+    api.users.mutations.updateProductionCompany.updateProductionCompany,
+  );
+
+  if (profile === undefined) {
+    return (
+      <View className="flex-1 items-center justify-center">
+        <Spinner />
+      </View>
+    );
+  }
+
+  if (profile === null || profile.mode !== "pm-self") {
+    return (
+      <View className="flex-1 items-center justify-center px-4">
+        <Title title="Not available" />
+      </View>
+    );
+  }
+
+  return (
+    <EditProductionCompanyForm
+      initialValue={profile.productionCompany ?? ""}
+      onDone={() => router.back()}
+      onSubmit={updateProductionCompany}
+    />
+  );
+}
+
+type FormProps = {
+  initialValue: string;
+  onDone: () => void;
+  onSubmit: (args: { productionCompany?: string }) => Promise<unknown>;
+};
+
+function EditProductionCompanyForm({ initialValue, onDone, onSubmit }: FormProps) {
+  const form = useForm({
+    defaultValues: {
+      productionCompany: initialValue,
+    },
+    onSubmit: async ({ value }) => {
+      await onSubmit({ productionCompany: value.productionCompany });
+      onDone();
+    },
+  });
+
+  return (
+    <ScrollView className="flex-1" contentContainerClassName="p-4 gap-6">
+      <Card className="gap-4">
+        <Card.Body className="gap-4">
+          <form.Field name="productionCompany">
+            {(field) => (
+              <TextField>
+                <Label>Production Company</Label>
+                <Input
+                  value={field.state.value}
+                  onChangeText={field.handleChange}
+                  onBlur={field.handleBlur}
+                  maxLength={100}
+                  placeholder="Your production company"
+                  returnKeyType="done"
+                />
+                <FieldError isInvalid={!!field.state.meta.errors.length}>
+                  {field.state.meta.errors[0]}
+                </FieldError>
+              </TextField>
+            )}
+          </form.Field>
+        </Card.Body>
+
+        <Card.Footer className="flex-col gap-4">
+          <form.Subscribe
+            selector={(state) => ({ canSubmit: state.canSubmit, isSubmitting: state.isSubmitting })}
+          >
+            {({ canSubmit, isSubmitting }) => (
+              <Button
+                variant="primary"
+                onPress={() => form.handleSubmit()}
+                isDisabled={!canSubmit || isSubmitting}
+                className="w-full"
+              >
+                {isSubmitting ? "Saving..." : "Save"}
+              </Button>
+            )}
+          </form.Subscribe>
+        </Card.Footer>
+      </Card>
+    </ScrollView>
+  );
+}

--- a/src/components/profile/PmProfile.stories.tsx
+++ b/src/components/profile/PmProfile.stories.tsx
@@ -1,0 +1,47 @@
+import type { Id } from "@convex/_generated/dataModel";
+import type { ViewableProfile } from "@shared/profile/viewableProfile";
+import type { Meta, StoryObj } from "@storybook/react-native";
+
+import { PmProfile } from "./PmProfile";
+
+const basePm = {
+  userId: "user_1" as Id<"users">,
+  firstName: "Grace",
+  lastName: "Hopper",
+  profilePictureUrl: undefined,
+  userType: "production-manager" as const,
+  nickname: undefined,
+};
+
+const pmSelfAllFields: Extract<ViewableProfile, { mode: "pm-self" }> = {
+  mode: "pm-self",
+  ...basePm,
+  city: "London",
+  country: "GB",
+  productionCompany: "Acme Films",
+  bio: "Award-winning production manager with 20 years in the industry.",
+  website: "https://acmefilms.example.com",
+};
+
+const pmSelfMinimal: Extract<ViewableProfile, { mode: "pm-self" }> = {
+  mode: "pm-self",
+  ...basePm,
+  city: undefined,
+  country: undefined,
+  productionCompany: undefined,
+  bio: undefined,
+  website: undefined,
+};
+
+const meta = {
+  title: "Profile/PmProfile",
+  component: PmProfile,
+  tags: ["autodocs"],
+  args: { profile: pmSelfAllFields },
+} satisfies Meta<typeof PmProfile>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const PMSelfAllFields: Story = { args: { profile: pmSelfAllFields } };
+export const PMSelfMinimal: Story = { args: { profile: pmSelfMinimal } };

--- a/src/components/profile/PmProfile.tsx
+++ b/src/components/profile/PmProfile.tsx
@@ -1,0 +1,27 @@
+import type { ViewableProfile } from "@shared/profile/viewableProfile";
+import { ScrollView } from "react-native";
+
+import { usePictureUpload } from "./PictureUploadFlow";
+import { BioSection } from "./sections/BioSection";
+import { IdentitySection } from "./sections/IdentitySection";
+import { LinksSection } from "./sections/LinksSection";
+import { LocationSection } from "./sections/LocationSection";
+import { ProductionCompanySection } from "./sections/ProductionCompanySection";
+
+type Props = {
+  profile: Extract<ViewableProfile, { mode: "pm-self" }>;
+};
+
+export function PmProfile({ profile }: Props) {
+  const pickAndUpload = usePictureUpload();
+
+  return (
+    <ScrollView contentContainerClassName="gap-4 p-4">
+      <IdentitySection profile={profile} onPicturePress={pickAndUpload} />
+      <LocationSection profile={profile} />
+      <ProductionCompanySection profile={profile} />
+      <BioSection profile={profile} />
+      <LinksSection profile={profile} />
+    </ScrollView>
+  );
+}

--- a/src/components/profile/Profile.stories.tsx
+++ b/src/components/profile/Profile.stories.tsx
@@ -87,6 +87,11 @@ const pmSelfProfile: ViewableProfile = {
   mode: "pm-self",
   ...basePm,
   nickname: undefined,
+  city: undefined,
+  country: undefined,
+  productionCompany: undefined,
+  bio: undefined,
+  website: undefined,
 };
 
 const meta = {

--- a/src/components/profile/sections/IdentitySection.stories.tsx
+++ b/src/components/profile/sections/IdentitySection.stories.tsx
@@ -107,6 +107,11 @@ const pmSelfProfile: ViewableProfile = {
   mode: "pm-self",
   ...basePm,
   nickname: undefined,
+  city: undefined,
+  country: undefined,
+  productionCompany: undefined,
+  bio: undefined,
+  website: undefined,
 };
 
 const noop = () => {};

--- a/src/components/profile/sections/LinksSection.tsx
+++ b/src/components/profile/sections/LinksSection.tsx
@@ -33,7 +33,7 @@ export function LinksSection({ profile }: Props) {
           <Text className="text-primary text-base">{profile.website}</Text>
         </Pressable>
       ) : null}
-      {profile.imdbId ? (
+      {"imdbId" in profile && profile.imdbId ? (
         <Pressable
           className="flex-row items-center gap-2"
           onPress={() => Linking.openURL(imdbUrl(profile.imdbId!))}

--- a/src/components/profile/sections/ProductionCompanySection.stories.tsx
+++ b/src/components/profile/sections/ProductionCompanySection.stories.tsx
@@ -1,0 +1,51 @@
+import type { Id } from "@convex/_generated/dataModel";
+import type { ViewableProfile } from "@shared/profile/viewableProfile";
+import type { Meta, StoryObj } from "@storybook/react-native";
+import { View } from "react-native";
+
+import { ProductionCompanySection } from "./ProductionCompanySection";
+
+const basePm = {
+  userId: "user_1" as Id<"users">,
+  firstName: "Grace",
+  lastName: "Hopper",
+  profilePictureUrl: undefined,
+  userType: "production-manager" as const,
+  nickname: undefined,
+  city: "London",
+  country: "GB",
+  bio: undefined,
+  website: undefined,
+};
+
+const withValue: ViewableProfile = {
+  mode: "pm-self",
+  ...basePm,
+  productionCompany: "Acme Films",
+};
+
+const empty: ViewableProfile = {
+  mode: "pm-self",
+  ...basePm,
+  productionCompany: undefined,
+};
+
+const meta = {
+  title: "Profile/ProductionCompanySection",
+  component: ProductionCompanySection,
+  decorators: [
+    (Story) => (
+      <View style={{ flex: 1, padding: 16 }}>
+        <Story />
+      </View>
+    ),
+  ],
+  tags: ["autodocs"],
+  args: { profile: withValue },
+} satisfies Meta<typeof ProductionCompanySection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WithValue: Story = { args: { profile: withValue } };
+export const Empty: Story = { args: { profile: empty } };

--- a/src/components/profile/sections/ProductionCompanySection.tsx
+++ b/src/components/profile/sections/ProductionCompanySection.tsx
@@ -1,0 +1,30 @@
+import type { ViewableProfile } from "@shared/profile/viewableProfile";
+import { Text, View } from "react-native";
+
+type Props = {
+  profile: ViewableProfile;
+};
+
+function hasProductionCompany(profile: ViewableProfile): profile is Extract<
+  ViewableProfile,
+  { productionCompany: string | undefined }
+> & {
+  productionCompany: string;
+} {
+  return (
+    "productionCompany" in profile &&
+    typeof profile.productionCompany === "string" &&
+    profile.productionCompany.length > 0
+  );
+}
+
+export function ProductionCompanySection({ profile }: Props) {
+  if (!hasProductionCompany(profile)) return null;
+
+  return (
+    <View className="gap-1">
+      <Text className="text-sm font-medium text-muted">Production Company</Text>
+      <Text className="text-base text-foreground">{profile.productionCompany}</Text>
+    </View>
+  );
+}

--- a/types/profile/viewableProfile.ts
+++ b/types/profile/viewableProfile.ts
@@ -49,9 +49,13 @@ type CrewProfile = ProfileIdentity & {
   roles: string[] | undefined;
 };
 
-type ProductionManagerProfile = ProfileIdentity & {
-  userType: "production-manager";
-};
+type ProductionManagerProfile = ProfileIdentity &
+  Location & {
+    userType: "production-manager";
+    productionCompany: string | undefined;
+    bio: string | undefined;
+    website: string | undefined;
+  };
 
 export type ViewableProfile =
   | ({ mode: "self"; isPublic: boolean } & CrewProfile & BioLinks & Location & CrewExtras)


### PR DESCRIPTION
Closes #265

## Summary

- **Schema + types**: Added `productionCompany` field to users schema; extended `ProductionManagerProfile` type with `Location`, `bio`, `website`, and `productionCompany` fields so the `pm-self` and `pm-job-linked` variants carry the full PM shape.
- **Mutation**: Created `updateProductionCompany` with length ≤ 100 validation and `accountType === "production-manager"` guard. 7 tests covering happy path, over-length, wrong account type, unauthenticated, whitespace trimming, clearing, and field isolation.
- **PM Profile UI**: Created `PmProfile` component rendering only the five PM-relevant sections (Identity, Location, Production Company, Bio, Links). Profile tab branches on mode to render `PmProfile` for `pm-self` vs `Profile` for crew. No ghost cards or pencil affordances per the design-pivot comment.
- **Edit hub**: Added Production Company row (PM only), gated CV to crew only, fixed bio/location preview extraction to work for PM profiles.
- **Bio-links edit**: Conditionally hides IMDB field for PM accounts; extracts bio/website for `pm-self` mode.
- **LinksSection**: Uses `"imdbId" in profile` guard for type safety with the expanded PM union.

## Test plan

- [x] `updateProductionCompany` mutation: 7 unit tests (happy path, over-length rejection, crew rejection, unauth, trim, clear, field isolation)
- [x] Existing queries tests pass (27 tests) — PM self variant still returns correct mode/userType
- [x] Existing resolveProfileVisibility tests pass — PM visibility logic unchanged
- [x] Full test suite passes (660 tests across 85 files)
- [x] Lint + format pass via pre-commit hooks
- [x] No new TypeScript errors introduced in changed files
- [ ] Manual: PM user sees minimal profile (Identity, Location, Production Company, Bio, Links)
- [ ] Manual: Crew user continues to see full profile
- [ ] Manual: Edit hub shows Production Company for PM, hides crew-only sections
- [ ] Manual: Production Company edit saves and displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)